### PR TITLE
Support Node 14 on Windows and release 0.3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,29 +5,11 @@ on: [push, pull_request]
 jobs:
   tests:
     strategy:
+      # We support Node Latest, Active LTS, and the most recent Maintenance LTS.
+      # See https://nodejs.org/en/about/releases/ for Node release schedule.
       matrix:
-        # See https://nodejs.org/en/about/releases/ for Node release
-        # information.
-        include:
-          # Most recent Node Maintenance LTS
-          - os: ubuntu-20.04
-            node: 14
-          # Node Active LTS
-          - os: ubuntu-20.04
-            node: 16
-          # Node Latest
-          - os: ubuntu-20.04
-            node: 18
-          # For macOS just test Active LTS. macOS is similar enough to Linux
-          # that we're unlikely to hit edge cases.
-          - os: macos-11
-            node: 16
-          # Windows has some special handling. Cover our oldest supported
-          # version in addition to Active LTS.
-          - os: windows-2022
-            node: 14
-          - os: windows-2022
-            node: 16
+        version: [14, 16, 18]
+        os: [ubuntu-20.04, macos-11, windows-2022]
 
       # Allow all matrix configurations to complete, instead of cancelling as
       # soon as one fails. Useful because we often have different kinds of

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,14 @@ jobs:
           # Node Latest
           - os: ubuntu-20.04
             node: 18
-          # For macOS and Windows, just test Node Active LTS. We should have
-          # good enough coverage of Node variations from the Linux builds above.
+          # For macOS just test Active LTS. macOS is similar enough to Linux
+          # that we're unlikely to hit edge cases.
           - os: macos-11
             node: 16
+          # Windows has some special handling. Cover our oldest supported
+          # version in addition to Active LTS.
+          - os: windows-2022
+            node: 14
           - os: windows-2022
             node: 16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed `replaceAll is not a function` errors when using Node 14 on Windows.
 
 ## [0.3.0] - 2022-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+
+## [0.3.1] - 2022-04-29
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wireit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wireit",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "vscode-extension"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wireit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Upgrade your npm scripts to make them smarter and more efficient",
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -18,6 +18,7 @@ import {unreachable} from './util/unreachable.js';
 import {glob} from './util/glob.js';
 import {deleteEntries} from './util/delete.js';
 import {AggregateError} from './util/aggregate-error.js';
+import {posixifyPathIfOnWindows} from './util/windows.js';
 
 import type {
   ScriptConfig,
@@ -52,8 +53,6 @@ const PATH_ENV_SUFFIX = (() => {
   );
   return entries.slice(endOfNodeModuleBins).join(pathlib.delimiter);
 })();
-
-const IS_WINDOWS = process.platform === 'win32';
 
 /**
  * Executes a script that has been analyzed and validated by the Analyzer.
@@ -746,10 +745,3 @@ const closeWriteStream = (stream: WriteStream): Promise<void> => {
     });
   });
 };
-
-/**
- * If we are on Windows, convert back slashes to forward slashes (e.g. "foo\bar"
- * -> "foo/bar").
- */
-const posixifyPathIfOnWindows = (path: string) =>
-  IS_WINDOWS ? path.replace(/\\/g, '/') : path;

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -18,7 +18,10 @@ import {unreachable} from './util/unreachable.js';
 import {glob} from './util/glob.js';
 import {deleteEntries} from './util/delete.js';
 import {AggregateError} from './util/aggregate-error.js';
-import {posixifyPathIfOnWindows} from './util/windows.js';
+import {
+  augmentProcessEnvSafelyIfOnWindows,
+  posixifyPathIfOnWindows,
+} from './util/windows.js';
 
 import type {
   ScriptConfig,
@@ -329,10 +332,9 @@ class ScriptExecution {
         //   https://nodejs.org/api/child_process.html#default-windows-shell
         //   https://github.com/npm/run-script/blob/a5b03bdfc3a499bf7587d7414d5ea712888bfe93/lib/make-spawn-args.js#L11
         shell: true,
-        env: {
-          ...process.env,
+        env: augmentProcessEnvSafelyIfOnWindows({
           PATH: this.#pathEnvironmentVariable,
-        },
+        }),
       });
 
       // Only create the stdout/stderr replay files if we encounter anything on

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -752,4 +752,4 @@ const closeWriteStream = (stream: WriteStream): Promise<void> => {
  * -> "foo/bar").
  */
 const posixifyPathIfOnWindows = (path: string) =>
