### PR TITLE
Return glob results as objects instead of strings

### DIFF
--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -5,6 +5,7 @@
  */
 
 import type {ScriptStateString, ScriptReference} from '../script.js';
+import type {Entry} from '../util/glob.js';
 
 /**
  * Saves and restores output files to some cache store (e.g. local disk or
@@ -35,14 +36,13 @@ export interface Cache {
    *
    * @param script The script whose output will be saved to the cache.
    * @param cacheKey The string-encoded cache key for the script.
-   * @param relativeFilePaths The package-relative output file paths to cache
-   * (concrete paths, not glob patterns).
+   * @param relativeFiles The package-relative output files to cache.
    * @returns Whether the cache was written.
    */
   set(
     script: ScriptReference,
     cacheKey: ScriptStateString,
-    relativeFilePaths: string[]
+    relativeFiles: Entry[]
   ): Promise<boolean>;
 }
 

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -29,6 +29,7 @@ import type {
 import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference, ScriptStateString} from '../script.js';
 import type {Logger} from '../logging/logger.js';
+import type {Entry} from '../util/glob.js';
 
 // TODO(aomarks) Consider dropping the dependency on @actions/cache by writing
 // our own implementation. See https://github.com/google/wireit/issues/107 for
@@ -135,11 +136,11 @@ export class GitHubActionsCache implements Cache {
   async set(
     script: ScriptReference,
     stateStr: ScriptStateString,
-    relativeFiles: string[]
+    relativeFiles: Entry[]
   ): Promise<boolean> {
     const compressionMethod = await GitHubActionsCache.#compressionMethod;
     const tarballPath = await this.#makeTarball(
-      relativeFiles.map((file) => pathlib.join(script.packageDir, file)),
+      relativeFiles.map((file) => pathlib.join(script.packageDir, file.path)),
       compressionMethod
     );
     try {

--- a/src/caching/local-cache.ts
+++ b/src/caching/local-cache.ts
@@ -12,6 +12,7 @@ import {optimizeCpRms, optimizeMkdirs} from '../util/optimize-fs-ops.js';
 
 import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference, ScriptStateString} from '../script.js';
+import type {Entry} from '../util/glob.js';
 
 /**
  * Caches script output to each package's
@@ -37,7 +38,7 @@ export class LocalCache implements Cache {
   async set(
     script: ScriptReference,
     cacheKey: ScriptStateString,
-    relativeFiles: string[]
+    relativeFiles: Entry[]
   ): Promise<boolean> {
     // TODO(aomarks) A script's cache directory currently just grows forever.
     // We'll have the "clean" command to help with manual cleanup, but we'll
@@ -56,7 +57,7 @@ export class LocalCache implements Cache {
     }
     // Compute the smallest set of recursive fs.cp and fs.mkdir operations
     // needed to cover all of the files.
-    const copyOps = optimizeCpRms(relativeFiles);
+    const copyOps = optimizeCpRms(relativeFiles.map((file) => file.path));
     const mkdirOps = optimizeMkdirs(
       copyOps.map((path) => pathlib.dirname(path))
     );

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -86,7 +86,8 @@ test.before.each(async (ctx) => {
       } else if (actual === undefined) {
         throw new Error('Actual was undefined');
       } else {
-        assert.equal(actual.sort(), expected.sort());
+        const actualPaths = actual.map((file) => file.path);
+        assert.equal(actualPaths.sort(), expected.sort());
       }
     };
   } catch (error) {
@@ -365,5 +366,33 @@ test('re-inclusion of directory into directory with expandDirectories=true', ({
     expected: ['foo/1', 'foo/bar/baz/1'],
     expandDirectories: true,
   }));
+
+test('dirent identifies files', async ({rig}) => {
+  await rig.touch('foo');
+  const actual = await glob(['foo'], {
+    cwd: rig.temp,
+    absolute: false,
+    includeDirectories: true,
+    expandDirectories: false,
+  });
+  assert.equal(actual.length, 1);
+  assert.equal(actual[0].path, 'foo');
+  assert.ok(actual[0].dirent.isFile());
+  assert.not(actual[0].dirent.isDirectory());
+});
+
+test('dirent identifies directories', async ({rig}) => {
+  await rig.mkdir('foo');
+  const actual = await glob(['foo'], {
+    cwd: rig.temp,
+    absolute: false,
+    includeDirectories: true,
+    expandDirectories: false,
+  });
+  assert.equal(actual.length, 1);
+  assert.equal(actual[0].path, 'foo');
+  assert.not(actual[0].dirent.isFile());
+  assert.ok(actual[0].dirent.isDirectory());
+});
 
 test.run();


### PR DESCRIPTION
`fast-glob` can return objects instead of strings. These objects contain the `path` along witha a [`dirent`](https://nodejs.org/api/fs.html#class-fsdirent) which can be used to check if something is a regular file, a directory, or some other kind of file.

According to https://github.com/mrmlnc/fast-glob#objectmode there is no overhead for returning this object, because it is an internal representation that `fast-glob` already uses (note that [`readdir`](https://nodejs.org/api/fs.html#fspromisesreaddirpath-options) can return dirents).

We now enable this option and return these objects from our `glob` function.

The context for this is upcoming PRs to address https://github.com/google/wireit/issues/77, which will switch to a different approach for deleting and copying files. This new approach will need to know whether each file is a regular file versus a directory, and it will work faster if it already receives that information, rather than having to `stat` for it.