### PR TITLE
Change Node support policy to only Active LTS and Current

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
         # See https://nodejs.org/en/about/releases/ for latest LTS information.
         node: [16] # Active LTS
         include:
-          # Also test Maintenance LTS, but just one OS should give us sufficient
+          # Also test latest, but just one OS should give us sufficient
           # coverage.
-          - node: 14
+          - node: 17
             os: ubuntu-20.04
 
     timeout-minutes: 15

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@
 npm i -D wireit
 ```
 
+## Requirements
+
+Wireit is supported on Linux, macOS, and Windows.
+
+Wireit requires Node Active LTS (16) or Current (17). Node Maintenance LTS
+releases are not supported. See [here](https://nodejs.org/en/about/releases/)
+for Node's release schedule.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "wireit": "bin/wireit.js"
       },
       "devDependencies": {
-        "@types/node": "^17.0.21",
+        "@types/node": "^16.11.26",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "cmd-shim": "^4.1.0",
@@ -22,7 +22,7 @@
         "uvu": "^0.5.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -107,9 +107,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -883,9 +883,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1666,9 +1666,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -2213,9 +2213,9 @@
       }
     },
     "globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "!lib/test/**"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "build": "tsc --build",
@@ -29,7 +29,7 @@
     "test": "uvu lib/test \"\\.test\\.js$\""
   },
   "devDependencies": {
-    "@types/node": "^17.0.21",
+    "@types/node": "^16.11.26",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "cmd-shim": "^4.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2021",
     "module": "es2020",
     "moduleResolution": "node",
     "lib": ["es2021"],


### PR DESCRIPTION
I'd like to use `AggregateError`, which is only available in Node 15+. There are some other nice things in ES2021 that it will be nice to be able to use as well (https://node.green/#ES2021).

Previously I was thinking we could support the most recent Maintenance LTS (14) release in addition to Active LTS (16) and Current (17). But since this is a new package, maybe we don't need to go back so far.

Active LTS + Current is the policy we adopted for Polymer tools, too: https://polymer-library.polymer-project.org/2.0/docs/tools/node-support