### PR TITLE
Convert other errors to diagnostics when possible

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -181,7 +181,7 @@ export class Analyzer {
               length: scriptsSection.name.length,
             },
           },
-        }
+        },
       });
     }
     assertNonBlankString(placeholder, scriptCommand, packageJson);
@@ -272,8 +272,26 @@ export class Analyzer {
               reason: 'duplicate-dependency',
               script: placeholder,
               dependency: resolved,
-              astNode: unresolved,
-              duplicate,
+              diagnostic: {
+                severity: 'error',
+                message: `This dependency is listed multiple times`,
+                location: {
+                  file: packageJson,
+                  range: {offset: unresolved.offset, length: unresolved.length},
+                },
+                supplementalLocations: [
+                  {
+                    message: `The dependency was first listed here.`,
+                    location: {
+                      file: packageJson,
+                      range: {
+                        offset: duplicate.offset,
+                        length: duplicate.length,
+                      },
+                    },
+                  },
+                ],
+              },
             });
           }
           uniqueDependencies.set(uniqueKey, unresolved);

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -171,13 +171,17 @@ export class Analyzer {
         type: 'failure',
         reason: 'script-not-found',
         script: placeholder,
-        locationOfScriptsSection: {
-          file: packageJson,
-          range: {
-            offset: scriptsSection.offset,
-            length: scriptsSection.length,
+        diagnostic: {
+          severity: 'error',
+          message: `Script "${placeholder.name}" not found in the scripts section of this package.json.`,
+          location: {
+            file: packageJson,
+            range: {
+              offset: scriptsSection.name.offset,
+              length: scriptsSection.name.length,
+            },
           },
-        },
+        }
       });
     }
     assertNonBlankString(placeholder, scriptCommand, packageJson);

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -14,7 +14,6 @@ import {scriptReferenceToString} from './script.js';
 import {AggregateError} from './util/aggregate-error.js';
 import {findNamedNodeAtLocation, findNodeAtLocation} from './util/ast.js';
 
