### PR TITLE
Bump self-testing Wireit version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,19 +38,10 @@ jobs:
 
       - run: npm ci
 
-      # TODO(aomarks) Remove this hack after Wireit published to npm with Node
-      # 14 support.
-      #
-      # We can't run tests for the PR that adds Node 14 support to Wireit,
-      # because we test ourselves using Wireit from npm, but the npm version
-      # doesn't support Node 14 yet.
-      #
       # Don't bother running the vscode-extension tests on Node 14, because the
       # minimum version of VSCode we support uses Node 16.
       - if: matrix.node == 14
-        run: |
-          npx tsc --build --pretty
-          npx uvu lib/test "\.test\.js$"
+        run: npm run test:headless
 
       # See https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions for why we need xvfb-run
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
-        "wireit": "^0.2.0",
+        "wireit": "^0.3.1",
         "yarn": "^1.22.18"
       },
       "engines": {
@@ -4092,9 +4092,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.1.tgz",
-      "integrity": "sha512-BUijYAuXMsGhTX2akWPRQyor5KmAzEg49WHV8jXRWVWyFQnREF88aSmlLkgn9KOKT7AfWpQdPfsTlraxOPHl1Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.3.1.tgz",
+      "integrity": "sha512-y7/2o6EdQqBiVJhoRsTzMB314m1AklydPXq7TvzZSGdSxhNm5U/9SjZDYH9BQje7AGiIBl7p9QJGZ3wQywChug==",
       "dev": true,
       "dependencies": {
         "@actions/cache": "=2.0.2",
@@ -4105,7 +4105,7 @@
         "wireit": "bin/wireit.js"
       },
       "engines": {
-        "node": ">=16.7.0"
+        "node": ">=14.14.0"
       }
     },
     "node_modules/wireit-extension": {
@@ -7159,9 +7159,9 @@
       }
     },
     "wireit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.2.1.tgz",
-      "integrity": "sha512-BUijYAuXMsGhTX2akWPRQyor5KmAzEg49WHV8jXRWVWyFQnREF88aSmlLkgn9KOKT7AfWpQdPfsTlraxOPHl1Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.3.1.tgz",
+      "integrity": "sha512-y7/2o6EdQqBiVJhoRsTzMB314m1AklydPXq7TvzZSGdSxhNm5U/9SjZDYH9BQje7AGiIBl7p9QJGZ3wQywChug==",
       "dev": true,
       "requires": {
         "@actions/cache": "=2.0.2",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
-    "wireit": "^0.2.0",
+    "wireit": "^0.3.1",
     "yarn": "^1.22.18"
   },
   "prettier": {


### PR DESCRIPTION
We can test on Node 14 using Wireit now that `0.3.1` is published.