### PR TITLE
Serialize execution of the same script across different Wireit processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Starting to improve error messages by drawing squiggles underneath the
   specific part of the `package.json` file that's in error.
 
+### Fixed
+
+- [**Breaking**] If two or more entirely separate `npm run` commands are run for
+  the same Wireit script, only one of them will now be allowed to run at a time,
+  while the others wait their turn. This restriction is removed if `output` is
+  set to an empty array.
+
 ## [0.3.1] - 2022-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ export WIREIT_PARALLEL=1
 npm run build
 ```
 
+If two or more seperate `npm run` commands are run for the same Wireit script
+simultaneously, then only one version will be allowed to run at a time, while
+the others wait their turn. This prevents coordination problems that can result
+in incorrect output files being produced. If `output` is set to an empty array,
+then this restriction is removed.
+
 ## Input and output files
 
 The `files` and `output` properties of `wireit.<script>` tell Wireit what your

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ npm run build
 ```
 
 If two or more seperate `npm run` commands are run for the same Wireit script
-simultaneously, then only one version will be allowed to run at a time, while
+simultaneously, then only one instance will be allowed to run at a time, while
 the others wait their turn. This prevents coordination problems that can result
 in incorrect output files being produced. If `output` is set to an empty array,
 then this restriction is removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "braces": "^3.0.2",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",
-        "jsonc-parser": "^3.0.0"
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "wireit": "bin/wireit.js"
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@types/braces": "^3.0.1",
         "@types/node": "^14.0.0",
+        "@types/proper-lockfile": "^4.1.2",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
         "@typescript-eslint/parser": "^5.17.0",
         "cmd-shim": "^5.0.0",
@@ -442,6 +444,21 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true
     },
     "node_modules/@types/tunnel": {
       "version": "0.0.3",
@@ -2339,8 +2356,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3187,6 +3203,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -3327,6 +3353,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -3454,8 +3488,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -4571,6 +4604,21 @@
           }
         }
       }
