### PR TITLE
Add FakeGitHubActionsCacheServer

### DIFF
--- a/src/test/util/fake-github-actions-cache-server.ts
+++ b/src/test/util/fake-github-actions-cache-server.ts
@@ -31,7 +31,7 @@ type KeyAndVersion = string & {
 interface CacheEntry {
   chunks: Buffer[];
   commited: boolean;
-  tarballId: string;
+  tarballId: TarballId;
 }
 
 const encodeKeyAndVersion = (key: string, version: string): KeyAndVersion =>


### PR DESCRIPTION
Adds a fake version of the GitHub Actions caching HTTP server.

This service is what backs the GitHub `@actions/cache` re-usable action (https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows), and it can also be used directly for more control over caching using the `@actions/cache` npm package (https://github.com/actions/toolkit/tree/main/packages/cache).
 
These APIs are not formally documented. This fake was implemented by looking at the behavior of the `@actions/cache` client library (https://github.com/actions/toolkit/tree/main/packages/cache), and through some live testing.

Part of https://github.com/google/wireit/issues/14

### Typical API usage overview

- Client generates a key+version.

- Client asks server to check if a cache entry exists for the given key+version.
  - If exists:
    - Server returns a URL of a tarball at a CDN.
    - Client downloads tarball and unpacks it.
    - STOP
  - If not exists:
    - Server returns "204 No Content" status.
 
- Client asks server to reserve a cache entry for a given key+version.
  - If entry was already reserved:
    - Server returns a "409 Conflict" status.
    - STOP
  - If not already exists:
    - Server returns a new unique numeric cache entry ID.

- Client sends 1 or more "upload" requests to endpoint containing chunks of the tarball.

- Client sends "commit" request to indicate that all tarball chunks have been sent.