### PR TITLE
Add an offset to position converter

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -114,9 +114,9 @@ export class Analyzer {
    * upgraded; dependencies are upgraded asynchronously.
    */
   async #upgradePlaceholder(placeholder: PlaceholderConfig): Promise<void> {
-    let packageJsonAst;
+    let packageJson;
     try {
-      packageJsonAst = await this.#packageJsonReader.read(
+      packageJson = await this.#packageJsonReader.read(
         placeholder.packageDir,
         placeholder
       );
@@ -138,7 +138,7 @@ export class Analyzer {
     }
 
     const scriptsSection = findNamedNodeAtLocation(
-      packageJsonAst,
+      packageJson.ast,
       ['scripts'],
       placeholder
     );
@@ -151,7 +151,7 @@ export class Analyzer {
     }
 
     const wireitSection = findNamedNodeAtLocation(
-      packageJsonAst,
+      packageJson.ast,
       ['wireit'],
       placeholder
     );

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -6,135 +6,251 @@
 
 import {test} from 'uvu';
 import * as assert from 'uvu/assert';
-import {drawSquiggleUnderRange} from '../error.js';
+import {drawSquiggle, OffsetToPositionConverter, Position} from '../error.js';
+import {JsonAstNode} from '../util/ast.js';
+
+function assertSquiggleAndPosition(
+  {
+    offset,
+    length,
+    contents,
+    indent,
+  }: {offset: number; length: number; contents: string; indent?: number},
+  expectedSquiggle: string,
+  expectedPosition: Position
+) {
+  const squiggle = drawSquiggle(
+    {
+      range: {offset, length},
+      file: {
+        path: 'package.json',
+        ast: null as unknown as JsonAstNode,
+        contents,
+      },
+    },
+    indent ?? 0
+  );
+  const position = new OffsetToPositionConverter(contents).toPosition(offset);
+  if (expectedSquiggle[0] !== '\n') {
+    throw new Error(
+      `Test authoring error: write the expected squiggle as a template string with a leading newline.`
+    );
+  }
+  assert.equal(squiggle, expectedSquiggle.slice(1));
+  assert.equal(position, expectedPosition);
+}
 
 test('drawing squiggles under ranges in single-line files', () => {
-  assert.equal(drawSquiggleUnderRange({offset: 0, length: 0}, 'H', 0), 'H\n');
-
-  assert.equal(drawSquiggleUnderRange({offset: 0, length: 1}, 'H', 0), 'H\n~');
-
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 3}, 'aaabbbccc', 0),
+  assertSquiggleAndPosition(
+    {
+      offset: 0,
+      length: 0,
+      contents: 'H',
+    },
     `
-aaabbbccc
-   ~~~`.slice(1)
+H
+`,
+    {line: 1, column: 1}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 3}, 'aaabbbccc', 8),
+  assertSquiggleAndPosition(
+    {
+      offset: 3,
+      length: 3,
+      contents: 'aaabbbccc',
+    },
+    `
+aaabbbccc
+   ~~~`,
+    {line: 1, column: 4}
+  );
+
+  assertSquiggleAndPosition(
+    {
+      offset: 3,
+      length: 3,
+      contents: 'aaabbbccc',
+      indent: 8,
+    },
     `
         aaabbbccc
-           ~~~`.slice(1)
+           ~~~`,
+    {line: 1, column: 4}
   );
 });
 
 test('drawing squiggles single-line ranges at the end of multi-line files', () => {
-  assert.equal(
-    drawSquiggleUnderRange({offset: 4, length: 0}, 'abc\nH\n', 0),
-    'H\n'
+  assertSquiggleAndPosition(
+    {
+      offset: 4,
+      length: 0,
+      contents: 'abc\nH\n',
+    },
+    `
+H
+`,
+    {line: 2, column: 1}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 4, length: 1}, 'abc\nH\n', 0),
-    'H\n~'
+  assertSquiggleAndPosition(
+    {
+      offset: 4,
+      length: 1,
+      contents: 'abc\nH\n',
+    },
+    `
+H
+~`,
+    {line: 2, column: 1}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 7, length: 3}, 'abc\naaabbbccc', 0),
+  assertSquiggleAndPosition(
+    {
+      offset: 4,
+      length: 1,
+      contents: 'abc\nH\n',
+    },
+    `
+H
+~`,
+    {line: 2, column: 1}
+  );
+
+  assertSquiggleAndPosition(
+    {offset: 7, length: 3, contents: 'abc\naaabbbccc'},
     `
 aaabbbccc
-   ~~~`.slice(1)
+   ~~~`,
+    {line: 2, column: 4}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 7, length: 3}, 'abc\naaabbbccc', 8),
+  assertSquiggleAndPosition(
+    {
+      offset: 7,
+      length: 3,
+      contents: 'abc\naaabbbccc',
+      indent: 8,
+    },
+
     `
         aaabbbccc
-           ~~~`.slice(1)
-  );
-});
-
-test('drawing squiggles under one line of a multi-line input', () => {
-  assert.equal(
-    drawSquiggleUnderRange({offset: 0, length: 0}, 'H\nabc', 0),
-    'H\n'
-  );
-
-  assert.equal(
-    drawSquiggleUnderRange({offset: 0, length: 1}, 'H\nabc', 0),
-    'H\n~'
-  );
-
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 3}, 'aaabbbccc\nabc', 0),
-    `
-aaabbbccc
-   ~~~`.slice(1)
-  );
-
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 3}, 'aaabbbccc\nabc', 8),
-    `
-        aaabbbccc
-           ~~~`.slice(1)
+           ~~~`,
+    {line: 2, column: 4}
   );
 });
 
 test('drawing squiggles under multi-line ranges', () => {
-  assert.equal(
-    drawSquiggleUnderRange({offset: 0, length: 0}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {
+      offset: 0,
+      length: 0,
+      contents: 'H\nabc',
+    },
     `
-abc
-`.slice(1)
+H
+`,
+    {line: 1, column: 1}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 0, length: 5}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {
+      offset: 0,
+      length: 1,
+      contents: 'H\nabc',
+    },
+    `
+H
+~`,
+    {line: 1, column: 1}
+  );
+
+  assertSquiggleAndPosition(
+    {
+      offset: 3,
+      length: 3,
+      contents: 'aaabbbccc\nabc',
+    },
+    `
+aaabbbccc
+   ~~~`,
+    {line: 1, column: 4}
+  );
+
+  assertSquiggleAndPosition(
+    {
+      offset: 3,
+      length: 3,
+      contents: 'aaabbbccc\nabc',
+      indent: 8,
+    },
+    `
+        aaabbbccc
+           ~~~`,
+    {line: 1, column: 4}
+  );
+});
+
+test('drawing squiggles under one line of a multi-line input', () => {
+  assertSquiggleAndPosition(
+    {offset: 0, length: 0, contents: 'abc\ndef\nhij'},
+    `
+abc
+`,
+    {line: 1, column: 1}
+  );
+
+  assertSquiggleAndPosition(
+    {offset: 0, length: 5, contents: 'abc\ndef\nhij'},
     `
 abc
 ~~~
 def
-~`.slice(1)
+~`,
+    {line: 1, column: 1}
   );
 
   // include the newline at the end of the first line
-  assert.equal(
-    drawSquiggleUnderRange({offset: 0, length: 4}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {offset: 0, length: 4, contents: 'abc\ndef\nhij'},
     `
 abc
 ~~~
 def
-`.slice(1)
+`,
+    {line: 1, column: 1}
   );
 
   // include _only_ the newline at the end of the first line
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 1}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {offset: 3, length: 1, contents: 'abc\ndef\nhij'},
     `
 abc
 ${'   '}
 def
-`.slice(1)
+`,
+    {line: 1, column: 4}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 3, length: 2}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {offset: 3, length: 2, contents: 'abc\ndef\nhij'},
     `
 abc
 ${'   '}
 def
-~`.slice(1)
+~`,
+    {line: 1, column: 4}
   );
 
-  assert.equal(
-    drawSquiggleUnderRange({offset: 2, length: 7}, 'abc\ndef\nhij', 0),
+  assertSquiggleAndPosition(
+    {offset: 2, length: 7, contents: 'abc\ndef\nhij'},
     `
 abc
   ~
 def
 ~~~
 hij
-~`.slice(1)
+~`,
+    {line: 1, column: 3}
   );
 });
 


### PR DESCRIPTION
Parsers, including jsonc-parser, often give locations in terms of a character offset, but when communicating to users we want to use line and character numbers.

This also introduces a JsonFile object, which includes the path, the string contents, and the ast of a json file all in one object. Useful for passing around, and also, in an upcoming change, as a WeakMap key to cache the OffsetToPosition converter from.