+    },
+    "@types/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true
     },
     "@types/tunnel": {
       "version": "0.0.3",
@@ -5858,8 +5906,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "has": {
       "version": "1.0.3",
@@ -6486,6 +6533,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6584,6 +6641,11 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6672,8 +6734,7 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "simple-concat": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
   "devDependencies": {
     "@types/braces": "^3.0.1",
     "@types/node": "^14.0.0",
+    "@types/proper-lockfile": "^4.1.2",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "cmd-shim": "^5.0.0",
@@ -259,7 +260,8 @@
     "braces": "^3.0.2",
     "chokidar": "^3.5.3",
     "fast-glob": "^3.2.11",
-    "jsonc-parser": "^3.0.0"
+    "jsonc-parser": "^3.0.0",
+    "proper-lockfile": "^4.1.2"
   },
   "workspaces": [
     "vscode-extension"

--- a/src/event.ts
+++ b/src/event.ts
@@ -238,7 +238,12 @@ export interface Stderr extends OutputBase {
 // Informational events
 // -------------------------------
 
-type Info = ScriptRunning | WatchRunStart | WatchRunEnd | GenericInfo;
+type Info =
+  | ScriptRunning
+  | ScriptLocked
+  | WatchRunStart
+  | WatchRunEnd
+  | GenericInfo;
 
 interface InfoBase<T extends ScriptReference> extends EventBase<T> {
   type: 'info';
@@ -249,6 +254,14 @@ interface InfoBase<T extends ScriptReference> extends EventBase<T> {
  */
 export interface ScriptRunning extends InfoBase<ScriptConfig> {
   detail: 'running';
+}
+
+/**
+ * A script can't run right now because a system-wide lock is being held by
+ * another process.
+ */
+export interface ScriptLocked extends InfoBase<ScriptConfig> {
+  detail: 'locked';
 }
 
 /**

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -22,6 +22,7 @@ import {
   augmentProcessEnvSafelyIfOnWindows,
   posixifyPathIfOnWindows,
 } from './util/windows.js';
+import lockfile from 'proper-lockfile';
 
 import type {
   ScriptConfig,
@@ -135,6 +136,69 @@ class ScriptExecution {
 
   async #execute(): Promise<ScriptState> {
     const dependencyStates = await this.#executeDependencies();
+    if (this.#script.output?.values.length === 0) {
+      // If there are explicitly no output files, then it's not actually
+      // important to maintain an exclusive lock.
+      return this.#executeScript(dependencyStates);
+    }
+    const releaseLock = await this.#acquireLock();
+    try {
+      return await this.#executeScript(dependencyStates);
+    } finally {
+      await releaseLock();
+    }
+  }
+
+  /**
+   * Acquire a system-wide lock on the execution of this script.
+   */
+  async #acquireLock(): Promise<() => Promise<void>> {
+    // The proper-lockfile library is designed to give an exclusive lock for a
+    // *file*. That's slightly misaligned with our use-case, because there's no
+    // particular file we need a lock for -- our lock is for the execution of
+    // this script.
+    //
+    // We can still use the library, we just need to pick some arbitrary file to
+    // ask it to lock for us. It actually errors if the file doesn't exist. So
+    // we end up with a mostly pointless file, and an adjacent "<file>.lock"
+    // directory that manages the lock (to acquire a lock, it does a mkdir for
+    // "<file>.lock", which will atomically succeed or fail depending on whether
+    // it already existed).
+    //
+    // TODO(aomarks) We could make our own implementation that directly takes a
+    // directory to mkdir and doesn't care about the file. There are some nice
+    // details proper-lockfile handles.
+    const lockFile = pathlib.join(this.#dataDir, 'lock');
+    await fs.mkdir(pathlib.dirname(lockFile), {recursive: true});
+    await fs.writeFile(lockFile, '');
+    while (true) {
+      try {
+        return await lockfile.lock(lockFile, {
+          // If this many milliseconds has elapsed since the lock mtime was last
+          // updated, proper-lockfile will delete it and attempt to acquire the
+          // lock again. This handles the case where a process holding the lock
+          // hard-crashed.
+          stale: 10_000,
+          // How frequently the mtime for the lock will be updated while it is
+          // being held. This should be some smallish factor of "stale" so that
+          // we're unlikely to appear stale when we're actually still working on
+          // the script.
+          update: 2000,
+        });
+      } catch (error) {
+        if ((error as {code: string}).code === 'ELOCKED') {
+          // Wait a moment before attempting to acquire the lock again.
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        } else {
+          throw error;
+        }
+      }
+    }
+  }
+
+  async #executeScript(
+    dependencyStates: Array<[ScriptReference, ScriptState]>
+  ): Promise<ScriptState> {
     // Note we must wait for dependencies to finish before generating the cache
     // key, because a dependency could create or modify an input file to this
     // script, which would affect the key.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -171,6 +171,7 @@ class ScriptExecution {
     const lockFile = pathlib.join(this.#dataDir, 'lock');
     await fs.mkdir(pathlib.dirname(lockFile), {recursive: true});
     await fs.writeFile(lockFile, '');
+    let loggedLocked = false;
     while (true) {
       try {
         return await lockfile.lock(lockFile, {
@@ -187,6 +188,15 @@ class ScriptExecution {
         });
       } catch (error) {
         if ((error as {code: string}).code === 'ELOCKED') {
+          if (!loggedLocked) {
+            // Only log this once.
+            this.#logger.log({
+              script: this.#script,
+              type: 'info',
+              detail: 'locked',
+            });
+            loggedLocked = true;
+          }
           // Wait a moment before attempting to acquire the lock again.
           await new Promise((resolve) => setTimeout(resolve, 200));
         } else {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -238,6 +238,12 @@ export class DefaultLogger implements Logger {
             );
             break;
           }
+          case 'locked': {
+            console.log(
+              `💤 ${prefix} Waiting for another process which is already running this script.`
+            );
+            break;
+          }
           case 'watch-run-start': {
             if (process.stdout.isTTY) {
               // If we are in an interactive terminal (TTY), reset it before

--- a/src/test/util/uvu-timeout.ts
+++ b/src/test/util/uvu-timeout.ts
@@ -4,13 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {IS_WINDOWS} from '../../util/windows.js';
-
 import type * as uvu from 'uvu';
 
-const DEFAULT_TIMEOUT = Number(
-  process.env.TEST_TIMEOUT ?? (IS_WINDOWS ? 60_000 : 30_000)
-);
+const DEFAULT_TIMEOUT = Number(process.env.TEST_TIMEOUT ?? 30_000);
 
 /**
  * Returns a promise that resolves after the given period of time.

--- a/src/test/util/uvu-timeout.ts
+++ b/src/test/util/uvu-timeout.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {IS_WINDOWS} from '../../util/windows.js';
+
 import type * as uvu from 'uvu';
 
-const DEFAULT_TIMEOUT = Number(process.env.TEST_TIMEOUT ?? 30_000);
+const DEFAULT_TIMEOUT = Number(
+  process.env.TEST_TIMEOUT ?? (IS_WINDOWS ? 60_000 : 30_000)
+);
 
 /**
  * Returns a promise that resolves after the given period of time.


### PR DESCRIPTION
Previously, if you `npm run` multiple versions of the same script (or 2 Wireit scripts that share a dependency) at the same time, then they would simply run simultaneously, and incorrect output could be produced. In particular, the second Wireit process might try and delete output, while the first one is still writing it.

Now, we prevent multiple versions of the same script from running at the same time. Before any script starts, we try to acquire an exclusive lock for it, and we wait if the lock can't be acquired, logging this message:

```
💤  [a] Waiting for another process which is already running this script.
```

An exception is when `output=[]`, because I think these cases are unlikely to cause problems, and it allows users to continue running e.g. multiple versions of the same server or other non-build step if they need to.

The lockfile is managed using the [proper-lockfile](https://github.com/moxystudio/node-proper-lockfile) library, which seems to have a nice design. It works by attempting to `mkdir` a directory, which will either succeed if it doesn't exist, or fail it does exist, atomically. It also detects when a lock has probably been abandoned, by regularly updating the directory `mtime` when the lock is held, and deleting the lock directory if it hasn't been updated in a long time.

Fixes https://github.com/google/wireit/issues/35