-  IS_WINDOWS ? path.replaceAll(pathlib.win32.sep, pathlib.posix.sep) : path;
+  IS_WINDOWS ? path.replace(/\\/g, '/') : path;

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -8,7 +8,7 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 import {timeout} from './util/uvu-timeout.js';
 import {WireitTestRig} from './util/test-rig.js';
-import {IS_WINDOWS} from './util/windows.js';
+import {IS_WINDOWS} from '../util/windows.js';
 import {NODE_MAJOR_VERSION} from './util/node-version.js';
 
 const test = suite<{rig: WireitTestRig}>();

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -67,7 +67,7 @@ test.before.each(async (ctx) => {
 
       if (pathlib.sep === '\\' && expected !== 'ERROR') {
         // On Windows we expect to get results back with "\" as the separator.
-        expected = expected.map((path) => path.replaceAll('/', '\\'));
+        expected = expected.map((path) => path.replace(/\//g, '\\'));
       }
 
       let actual, error;

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -11,7 +11,7 @@ import {spawn, type ChildProcessWithoutNullStreams} from 'child_process';
 import cmdShim from 'cmd-shim';
 import {WireitTestRigCommand} from './test-rig-command.js';
 import {Deferred} from '../../util/deferred.js';
-import {IS_WINDOWS} from './windows.js';
+import {IS_WINDOWS} from '../../util/windows.js';
 import {FilesystemTestRig} from './filesystem-test-rig.js';
 import {NODE_MAJOR_VERSION} from './node-version.js';
 

--- a/src/test/util/windows.ts
+++ b/src/test/util/windows.ts
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as pathlib from 'path';
-
 export const IS_WINDOWS = process.platform === 'win32';
 
 /**
  * If we're on Windows, replace all forward-slashes with back-slashes.
  */
 export const windowsifyPathIfOnWindows = (path: string) =>
-  IS_WINDOWS ? path.replaceAll(pathlib.posix.sep, pathlib.win32.sep) : path;
+  IS_WINDOWS ? path.replace(/\//g, '\\') : path;

--- a/src/test/util/windows.ts
+++ b/src/test/util/windows.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const IS_WINDOWS = process.platform === 'win32';
+import {IS_WINDOWS} from '../../util/windows.js';
 
 /**
  * If we're on Windows, replace all forward-slashes with back-slashes.

--- a/src/util/copy.ts
+++ b/src/util/copy.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs/promises';
 import * as pathlib from 'path';
 import {optimizeMkdirs} from './optimize-fs-ops.js';
 import {constants} from 'fs';
+import {IS_WINDOWS} from '../util/windows.js';
 
 import type {RelativeEntry} from './glob.js';
 
@@ -87,8 +88,6 @@ const copyFileGracefully = async (src: string, dest: string): Promise<void> => {
     throw error;
   }
 };
-
-const IS_WINDOWS = process.platform === 'win32';
 
 /**
  * Copy a symlink verbatim without following or resolving the target. If the

--- a/src/util/windows.ts
+++ b/src/util/windows.ts
@@ -15,3 +15,80 @@ export const IS_WINDOWS = process.platform === 'win32';
  */
 export const posixifyPathIfOnWindows = (path: string) =>
   IS_WINDOWS ? path.replace(/\\/g, '/') : path;
+
+/**
+ * Overlay the given environment variables on top of the current process's
+ * environment variables in a way that is reliable on Windows.
+ *
+ * Windows environment variable names are **sort of** case-insensitive. When you
+ * `spawn` a process and pass 2 environment variables that differ only in case,
+ * then the value that actually gets set is ambiguous, and depends on the Node
+ * version. In Node 14 it seems to be the last one in iteration order, in Node
+ * 16 it seems to be the first one after sorting.
+ *
+ * For example, if you run:
+ *
+ * ```ts
+ * spawn('foo', {
+ *   env: {
+ *     PATH: 'C:\\extra;C:\\before',
+ *     Path: 'C:\\before'
+ *   }
+ * });
+ * ```
+ *
+ * Then sometimes the value that the spawned process receives could be
+ * `C:\before`, and other times it could be `C:\extra;C:\before`.
+ *
+ * This function ensures that the values given in `augmentations` will always
+ * win, by normalizing casing to match the casing that was already set in
+ * `process.env`.
+ */
+export const augmentProcessEnvSafelyIfOnWindows = (
+  augmentations: Record<string, string | undefined>
+): Record<string, string | undefined> => {
+  if (ENVIRONMENT_VARIABLE_CASINGS_IF_WINDOWS === undefined) {
+    // On Linux and macOS, environment variables are case-sensitive, so there's
+    // nothing special to do here.
+    return {...process.env, ...augmentations};
+  }
+  const augmented = {...process.env};
+  for (const [name, value] of Object.entries(augmentations)) {
+    const existingNames = ENVIRONMENT_VARIABLE_CASINGS_IF_WINDOWS.get(
+      name.toLowerCase()
+    );
+    if (existingNames === undefined) {
+      augmented[name] = value;
+    } else {
+      for (const existingName of existingNames) {
+        augmented[existingName] = value;
+      }
+    }
+  }
+  return augmented;
+};
+
+/**
+ * A map from lowercase environment variable name to the specific name casing(s)
+ * that were found in this process's environment variables.
+ *
+ * This is an array because in Node 14 the `process.env` object can actually
+ * contain multiple entries for the same variable with different casings, even
+ * though the values are always the same. In Node 16, there is only one name
+ * casing, even if it was spawned with multiple.
+ */
+const ENVIRONMENT_VARIABLE_CASINGS_IF_WINDOWS = IS_WINDOWS
+  ? (() => {
+      const map = new Map<string, string[]>();
+      for (const caseSensitiveName of Object.keys(process.env)) {
+        const lowerCaseName = caseSensitiveName.toLowerCase();
+        let arr = map.get(lowerCaseName);
+        if (arr === undefined) {
+          arr = [];
+          map.set(lowerCaseName, arr);
+        }
+        arr.push(caseSensitiveName);
+      }
+      return map;
+    })()
+  : undefined;

--- a/src/util/windows.ts
+++ b/src/util/windows.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Whether we're running on Windows.
+ */
+export const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * If we're on Windows, convert all back-slashes to forward-slashes (e.g.
+ * "foo\bar" -> "foo/bar").
+ */
+export const posixifyPathIfOnWindows = (path: string) =>
+  IS_WINDOWS ? path.replace(/\\/g, '/') : path;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2022",
     "moduleResolution": "node",
     "useDefineForClassFields": true,
-    "lib": ["es2021"],
+    "lib": ["es2020"],
     "rootDir": "src",
     "outDir": "lib",
     "strict": true,


### PR DESCRIPTION
I didn't test Node 14 on Windows in https://github.com/google/wireit/pull/160, so I missed two issues:

- We use `replaceAll`, but only on Windows. Fixed by using `replace` instead, and by dropping `lib` down to `es2020` in `tsconfig.json` (which catches this error in `tsc`).

- There is a subtle difference between how environment variables are treated when `spawn`ing between Node 14 and 16 on Windows, relating to the way environment variables are case-insensitive on Windows. Full details in `test/windows.ts`.

I've also expanded to the test matrix to just test all OS/Node permutations that we support, because obviously it is not safe to assume anything (especially on Windows, but let's be safe and not assume anything about macOS acting exactly like Linux either).

Actually fixes https://github.com/google/wireit/pull/160