### PR TITLE
Unset github caching environment variables in tests

### DIFF
--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -136,6 +136,11 @@ export class WireitTestRig extends FilesystemTestRig {
       // GitHub Actions sets CI=true, but we want our tests to act like they are
       // running locally by default, even when they are actually running on CI.
       CI: undefined,
+      // Unset GitHub Actions caching environment variables that are set when we
+      // are running these tests in CI.
+      WIREIT_CACHE: undefined,
+      ACTIONS_CACHE_URL: undefined,
+      ACTIONS_RUNTIME_TOKEN: undefined,
       // Environment variables specific to this TestRig instance.
       ...this.env,
       // Environment variables specific to this test case.


### PR DESCRIPTION
Fixes an oversight from when I turned on GitHub Actions caching in https://github.com/google/wireit/pull/141.

The `GITHUB_CACHE` environment variable that was turned on propagated to all of the Wireit instances that we spawned in tests.

That meant we were actually using live, remote caching for every test that had `files` and `output` defined. Oops!