### PR TITLE
Upgrade our own version of wireit and enable GitHub caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
+      - uses: google/wireit@setup-github-actions-caching/v1
+
       - run: npm ci
       - run: npm test
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Here are some things you might especially like about Wireit:
 
 - **Caching with GitHub Actions**. Wireit supports caching build artifacts and
   test results directly through GitHub Actions, without any extra third-party
-  services. Just add a single `use` line to your workflows.
+  services. Just add a single `uses:` line to your workflows.
 
 - **Watch any script**. Want to automatically re-run your build and tests
   whenever you make a change? Type `npm test watch`. Any script you've

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
-        "wireit": "^0.1.1"
+        "wireit": "^0.2.0"
       },
       "engines": {
         "node": ">=16.7.0"
@@ -2199,11 +2199,12 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.0.tgz",
+      "integrity": "sha512-iE+i8PBthGdSrtAhUv+hRv7UV5tsJtAKMs+h1sIZE5ciEqH6kwGqtyirIldxrkSqpn1MfL6tGiQSdas77zPSGQ==",
       "dev": true,
       "dependencies": {
+        "@actions/cache": "=2.0.2",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11"
       },
@@ -3837,11 +3838,12 @@
       }
     },
     "wireit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.1.1.tgz",
-      "integrity": "sha512-6Ocik3cdyFiA1yJY7y2f+WwKGb2o1exl/gbW4aThHuA8Im9WkeiU9oadpO6NFZDQn5R/67Q2H34a/IfEbvlrkQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.0.tgz",
+      "integrity": "sha512-iE+i8PBthGdSrtAhUv+hRv7UV5tsJtAKMs+h1sIZE5ciEqH6kwGqtyirIldxrkSqpn1MfL6tGiQSdas77zPSGQ==",
       "dev": true,
       "requires": {
+        "@actions/cache": "=2.0.2",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11"
       }

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
-    "wireit": "^0.1.1"
+    "wireit": "^0.2.0"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Bumps the version of Wireit we use to test Wireit to `0.2.0`, and enables GitHub Actions caching.

The 2nd commit in this PR is a minor README fix. You can see that it finished in only a few seconds, because all of the tests were already cached from the first commit:

https://github.com/google/wireit/runs/6185010301?check_suite_focus=true

![image](https://user-images.githubusercontent.com/48894/165412924-7673bdc0-8360-4387-9539-73b387a8ac39.png)

