### PR TITLE
Upgrade tests to use pnpm7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
-## [0.3.1] - 2022-04-29
+## [0.3.1] - 2022-04-30
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "cmd-shim": "^5.0.0",
         "eslint": "^8.12.0",
         "jsonschema": "^1.4.0",
-        "pnpm": "^6.32.11",
+        "pnpm": "^7.0.0",
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
@@ -450,14 +450,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
-      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
+      "integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/type-utils": "5.21.0",
-        "@typescript-eslint/utils": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/type-utils": "5.22.0",
+        "@typescript-eslint/utils": "5.22.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -498,14 +498,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
-      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
+      "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/typescript-estree": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/typescript-estree": "5.22.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -525,13 +525,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
-      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
+      "integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/visitor-keys": "5.21.0"
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/visitor-keys": "5.22.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -542,12 +542,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
-      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
+      "integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.21.0",
+        "@typescript-eslint/utils": "5.22.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -568,9 +568,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
-      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
+      "integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -581,13 +581,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
-      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
+      "integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/visitor-keys": "5.21.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/visitor-keys": "5.22.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -623,15 +623,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
-      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
+      "integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/typescript-estree": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/typescript-estree": "5.22.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -647,12 +647,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
-      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
+      "integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/types": "5.22.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3099,16 +3099,16 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "6.32.11",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-6.32.11.tgz",
-      "integrity": "sha512-KIb3ImAEGl03aJNy0pai7J0mWn52GJwRrUllxUZwibhLdUoeOuDjXhNSgRxxW9BH2gR91b3UadxzdAvhehmM8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-7.0.0.tgz",
+      "integrity": "sha512-5njVSmE/Sz6coyikS6gjwoKWaxxsJ6BY6jL1aqwvnEpNUfFednbHqid3aZ42JszOFaSOz3Qipcfp4ei22G/JEg==",
       "dev": true,
       "bin": {
         "pnpm": "bin/pnpm.cjs",
         "pnpx": "bin/pnpx.cjs"
       },
       "engines": {
-        "node": ">=12.17"
+        "node": ">=14.19"
       },
       "funding": {
         "url": "https://opencollective.com/pnpm"
@@ -4573,14 +4573,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
-      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
+      "integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/type-utils": "5.21.0",
-        "@typescript-eslint/utils": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/type-utils": "5.22.0",
+        "@typescript-eslint/utils": "5.22.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -4601,52 +4601,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
-      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
+      "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/typescript-estree": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/typescript-estree": "5.22.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
-      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
+      "integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/visitor-keys": "5.21.0"
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/visitor-keys": "5.22.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
-      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
+      "integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.21.0",
+        "@typescript-eslint/utils": "5.22.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
-      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
+      "integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
-      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
+      "integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/visitor-keys": "5.21.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/visitor-keys": "5.22.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -4666,26 +4666,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
-      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
+      "integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.21.0",
-        "@typescript-eslint/types": "5.21.0",
-        "@typescript-eslint/typescript-estree": "5.21.0",
+        "@typescript-eslint/scope-manager": "5.22.0",
+        "@typescript-eslint/types": "5.22.0",
+        "@typescript-eslint/typescript-estree": "5.22.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
-      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
+      "integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/types": "5.22.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -6423,9 +6423,9 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pnpm": {
-      "version": "6.32.11",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-6.32.11.tgz",
-      "integrity": "sha512-KIb3ImAEGl03aJNy0pai7J0mWn52GJwRrUllxUZwibhLdUoeOuDjXhNSgRxxW9BH2gR91b3UadxzdAvhehmM8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-7.0.0.tgz",
+      "integrity": "sha512-5njVSmE/Sz6coyikS6gjwoKWaxxsJ6BY6jL1aqwvnEpNUfFednbHqid3aZ42JszOFaSOz3Qipcfp4ei22G/JEg==",
       "dev": true
     },
     "prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "cmd-shim": "^5.0.0",
     "eslint": "^8.12.0",
     "jsonschema": "^1.4.0",
-    "pnpm": "^6.32.11",
+    "pnpm": "^7.0.0",
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -910,7 +910,7 @@ test(
 
     // Run both from the workspaces root package.
     {
-      const exec = rig.exec('pnpm run cmd --recursive');
+      const exec = rig.exec('pnpm run --recursive cmd');
       // Workspace commands run in serial.
       (await cmdA.nextInvocation()).exit(0);
       (await cmdB.nextInvocation()).exit(0);


### PR DESCRIPTION
Supersedes https://github.com/google/wireit/pull/166

Our pnpm workspaces test was affected by this change in pnpm 7:

```
When using pnpm run <script>, all command line arguments after the script name are now passed
to the script's argv, even --. For example, pnpm run echo --hello -- world will now pass
--hello -- world to the echo script's argv. Previously flagged arguments (e.g. --silent)
were interpreted as pnpm arguments unless -- came before it.
```

https://github.com/pnpm/pnpm/releases/tag/v7.0.0

Also fixed an incorrect date in the CHANGELOG