### PR TITLE
Set up dependabot

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /bin/wireit.js
 /lib
 /node_modules
+/temp

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@
 version: 2
 
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
-      
-  - package-ecosystem: "github-actions"
+      interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
     # Workflow files stored in the
     # default location of `.github/workflows`
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /lib
 /node_modules
 /package-lock.json
+/temp


### PR DESCRIPTION
Following the instructions at https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates. This should auto-generate PRs to update npm and github action dependencies, checking daily.