### PR TITLE
Handle keyboard input in child process

### DIFF
--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -13,7 +13,11 @@ import {
 
 import type {Result} from './error.js';
 import type {ScriptConfig} from './script.js';
-import type {ChildProcessWithoutNullStreams} from 'child_process';
+import type {
+  ChildProcessWithoutNullStreams,
+  ChildProcessByStdio,
+} from 'child_process';
+import {Readable} from 'stream';
 import type {ExitNonZero, ExitSignal, SpawnError, Killed} from './event.js';
 
 /**
@@ -56,7 +60,9 @@ type ScriptConfigWithRequiredCommand = ScriptConfig & {
  */
 export class ScriptChildProcess {
   readonly #script: ScriptConfigWithRequiredCommand;
-  readonly #child: ChildProcessWithoutNullStreams;
+  readonly #child:
+    | ChildProcessWithoutNullStreams
+    | ChildProcessByStdio<null, Readable, Readable>;
   #state: ScriptChildProcessState = 'starting';
 
   /**
@@ -90,6 +96,7 @@ export class ScriptChildProcess {
       //   https://nodejs.org/api/child_process.html#default-windows-shell
       //   https://github.com/npm/run-script/blob/a5b03bdfc3a499bf7587d7414d5ea712888bfe93/lib/make-spawn-args.js#L11
       shell: true,
+      stdio: ['inherit', 'pipe', 'pipe'],
       env: augmentProcessEnvSafelyIfOnWindows({
         PATH: this.#pathEnvironmentVariable,
       }),


### PR DESCRIPTION
When wiring release-it up with wireit and create a monorepo setup, I saw interesting use cases.

However, using a process like this would require a way to set `stdio: 'inherit'`, or deal in some other way with keyboard input. Would you be open to something like this? Perhaps as a configuration option of sorts. Maybe this should even work out-of-the-box, although currently I'm not sure how handling this stream fits into the rest of the program.

Just to be sure, this first commit is not to be merged as-is, it's just to open this discussion in a draft PR.

Please see the readme and `package.json` of https://github.com/webpro/release-it-monorepo. Also see this screenshot for the working demo to publish three packages in this mini monorepo:

<img width="582" alt="Screen Shot 2022-05-04 at 8 47 33 PM" src="https://user-images.githubusercontent.com/456426/166842786-a1554e7d-64c2-44b4-9535-a004a5205a26.png">

By the way, release-it can be used in `--ci` mode as well, eliminating the need for user/keyboard input.