### PR TITLE
Bump self wireit version and use if-file-deleted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
-        "wireit": "^0.1.0"
+        "wireit": "^0.1.1"
       },
       "engines": {
         "node": ">=16.7.0"
@@ -1671,9 +1671,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.0.tgz",
-      "integrity": "sha512-9bOBtmEFIEanmY7DL0yH5rHrupCwtvACIzi3ObUD8ob/ToKLF/Syxxs7NkhG2jTLeTo+7OcHktW+YeR6T0KXpQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
+      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.3",
@@ -2844,9 +2844,9 @@
       }
     },
     "wireit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.0.tgz",
-      "integrity": "sha512-9bOBtmEFIEanmY7DL0yH5rHrupCwtvACIzi3ObUD8ob/ToKLF/Syxxs7NkhG2jTLeTo+7OcHktW+YeR6T0KXpQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
+      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
         "tsconfig.json"
       ],
       "output": [
-        "lib/**"
+        "lib/**",
+        ".tsbuildinfo"
       ],
-      "clean": false
+      "clean": "if-file-deleted"
     },
     "test": {
       "dependencies": [
@@ -143,7 +144,7 @@
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
-    "wireit": "^0.1.0"
+    "wireit": "^0.1.1"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
- Bump our self-hosted version to `0.1.1`.
- Use the new `if-file-deleted` setting for our TypeScript builds.
- Add `.tsbuildinfo` to our `output` files (see https://github.com/google/wireit#typescript for explanation).