### PR TITLE
Support yarn, pnpm, and older versions of npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Added support for running scripts with [yarn](https://yarnpkg.com/),
+  [pnpm](https://pnpm.io/), and older versions of npm.
 
 ## [0.2.0] - 2022-04-26
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ and replace the original script with the `wireit` command.
 </table>
 
 Now when you run `npm run build`, Wireit upgrades the script to be smarter and
-more efficient.
+more efficient. Wireit works with [yarn](https://yarnpkg.com/) and
+[pnpm](https://pnpm.io/), too.
 
 You should also add `.wireit` to your `.gitignore` file. Wireit uses the
 `.wireit` directory to store caches and other data for your scripts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,12 @@
         "cmd-shim": "^5.0.0",
         "eslint": "^8.12.0",
         "jsonschema": "^1.4.0",
+        "pnpm": "^6.32.11",
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
-        "wireit": "^0.2.0"
+        "wireit": "^0.2.0",
+        "yarn": "^1.22.18"
       },
       "engines": {
         "node": ">=16.7.0"
@@ -2735,6 +2737,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pnpm": {
+      "version": "6.32.11",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-6.32.11.tgz",
+      "integrity": "sha512-KIb3ImAEGl03aJNy0pai7J0mWn52GJwRrUllxUZwibhLdUoeOuDjXhNSgRxxW9BH2gR91b3UadxzdAvhehmM8w==",
+      "dev": true,
+      "bin": {
+        "pnpm": "bin/pnpm.cjs",
+        "pnpx": "bin/pnpx.cjs"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
@@ -3701,6 +3719,20 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yarn": {
+      "version": "1.22.18",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
+      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
@@ -5781,6 +5813,12 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
+    "pnpm": {
+      "version": "6.32.11",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-6.32.11.tgz",
+      "integrity": "sha512-KIb3ImAEGl03aJNy0pai7J0mWn52GJwRrUllxUZwibhLdUoeOuDjXhNSgRxxW9BH2gR91b3UadxzdAvhehmM8w==",
+      "dev": true
+    },
     "prebuild-install": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
@@ -6500,6 +6538,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yarn": {
+      "version": "1.22.18",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.18.tgz",
+      "integrity": "sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==",
       "dev": true
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -222,10 +222,12 @@
     "cmd-shim": "^5.0.0",
     "eslint": "^8.12.0",
     "jsonschema": "^1.4.0",
+    "pnpm": "^6.32.11",
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
-    "wireit": "^0.2.0"
+    "wireit": "^0.2.0",
+    "yarn": "^1.22.18"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/event.ts
+++ b/src/event.ts
@@ -69,7 +69,6 @@ export type Failure =
   | ExitSignal
   | SpawnError
   | LaunchedIncorrectly
-  | OldNpmVersion
   | MissingPackageJson
   | InvalidPackageJson
   | ScriptNotFound
@@ -113,15 +112,6 @@ export interface SpawnError extends ErrorBase<ScriptReference> {
  */
 export interface LaunchedIncorrectly extends ErrorBase<PackageReference> {
   reason: 'launched-incorrectly';
-}
-
-/**
- * Wireit was launched with an unsupported version of npm.
- */
-export interface OldNpmVersion extends ErrorBase<PackageReference> {
-  reason: 'old-npm-version';
-  minNpmVersion: string;
-  // More info on what specifically went wrong.
   detail: string;
 }
 

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -98,12 +98,8 @@ export class DefaultLogger implements Logger {
             );
           }
           case 'launched-incorrectly': {
-            console.error(`❌${prefix} wireit must be launched with "npm run"`);
-            break;
-          }
-          case 'old-npm-version': {
             console.error(
-              `❌${prefix} wireit must be run with npm at least v${event.minNpmVersion}.`
+              `❌${prefix} wireit must be launched with "npm run" or a compatible command.`
             );
             console.error(`    More info: ${event.detail}`);
             break;

--- a/src/test/errors-usage.test.ts
+++ b/src/test/errors-usage.test.ts
@@ -46,7 +46,8 @@ test(
     assert.equal(
       done.stderr.trim(),
       `
-❌ wireit must be launched with "npm run"`.trim()
+❌ wireit must be launched with "npm run" or a compatible command.
+    More info: Wireit could not identify the script to run.`.trim()
     );
   })
 );
@@ -60,7 +61,8 @@ test(
     assert.equal(
       done.stderr.trim(),
       `
-❌ wireit must be launched with "npm run"`.trim()
+❌ wireit must be launched with "npm run" or a compatible command.
+    More info: Launching Wireit with npx is not supported.`.trim()
     );
   })
 );


### PR DESCRIPTION
We weren't compatible with yarn, pnpm, or older versions of npm because we required the `npm_package_json` environment variable to figure out what our starting package directory was. But this variable is only set by newer versions of npm.

Now, if we don't find this environment variable, we walk up the filesystem to find the nearest `package.json` file, just like how npm does.

Fixes https://github.com/google/wireit/issues/146

cc @appsforartists