-import type {CachingPackageJsonReaderError} from './util/package-json-reader.js';
 import type {
   ScriptConfig,
   ScriptReference,
@@ -117,28 +116,10 @@ export class Analyzer {
    * upgraded; dependencies are upgraded asynchronously.
    */
   async #upgradePlaceholder(placeholder: PlaceholderConfig): Promise<void> {
-    let packageJson;
-    try {
-      packageJson = await this.#packageJsonReader.read(
-        placeholder.packageDir,
-        placeholder
-      );
-    } catch (error) {
-      const reason = (error as CachingPackageJsonReaderError).reason;
-      if (
-        reason === 'missing-package-json' ||
-        reason === 'invalid-package-json'
-      ) {
-        // Add extra context to make this exception a full WireitError.
-        throw new WireitError({
-          type: 'failure',
-          reason,
-          script: placeholder,
-        });
-      } else {
-        throw error;
-      }
-    }
+    const packageJson = await this.#packageJsonReader.read(
+      placeholder.packageDir,
+      placeholder
+    );
 
     const scriptsSection = findNamedNodeAtLocation(
       packageJson.ast,

--- a/src/event.ts
+++ b/src/event.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Diagnostic, Location} from './error.js';
+import {Diagnostic} from './error.js';
 import type {
   ScriptConfig,
   ScriptReference,
@@ -154,7 +154,7 @@ export interface NoScriptsSectionInPackageJson
  */
 export interface ScriptNotFound extends ErrorBase<ScriptReference> {
   reason: 'script-not-found';
-  locationOfScriptsSection: Location;
+  diagnostic: Diagnostic;
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -10,7 +10,7 @@ import type {
   ScriptReference,
   PackageReference,
 } from './script.js';
-import type {JsonAstNode, ParseError} from './util/ast.js';
+import type {ParseError} from './util/ast.js';
 
 /**
  * Something that happened during Wireit execution. Includes successes,
@@ -187,8 +187,7 @@ export interface DuplicateDependency extends ErrorBase<ScriptReference> {
    * The dependency that is duplicated.
    */
   dependency: ScriptReference;
-  astNode: JsonAstNode;
-  duplicate: JsonAstNode;
+  diagnostic: Diagnostic;
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -71,7 +71,6 @@ export type Failure =
   | SpawnError
   | LaunchedIncorrectly
   | MissingPackageJson
-  | InvalidPackageJson
   | NoScriptsSectionInPackageJson
   | PackageJsonParseError
   | ScriptNotFound
@@ -131,13 +130,6 @@ export interface MissingPackageJson extends ErrorBase<ScriptReference> {
 export interface PackageJsonParseError extends ErrorBase<ScriptReference> {
   reason: 'invalid-json-syntax';
   diagnostics: Diagnostic[];
-}
-
-/**
- * A package.json file was invalid.
- */
-export interface InvalidPackageJson extends ErrorBase<ScriptReference> {
-  reason: 'invalid-package-json';
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -195,16 +195,7 @@ export interface DuplicateDependency extends ErrorBase<ScriptReference> {
 export interface Cycle extends ErrorBase<ScriptReference> {
   reason: 'cycle';
 
-  /**
-   * The number of edges in the cycle (e.g. "A -> B -> A" is 2).
-   */
-  length: number;
-
-  /**
-   * The walk that was taken that resulted in the cycle being detected, starting
-   * from the root script.
-   */
-  trail: ScriptReference[];
+  diagnostic: Diagnostic;
 }
 
 // -------------------------------

--- a/src/event.ts
+++ b/src/event.ts
@@ -10,7 +10,6 @@ import type {
   ScriptReference,
   PackageReference,
 } from './script.js';
-import type {ParseError} from './util/ast.js';
 
 /**
  * Something that happened during Wireit execution. Includes successes,
@@ -131,7 +130,7 @@ export interface MissingPackageJson extends ErrorBase<ScriptReference> {
  */
 export interface PackageJsonParseError extends ErrorBase<ScriptReference> {
   reason: 'invalid-json-syntax';
-  errors: ParseError[];
+  diagnostics: Diagnostic[];
 }
 
 /**

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -119,12 +119,6 @@ export class DefaultLogger implements Logger {
             }
             break;
           }
-          case 'invalid-package-json': {
-            console.error(
-              `❌${prefix} Invalid JSON in package.json file in ${event.script.packageDir}`
-            );
-            break;
-          }
 
           case 'no-scripts-in-package-json': {
             console.error(

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -135,7 +135,8 @@ export class DefaultLogger implements Logger {
           case 'script-not-found':
           case 'duplicate-dependency':
           case 'script-not-wireit':
-          case 'invalid-config-syntax': {
+          case 'invalid-config-syntax':
+          case 'cycle': {
             console.error(this.#diagnosticPrinter.print(event.diagnostic));
             break;
           }
@@ -156,32 +157,6 @@ export class DefaultLogger implements Logger {
           }
           case 'spawn-error': {
             console.error(`❌${prefix} Process spawn error: ${event.message}`);
-            break;
-          }
-          case 'cycle': {
-            console.error(`❌${prefix} Cycle detected`);
-            // Display the trail of scripts and indicate where the loop is, like
-            // this:
-            //
-            //     a
-            // .-> b
-            // |   c
-            // `-- b
-            const cycleEnd = event.trail.length - 1;
-            const cycleStart = cycleEnd - event.length;
-            for (let i = 0; i < event.trail.length; i++) {
-              if (i < cycleStart) {
-                process.stderr.write('    ');
-              } else if (i === cycleStart) {
-                process.stderr.write(`.-> `);
-              } else if (i !== cycleEnd) {
-                process.stderr.write('|   ');
-              } else {
-                process.stderr.write('`-- ');
-              }
-              process.stderr.write(this.#label(event.trail[i]));
-              process.stderr.write('\n');
-            }
             break;
           }
         }

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -114,9 +114,9 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'invalid-json-syntax': {
-            console.error(
-              `❌${prefix} Invalid JSON syntax in package.json file in ${event.script.packageDir}`
-            );
+            for (const diagnostic of event.diagnostics) {
+              console.error(this.#diagnosticPrinter.print(diagnostic));
+            }
             break;
           }
           case 'invalid-package-json': {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -132,14 +132,9 @@ export class DefaultLogger implements Logger {
             );
             break;
           }
-          case 'script-not-found': {
-            console.error(this.#diagnosticPrinter.print(event.diagnostic));
-            break;
-          }
-          case 'script-not-wireit': {
-            console.error(this.#diagnosticPrinter.print(event.diagnostic));
-            break;
-          }
+          case 'script-not-found':
+          case 'duplicate-dependency':
+          case 'script-not-wireit':
           case 'invalid-config-syntax': {
             console.error(this.#diagnosticPrinter.print(event.diagnostic));
             break;
@@ -154,12 +149,7 @@ export class DefaultLogger implements Logger {
             );
             break;
           }
-          case 'duplicate-dependency': {
-            console.error(
-              `❌${prefix} The dependency "${event.dependency.name}" was declared multiple times`
-            );
-            break;
-          }
+
           case 'signal': {
             console.error(`❌${prefix} Failed with signal ${event.signal}`);
             break;

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -133,9 +133,7 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'script-not-found': {
-            console.error(
-              `❌${prefix} No script named "${event.script.name}" was found in ${event.script.packageDir}`
-            );
+            console.error(this.#diagnosticPrinter.print(event.diagnostic));
             break;
           }
           case 'script-not-wireit': {

--- a/src/script.ts
+++ b/src/script.ts
@@ -79,7 +79,7 @@ export interface ScriptConfig extends ScriptReference {
    *   }
    * ```
    */
-  scriptAstNode: NamedAstNode<string> | undefined;
+  scriptAstNode: NamedAstNode<string>;
 
   /**
    * The entire config in the wireit section. i.e.:

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -27,6 +27,9 @@ const assertScriptOutputEquals = (
 
   actual = removeAciiColors(actual.trim());
   expected = expected.trim();
+  if (actual !== expected) {
+    console.log(`Copy-pastable output:\n${actual}`);
+  }
   assertOutputEqualish(actual, expected, message);
 };
 
@@ -912,9 +915,13 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ [a] Cycle detected
-.-> a
-\`-- a
+❌ package.json:6:5 Cycle detected in dependencies of "a".
+        "a": {
+        ~~~
+
+    package.json:8:9 "a" points back to "a"
+                "a"
+                ~~~
 `
     );
   })
@@ -949,10 +956,17 @@ test(
     assertScriptOutputEquals(
       stderr,
       `
-❌ [a] Cycle detected
-.-> a
-|   b
-\`-- a
+❌ package.json:7:5 Cycle detected in dependencies of "a".
+        "a": {
+        ~~~
+
+    package.json:9:9 "a" points to "b"
+                "b"
+                ~~~
+
+    package.json:14:9 "b" points back to "a"
+                "a"
+                ~~~
 `
     );
   })
@@ -991,11 +1005,21 @@ test(
     assertScriptOutputEquals(
       stderr,
       `
-❌ [a] Cycle detected
-.-> a
-|   b
-|   c
-\`-- a
+❌ package.json:8:5 Cycle detected in dependencies of "a".
+        "a": {
+        ~~~
+
+    package.json:10:9 "a" points to "b"
+                "b"
+                ~~~
+
+    package.json:15:9 "b" points to "c"
+                "c"
+                ~~~
+
+    package.json:20:9 "c" points back to "a"
+                "a"
+                ~~~
 `
     );
   })
@@ -1030,9 +1054,13 @@ test(
     assertScriptOutputEquals(
       stderr,
       `
-❌ [a] Cycle detected
-.-> a
-\`-- a
+❌ package.json:7:5 Cycle detected in dependencies of "a".
+        "a": {
+        ~~~
+
+    package.json:9:9 "a" points back to "a"
+                "a",
+                ~~~
     `
     );
   })
@@ -1079,13 +1107,21 @@ test(
     assertScriptOutputEquals(
       stderr,
       `
-❌ [b] Cycle detected
-    a
-.-> b
-|   c
-|   d
-\`-- b
-`
+❌ package.json:15:5 Cycle detected in dependencies of "b".
+        "b": {
+        ~~~
+
+    package.json:17:9 "b" points to "c"
+                "c"
+                ~~~
+
+    package.json:22:9 "c" points to "d"
+                "d"
+                ~~~
+
+    package.json:27:9 "d" points back to "e"
+                "e",
+                ~~~`
     );
   })
 );
@@ -1131,12 +1167,21 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-  ❌ [b] Cycle detected
-    a
-.-> b
-|   c
-|   d
-\`-- b
+❌ package.json:16:5 Cycle detected in dependencies of "b".
+        "b": {
+        ~~~
+
+    package.json:18:9 "b" points to "c"
+                "c"
+                ~~~
+
+    package.json:23:9 "c" points to "d"
+                "d"
+                ~~~
+
+    package.json:28:9 "d" points back to "b"
+                "b"
+                ~~~
       `
     );
   })
@@ -1185,12 +1230,21 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-  ❌ [b] Cycle detected
-    a
-.-> b
-|   c
-|   d
-\`-- b
+  ❌ package.json:16:5 Cycle detected in dependencies of "b".
+        "b": {
+        ~~~
+
+    package.json:18:9 "b" points to "c"
+                "c"
+                ~~~
+
+    package.json:23:9 "c" points to "d"
+                "d"
+                ~~~
+
+    package.json:28:9 "d" points back to "b"
+                "b"
+                ~~~
       `
     );
   })
@@ -1231,10 +1285,17 @@ test(
     assertScriptOutputEquals(
       stderr,
       `
-❌ [a] Cycle detected
-.-> a
-|   ../bar:b
-\`-- a
+❌ package.json:6:5 Cycle detected in dependencies of "a".
+        "a": {
+        ~~~
+
+    package.json:8:9 "a" points to "../bar:b"
+                "../bar:b"
+                ~~~~~~~~~~
+
+    ../bar/package.json:8:9 "b" points back to "../foo:a"
+                "../foo:a"
+                ~~~~~~~~~~
 `
     );
   })

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -583,7 +583,9 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ [missing] No script named "missing" was found in ${rig.temp}`
+❌ package.json:2:3 Script "missing" not found in the scripts section of this package.json.
+      "scripts": {
+      ~~~~~~~~~`
     );
   })
 );

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -879,10 +879,10 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ ../bar/package.json:1:16 JSON syntax error
+❌ ..${pathlib.sep}bar${pathlib.sep}package.json:1:16 JSON syntax error
     {"scripts": {},}
                    ~
-❌ ../bar/package.json:1:16 JSON syntax error
+❌ ..${pathlib.sep}bar${pathlib.sep}package.json:1:16 JSON syntax error
     {"scripts": {},}
                    ~
 `
@@ -1293,7 +1293,7 @@ test(
                 "../bar:b"
                 ~~~~~~~~~~
 
-    ../bar/package.json:8:9 "b" points back to "../foo:a"
+    ..${pathlib.sep}bar${pathlib.sep}package.json:8:9 "b" points back to "../foo:a"
                 "../foo:a"
                 ~~~~~~~~~~
 `

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -868,7 +868,7 @@ test(
           },
         },
       },
-      'bar/package.json': 'THIS IS NOT VALID JSON',
+      'bar/package.json': '{"scripts": {},}',
     });
     const result = rig.exec('npm run a', {cwd: 'foo'});
     const done = await result.exit;
@@ -876,10 +876,12 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ [../bar:b] Invalid JSON syntax in package.json file in ${pathlib.resolve(
-        rig.temp,
-        'bar'
-      )}
+❌ ../bar/package.json:1:16 JSON syntax error
+    {"scripts": {},}
+                   ~
+❌ ../bar/package.json:1:16 JSON syntax error
+    {"scripts": {},}
+                   ~
 `
     );
   })

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -612,7 +612,13 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ [a] The dependency "b" was declared multiple times`
+❌ package.json:10:9 This dependency is listed multiple times
+            "b"
+            ~~~
+
+    package.json:9:9 The dependency was first listed here.
+                "b",
+                ~~~`
     );
   })
 );

--- a/src/util/package-json-reader.ts
+++ b/src/util/package-json-reader.ts
@@ -41,7 +41,7 @@ export class CachingPackageJsonReader {
         }
         throw error;
       }
-      const ast = parseTree(contents, placeholder);
+      const ast = parseTree(path, contents, placeholder);
       file = {path, ast, contents};
       this.#cache.set(packageDir, file);
     }

--- a/src/util/package-json-reader.ts
+++ b/src/util/package-json-reader.ts
@@ -10,6 +10,7 @@ import {parseTree} from './ast.js';
 
 import type {PlaceholderConfig} from '../analyzer.js';
 import type {JsonAstNode} from './ast.js';
+import {WireitError} from '../error.js';
 
 export const astKey = Symbol('ast');
 
@@ -37,7 +38,11 @@ export class CachingPackageJsonReader {
         contents = await fs.readFile(path, 'utf8');
       } catch (error) {
         if ((error as {code?: string}).code === 'ENOENT') {
-          throw new CachingPackageJsonReaderError('missing-package-json');
+          throw new WireitError({
+            type: 'failure',
+            reason: 'missing-package-json',
+            script: placeholder,
+          });
         }
         throw error;
       }
@@ -48,21 +53,3 @@ export class CachingPackageJsonReader {
     return file;
   }
 }
-
-/**
- * An exception thrown by {@link CachingPackageJsonReader}.
- *
- * Note we don't use {@link WireitError} here because we don't have the full
- * context of the script we're trying to evaluate.
- */
-class CachingPackageJsonReaderError extends Error {
-  reason: 'missing-package-json' | 'invalid-package-json';
-
-  constructor(reason: CachingPackageJsonReaderError['reason']) {
-    super(reason);
-    this.reason = reason;
-  }
-}
-
-// Export the interface of this class, but not the class itself.
-export type {CachingPackageJsonReaderError};


### PR DESCRIPTION
I think this converts the rest of the error events that are caused by file locations to use diagnostics.

The commits are pretty targeted and should be fairly easy to review one at a time.