### PR TITLE
Fix bug that prevented workspace scripts from running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Scripts now identify their own package correctly when they are members of npm
+  workspaces, and they can be invoked from the root workspace using `-ws`
+  commands.
+
 - Give a clearer error message when run with an old npm version.
 
 - When cleaning output, directories will now only be deleted if they are empty.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@
  */
 
 import * as os from 'os';
+import {dirname} from 'path';
 import {WireitError} from './error.js';
 import {DefaultLogger} from './logging/default-logger.js';
 import {Analyzer} from './analyzer.js';
@@ -14,7 +15,14 @@ import {unreachable} from './util/unreachable.js';
 
 import type {ScriptReference} from './script.js';
 
-const packageDir = process.env.npm_config_local_prefix;
+// The "npm_package_json" environment variable gives us the path to the
+// package.json file for the current script's npm package. The similar
+// environment variable "npm_config_local_prefix" gives us the package directory
+// (i.e. without the "/package.json"), however when a package is a member of an
+// npm workspace, then "npm_config_local_prefix" is instead that of the
+// workspace root package.
+const packageJsonPath = process.env.npm_package_json;
+const packageDir = packageJsonPath ? dirname(packageJsonPath) : undefined;
 const logger = new DefaultLogger(packageDir ?? process.cwd());
 
 interface Options {
@@ -45,7 +53,7 @@ const getOptions = (): Options => {
         reason: 'old-npm-version',
         minNpmVersion: `${minimumMajorNpmVersion}`,
         script: {packageDir: process.cwd()},
-        detail: `Env variable npm_config_local_prefix was not set.`,
+        detail: `Env variable npm_package_json was not set.`,
       });
     }
   }


### PR DESCRIPTION
Previously, we were using the `npm_config_local_prefix` environment variable to discover the package directory for the current script.

However, when a package is a member of a workspace (meaning a parent directory has a `package.json` that lists the path of that package in its `workspaces` array), then `npm_config_local_prefix` instead corresponds to the workspace root package.

We now instead use the `npm_package_json` environment variable, which in the case of a workspace is set to the specific workspace package, instead of the root. The only other difference is that it includes the `/package.json` portion of the path.

(It's interesting to note that this bug affected not only commands like `npm run foo -ws`, but a regular command like `cd packages/foo; npm run foo`. This implies that npm actually walks up the filesystem tree to discover if there is another `package.json` file that lists the package as one of its workspaces.)

Fixes https://github.com/google/wireit/issues/123