### PR TITLE
Pull file-level analysis out into its own object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
 
-- If two or more scripts depend on the same invalid config, we only log the issue once.
-
-- If two or more scripts depend on a script that fails, we only log that failure once.
+- If two or more scripts depend on the same invalid config, or if they both depend on a script that fails, we now only log about it once.
 
 ## [0.4.0] - 2022-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+- If two or more scripts depend on the same invalid config, we only log the issue once.
+
+- If two or more scripts depend on a script that fails, we only log that failure once.
+
 ## [0.4.0] - 2022-05-06
 
 ### Changed

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -6,9 +6,7 @@
 
 import * as pathlib from 'path';
 import {Diagnostic, MessageLocation, Result} from './error.js';
-import {
-  CachingPackageJsonReader,
-} from './util/package-json-reader.js';
+import {CachingPackageJsonReader} from './util/package-json-reader.js';
 import {scriptReferenceToString} from './script.js';
 import {findNodeAtLocation, JsonFile} from './util/ast.js';
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -8,10 +8,9 @@ import * as pathlib from 'path';
 import {Diagnostic, MessageLocation, Result} from './error.js';
 import {
   CachingPackageJsonReader,
-  JsonFile,
 } from './util/package-json-reader.js';
 import {scriptReferenceToString} from './script.js';
-import {findNodeAtLocation} from './util/ast.js';
+import {findNodeAtLocation, JsonFile} from './util/ast.js';
 
 import type {
   ScriptConfig,

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -214,6 +214,7 @@ export class Analyzer {
           {
             type: 'failure',
             reason: 'invalid-config-syntax',
+            script: placeholder,
             diagnostic: {
               severity: 'error',
               message: `This script is configured to run wireit but it has no config in the wireit section of this package.json file`,
@@ -346,6 +347,7 @@ export class Analyzer {
             {
               type: 'failure',
               reason: 'invalid-config-syntax',
+              script: placeholder,
               diagnostic: {
                 severity: 'error',
                 message: `A wireit config must set at least one of "wireit" or "dependencies", otherwise there is nothing for wireit to do.`,
@@ -417,6 +419,7 @@ export class Analyzer {
             {
               type: 'failure',
               reason: 'invalid-config-syntax',
+              script: placeholder,
               diagnostic: {
                 severity: 'error',
                 message: `The "clean" property must be either true, false, or "if-file-deleted".`,
@@ -458,6 +461,7 @@ export class Analyzer {
                 {
                   type: 'failure',
                   reason: 'invalid-config-syntax',
+                  script: placeholder,
                   diagnostic: {
                     severity: 'error',
                     message: `A package lock must be a filename, not a path`,
@@ -684,6 +688,7 @@ export class Analyzer {
         error: {
           type: 'failure',
           reason: 'invalid-config-syntax',
+          script: context,
           diagnostic: {
             severity: 'error',
             message:
@@ -705,6 +710,7 @@ export class Analyzer {
         error: {
           type: 'failure',
           reason: 'invalid-config-syntax',
+          script: context,
           diagnostic: {
             severity: 'error',
             message:
@@ -730,6 +736,7 @@ export class Analyzer {
         error: {
           type: 'failure',
           reason: 'invalid-config-syntax',
+          script: context,
           diagnostic: {
             severity: 'error',
             message:
@@ -772,6 +779,7 @@ export function failUnlessNonBlankString(
       error: {
         type: 'failure',
         reason: 'invalid-config-syntax',
+        script: {packageDir: pathlib.dirname(file.path)},
         diagnostic: {
           severity: 'error',
           message: `Expected a string, but was ${astNode.type}.`,
@@ -792,6 +800,7 @@ export function failUnlessNonBlankString(
       error: {
         type: 'failure',
         reason: 'invalid-config-syntax',
+        script: {packageDir: pathlib.dirname(file.path)},
         diagnostic: {
           severity: 'error',
           message: `Expected this field to be nonempty`,
@@ -822,6 +831,7 @@ const failUnlessArray = (
       error: {
         type: 'failure',
         reason: 'invalid-config-syntax',
+        script: {packageDir: pathlib.dirname(file.path)},
         diagnostic: {
           severity: 'error',
           message: `Expected an array, but was ${astNode.type}.`,
@@ -850,6 +860,7 @@ export const failUnlessJsonObject = (
     return {
       type: 'failure',
       reason: 'invalid-config-syntax',
+      script: {packageDir: pathlib.dirname(file.path)},
       diagnostic: {
         severity: 'error',
         message: `Expected an object, but was ${astNode.type}.`,

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -234,7 +234,7 @@ export class Analyzer {
     const dependenciesAst =
       wireitConfig && findNodeAtLocation(wireitConfig, ['dependencies']);
     if (dependenciesAst !== undefined) {
-      const result = assertArray(dependenciesAst, packageJson.jsonFile);
+      const result = failUnlessArray(dependenciesAst, packageJson.jsonFile);
       if (!result.ok) {
         return {ok: false, error: [result.error]};
       }
@@ -247,7 +247,7 @@ export class Analyzer {
       const children = dependenciesAst.children ?? [];
       for (let i = 0; i < children.length; i++) {
         const maybeUnresolved = children[i];
-        const stringResult = assertNonBlankString(
+        const stringResult = failUnlessNonBlankString(
           maybeUnresolved,
           packageJson.jsonFile
         );
@@ -311,7 +311,10 @@ export class Analyzer {
 
     let command: JsonAstNode<string> | undefined;
     if (wireitConfig === undefined) {
-      const result = assertNonBlankString(scriptCommand, packageJson.jsonFile);
+      const result = failUnlessNonBlankString(
+        scriptCommand,
+        packageJson.jsonFile
+      );
       if (!result.ok) {
         return {ok: false, error: [result.error]};
       }
@@ -321,7 +324,10 @@ export class Analyzer {
         | undefined
         | JsonAstNode<string>;
       if (commandAst !== undefined) {
-        const result = assertNonBlankString(commandAst, packageJson.jsonFile);
+        const result = failUnlessNonBlankString(
+          commandAst,
+          packageJson.jsonFile
+        );
         if (!result.ok) {
           return {ok: false, error: [result.error]};
         }
@@ -359,14 +365,14 @@ export class Analyzer {
       const filesNode = findNodeAtLocation(wireitConfig, ['files']);
       if (filesNode !== undefined) {
         const values = [];
-        const result = assertArray(filesNode, packageJson.jsonFile);
+        const result = failUnlessArray(filesNode, packageJson.jsonFile);
         if (!result.ok) {
           return {ok: false, error: [result.error]};
         }
         const children = filesNode.children ?? [];
         for (let i = 0; i < children.length; i++) {
           const file = children[i];
-          const result = assertNonBlankString(file, packageJson.jsonFile);
+          const result = failUnlessNonBlankString(file, packageJson.jsonFile);
           if (!result.ok) {
             return {ok: false, error: [result.error]};
           }
@@ -378,14 +384,17 @@ export class Analyzer {
       const outputNode = findNodeAtLocation(wireitConfig, ['output']);
       if (outputNode !== undefined) {
         const values = [];
-        const result = assertArray(outputNode, packageJson.jsonFile);
+        const result = failUnlessArray(outputNode, packageJson.jsonFile);
         if (!result.ok) {
           return {ok: false, error: [result.error]};
         }
         const children = outputNode.children ?? [];
         for (let i = 0; i < children.length; i++) {
           const anOutput = children[i];
-          const result = assertNonBlankString(anOutput, packageJson.jsonFile);
+          const result = failUnlessNonBlankString(
+            anOutput,
+            packageJson.jsonFile
+          );
           if (!result.ok) {
             return {ok: false, error: [result.error]};
           }
@@ -426,7 +435,7 @@ export class Analyzer {
       ]);
       let packageLocks: undefined | {node: JsonAstNode; values: string[]};
       if (packageLocksNode !== undefined) {
-        const result = assertArray(packageLocksNode, packageJson.jsonFile);
+        const result = failUnlessArray(packageLocksNode, packageJson.jsonFile);
         if (!result.ok) {
           return {ok: false, error: [result.error]};
         }
@@ -434,7 +443,7 @@ export class Analyzer {
         const children = packageLocksNode.children ?? [];
         for (let i = 0; i < children.length; i++) {
           const maybeFilename = children[i];
-          const result = assertNonBlankString(
+          const result = failUnlessNonBlankString(
             maybeFilename,
             packageJson.jsonFile
           );
@@ -742,17 +751,18 @@ export class Analyzer {
 }
 
 /**
- * Throw an error if the given value is not a string.
+ * Return a failing result if the given value is not a string, or is an empty
+ * string.
  */
-export function assertNonBlankString(
+export function failUnlessNonBlankString(
   astNode: NamedAstNode,
   file: JsonFile
 ): Result<NamedAstNode<string>, Failure>;
-export function assertNonBlankString(
+export function failUnlessNonBlankString(
   astNode: JsonAstNode,
   file: JsonFile
 ): Result<JsonAstNode<string>, Failure>;
-export function assertNonBlankString(
+export function failUnlessNonBlankString(
   astNode: JsonAstNode,
   file: JsonFile
 ): Result<JsonAstNode<string>, Failure> {
@@ -800,9 +810,9 @@ export function assertNonBlankString(
 }
 
 /**
- * Throw an error if the given value is not an Array.
+ * Return a failing result if the given value is not an Array.
  */
-const assertArray = (
+const failUnlessArray = (
   astNode: JsonAstNode,
   file: JsonFile
 ): Result<void, Failure> => {
@@ -830,10 +840,9 @@ const assertArray = (
 };
 
 /**
- * Throw an error if it was an object literal ({...}), assuming it was parsed
- * from JSON.
+ * Return a failed result if the given value is not an object literal ({...}).
  */
-export const failIfNotJsonObject = (
+export const failUnlessJsonObject = (
   astNode: JsonAstNode,
   file: JsonFile
 ): Failure | void => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,8 +5,8 @@
  */
 
 import type {Failure} from './event.js';
-import {JsonFile} from './util/package-json-reader.js';
 import * as pathlib from 'path';
+import {JsonFile} from './util/ast.js';
 
 export type Result<T, E = Failure> =
   | {ok: true; value: T}

--- a/src/event.ts
+++ b/src/event.ts
@@ -85,6 +85,10 @@ interface ErrorBase<T extends PackageReference> extends EventBase<T> {
   type: 'failure';
 }
 
+interface ScriptlessError {
+  type: 'failure';
+}
+
 /**
  * A script finished with an exit status that was not 0.
  */
@@ -121,14 +125,14 @@ export interface LaunchedIncorrectly extends ErrorBase<PackageReference> {
 /**
  * The package.json file could not be found.
  */
-export interface MissingPackageJson extends ErrorBase<ScriptReference> {
+export interface MissingPackageJson extends ErrorBase<PackageReference> {
   reason: 'missing-package-json';
 }
 
 /**
  * The package.json file was invalid JSON.
  */
-export interface PackageJsonParseError extends ErrorBase<ScriptReference> {
+export interface PackageJsonParseError extends ScriptlessError {
   reason: 'invalid-json-syntax';
   diagnostics: Diagnostic[];
 }
@@ -160,7 +164,7 @@ export interface ScriptNotWireit extends ErrorBase<ScriptReference> {
 /**
  * Something is syntactically wrong with the wireit config.
  */
-export interface InvalidConfigSyntax extends ErrorBase<ScriptReference> {
+export interface InvalidConfigSyntax extends ScriptlessError {
   reason: 'invalid-config-syntax';
   diagnostic: Diagnostic;
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -85,10 +85,6 @@ interface ErrorBase<T extends PackageReference> extends EventBase<T> {
   type: 'failure';
 }
 
-interface ScriptlessError {
-  type: 'failure';
-}
-
 /**
  * A script finished with an exit status that was not 0.
  */
@@ -132,7 +128,7 @@ export interface MissingPackageJson extends ErrorBase<PackageReference> {
 /**
  * The package.json file was invalid JSON.
  */
-export interface PackageJsonParseError extends ScriptlessError {
+export interface PackageJsonParseError extends ErrorBase<PackageReference> {
   reason: 'invalid-json-syntax';
   diagnostics: Diagnostic[];
 }
@@ -164,7 +160,7 @@ export interface ScriptNotWireit extends ErrorBase<ScriptReference> {
 /**
  * Something is syntactically wrong with the wireit config.
  */
-export interface InvalidConfigSyntax extends ScriptlessError {
+export interface InvalidConfigSyntax extends ErrorBase<PackageReference> {
   reason: 'invalid-config-syntax';
   diagnostic: Diagnostic;
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -608,7 +608,6 @@ class ScriptExecution {
         return {
           ok: false,
           error: {
-            script: this.#script,
             type: 'failure',
             reason: 'invalid-config-syntax',
             diagnostic: {
@@ -809,7 +808,6 @@ class ScriptExecution {
         return {
           ok: false,
           error: {
-            script: this.#script,
             type: 'failure',
             reason: 'invalid-config-syntax',
             diagnostic: {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -612,6 +612,7 @@ class ScriptExecution {
           error: {
             type: 'failure',
             reason: 'invalid-config-syntax',
+            script: this.#script,
             diagnostic: {
               severity: 'error',
               message: `Output files must be within the package: ${error.message}`,
@@ -812,6 +813,7 @@ class ScriptExecution {
           error: {
             type: 'failure',
             reason: 'invalid-config-syntax',
+            script: this.#script,
             diagnostic: {
               severity: 'error',
               message: `Output files must be within the package: ${error.message}`,

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -55,10 +55,13 @@ export class DefaultLogger implements Logger {
     return '';
   }
 
+  #getPrefix(script: PackageReference) {
+    const label = this.#label(script);
+    return label !== '' ? ` [${label}]` : '';
+  }
+
   log(event: Event) {
     const type = event.type;
-    const label = this.#label(event.script);
-    const prefix = label !== '' ? ` [${label}]` : '';
     switch (type) {
       default: {
         throw new Error(`Unknown event type: ${unreachable(type) as string}`);
@@ -66,6 +69,7 @@ export class DefaultLogger implements Logger {
 
       case 'success': {
         const reason = event.reason;
+        const prefix = this.#getPrefix(event.script);
         switch (reason) {
           default: {
             throw new Error(
@@ -101,6 +105,7 @@ export class DefaultLogger implements Logger {
             );
           }
           case 'launched-incorrectly': {
+            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} wireit must be launched with "npm run" or a compatible command.`
             );
@@ -108,6 +113,7 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'missing-package-json': {
+            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} No package.json was found in ${event.script.packageDir}`
             );
@@ -121,6 +127,7 @@ export class DefaultLogger implements Logger {
           }
 
           case 'no-scripts-in-package-json': {
+            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} No "scripts" section defined in package.json in ${event.script.packageDir}`
             );
@@ -135,10 +142,12 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'invalid-usage': {
+            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Invalid usage: ${event.message}`);
             break;
           }
           case 'exit-non-zero': {
+            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} Failed with exit status ${event.status}`
             );
@@ -146,14 +155,17 @@ export class DefaultLogger implements Logger {
           }
 
           case 'signal': {
+            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Failed with signal ${event.signal}`);
             break;
           }
           case 'spawn-error': {
+            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Process spawn error: ${event.message}`);
             break;
           }
           case 'unknown-error-thrown': {
+            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} Internal error! Unknown error thrown: ${String(
                 event.error
@@ -192,6 +204,7 @@ export class DefaultLogger implements Logger {
       }
 
       case 'info': {
+        const prefix = this.#getPrefix(event.script);
         const detail = event.detail;
         switch (detail) {
           default: {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -62,6 +62,7 @@ export class DefaultLogger implements Logger {
 
   log(event: Event) {
     const type = event.type;
+    const prefix = this.#getPrefix(event.script);
     switch (type) {
       default: {
         throw new Error(`Unknown event type: ${unreachable(type) as string}`);
@@ -69,7 +70,6 @@ export class DefaultLogger implements Logger {
 
       case 'success': {
         const reason = event.reason;
-        const prefix = this.#getPrefix(event.script);
         switch (reason) {
           default: {
             throw new Error(
@@ -105,7 +105,6 @@ export class DefaultLogger implements Logger {
             );
           }
           case 'launched-incorrectly': {
-            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} wireit must be launched with "npm run" or a compatible command.`
             );
@@ -113,7 +112,6 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'missing-package-json': {
-            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} No package.json was found in ${event.script.packageDir}`
             );
@@ -127,7 +125,6 @@ export class DefaultLogger implements Logger {
           }
 
           case 'no-scripts-in-package-json': {
-            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} No "scripts" section defined in package.json in ${event.script.packageDir}`
             );
@@ -142,12 +139,10 @@ export class DefaultLogger implements Logger {
             break;
           }
           case 'invalid-usage': {
-            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Invalid usage: ${event.message}`);
             break;
           }
           case 'exit-non-zero': {
-            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} Failed with exit status ${event.status}`
             );
@@ -155,17 +150,14 @@ export class DefaultLogger implements Logger {
           }
 
           case 'signal': {
-            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Failed with signal ${event.signal}`);
             break;
           }
           case 'spawn-error': {
-            const prefix = this.#getPrefix(event.script);
             console.error(`❌${prefix} Process spawn error: ${event.message}`);
             break;
           }
           case 'unknown-error-thrown': {
-            const prefix = this.#getPrefix(event.script);
             console.error(
               `❌${prefix} Internal error! Unknown error thrown: ${String(
                 event.error
@@ -204,7 +196,6 @@ export class DefaultLogger implements Logger {
       }
 
       case 'info': {
-        const prefix = this.#getPrefix(event.script);
         const detail = event.detail;
         switch (detail) {
           default: {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -55,14 +55,10 @@ export class DefaultLogger implements Logger {
     return '';
   }
 
-  #getPrefix(script: PackageReference) {
-    const label = this.#label(script);
-    return label !== '' ? ` [${label}]` : '';
-  }
-
   log(event: Event) {
     const type = event.type;
-    const prefix = this.#getPrefix(event.script);
+    const label = this.#label(event.script);
+    const prefix = label !== '' ? ` [${label}]` : '';
     switch (type) {
       default: {
         throw new Error(`Unknown event type: ${unreachable(type) as string}`);

--- a/src/script.ts
+++ b/src/script.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ArrayNode, JsonAstNode, NamedAstNode} from './util/ast.js';
-import {JsonFile} from './util/package-json-reader.js';
+import type {
+  JsonFile,
+  ArrayNode,
+  JsonAstNode,
+  NamedAstNode,
+} from './util/ast.js';
 
 /**
  * The location on disk of an npm package.

--- a/src/test/diagnostic.test.ts
+++ b/src/test/diagnostic.test.ts
@@ -7,7 +7,6 @@
 import {test} from 'uvu';
 import * as assert from 'uvu/assert';
 import {drawSquiggle, OffsetToPositionConverter, Position} from '../error.js';
-import {JsonAstNode} from '../util/ast.js';
 import {removeAciiColors} from './util/colors.js';
 
 function assertSquiggleAndPosition(
@@ -25,7 +24,6 @@ function assertSquiggleAndPosition(
       range: {offset, length},
       file: {
         path: 'package.json',
-        ast: null as unknown as JsonAstNode,
         contents,
       },
     },

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -851,7 +851,7 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ [../bar:b] No package.json was found in ${pathlib.resolve(rig.temp, 'bar')}
+❌ [../bar] No package.json was found in ${pathlib.resolve(rig.temp, 'bar')}
 `
     );
   })

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -1425,7 +1425,7 @@ test(`we don't produce a duplicate error when there's multiple deps into the sam
   assertScriptOutputEquals(
     done.stderr,
     `
-❌ child/package.json:2:14 Expected an object, but was string.
+❌ child${pathlib.sep}package.json:2:14 Expected an object, but was string.
       "scripts": "bad"
                  ~~~~~`
   );

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -6,7 +6,6 @@
 
 import * as jsonParser from 'jsonc-parser';
 import {parseTree as parseTreeInternal, ParseError} from 'jsonc-parser';
-import {PlaceholderConfig} from '../analyzer.js';
 import {Result, Diagnostic} from '../error.js';
 import {Failure} from '../event.js';
 import {JsonFile} from './package-json-reader.js';
@@ -62,7 +61,6 @@ export interface NamedAstNode<T extends ValueTypes = ValueTypes>
 export function findNamedNodeAtLocation(
   astNode: JsonAstNode,
   path: jsonParser.JSONPath,
-  script: PlaceholderConfig,
   file: JsonFile
 ): Result<NamedAstNode | undefined> {
   const node = findNodeAtLocation(astNode, path) as NamedAstNode | undefined;
@@ -77,7 +75,6 @@ export function findNamedNodeAtLocation(
       error: {
         type: 'failure',
         reason: 'invalid-config-syntax',
-        script,
         diagnostic: {
           severity: 'error',
           message: `Expected a property, but got a ${parent.type}`,
@@ -104,8 +101,7 @@ export function findNodeAtLocation(
 
 export function parseTree(
   filePath: string,
-  json: string,
-  placeholder: PlaceholderConfig
+  json: string
 ): Result<JsonAstNode, Failure> {
   const errors: ParseError[] = [];
   const result = parseTreeInternal(json, errors);
@@ -131,7 +127,6 @@ export function parseTree(
         type: 'failure',
         reason: 'invalid-json-syntax',
         diagnostics,
-        script: placeholder,
       },
     };
   }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -9,6 +9,7 @@ import {parseTree as parseTreeInternal, ParseError} from 'jsonc-parser';
 import {Result, Diagnostic} from '../error.js';
 import {Failure} from '../event.js';
 import {JsonFile} from './package-json-reader.js';
+import * as pathlib from 'path';
 export {ParseError} from 'jsonc-parser';
 
 type ValueTypes = string | number | boolean | null | undefined;
@@ -75,6 +76,7 @@ export function findNamedNodeAtLocation(
       error: {
         type: 'failure',
         reason: 'invalid-config-syntax',
+        script: {packageDir: pathlib.dirname(file.path)},
         diagnostic: {
           severity: 'error',
           message: `Expected a property, but got a ${parent.type}`,
@@ -126,6 +128,7 @@ export function parseTree(
       error: {
         type: 'failure',
         reason: 'invalid-json-syntax',
+        script: {packageDir: pathlib.dirname(filePath)},
         diagnostics,
       },
     };

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -8,11 +8,15 @@ import * as jsonParser from 'jsonc-parser';
 import {parseTree as parseTreeInternal, ParseError} from 'jsonc-parser';
 import {Result, Diagnostic} from '../error.js';
 import {Failure} from '../event.js';
-import {JsonFile} from './package-json-reader.js';
 import * as pathlib from 'path';
 export {ParseError} from 'jsonc-parser';
 
 type ValueTypes = string | number | boolean | null | undefined;
+
+export interface JsonFile {
+  path: string;
+  contents: string;
+}
 
 /**
  * A JSON AST node.

--- a/src/util/async-cache.ts
+++ b/src/util/async-cache.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A cache for values that are asynchronously computed that ensures that we
+ * will compute the value for each key at most once.
+ */
+export class AsyncCache<K, V> {
+  readonly #cache = new Map<K, Promise<V>>();
+
+  async getOrCompute(key: K, compute: () => Promise<V>): Promise<V> {
+    let result = this.#cache.get(key);
+    if (result === undefined) {
+      result = compute();
+      this.#cache.set(key, result);
+    }
+    return result;
+  }
+}

--- a/src/util/package-json-reader.ts
+++ b/src/util/package-json-reader.ts
@@ -13,10 +13,6 @@ import {parseTree} from './ast.js';
 
 export const astKey = Symbol('ast');
 
-export interface JsonFile {
-  path: string;
-  contents: string;
-}
 
 /**
  * Reads package.json files and caches them.

--- a/src/util/package-json-reader.ts
+++ b/src/util/package-json-reader.ts
@@ -13,7 +13,6 @@ import {parseTree} from './ast.js';
 
 export const astKey = Symbol('ast');
 
-
 /**
  * Reads package.json files and caches them.
  */

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -3,7 +3,7 @@
  * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import {findNamedNodeAtLocation, JsonFile} from './ast.js';
 import {JsonAstNode, NamedAstNode} from './ast.js';
 import {Failure} from '../event.js';
 import {failUnlessJsonObject, failUnlessNonBlankString} from '../analyzer.js';

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -1,0 +1,165 @@
+import {JsonFile} from './package-json-reader.js';
+import {findNamedNodeAtLocation} from './ast.js';
+import {JsonAstNode, NamedAstNode} from './ast.js';
+import {Failure} from '../event.js';
+import {failIfNotJsonObject, assertNonBlankString} from '../analyzer.js';
+
+export interface ScriptSyntaxInfo {
+  name: string;
+  /** The node for this script in the scripts section of the package.json */
+  scriptNode?: NamedAstNode<string>;
+  /** The node for this script in the wireit section of the package.json */
+  wireitConfigNode?: NamedAstNode;
+}
+
+/**
+ * A parsed and minimally analyzed package.json file.
+ *
+ * This does some very basic syntactic analysis of the package.json file,
+ * finding issues like "the scripts section isn't an object mapping strings to
+ * strings" and "the wireit section isn't an object mapping strings to objects".
+ *
+ * Makes it easy to find the syntax nodes for a script.
+ *
+ * Does not do any validation or analysis of the wirit script configs.
+ *
+ * This class exists in part so that we walk the package.json file only once,
+ * and in part so that we generate file-level syntactic diagnostics only once,
+ * so that we can do better deduplication of errors.
+ */
+export class PackageJson {
+  readonly jsonFile: JsonFile;
+  // We keep the file level AST node private to represent the invariant that
+  // we only walk the file once, in this class, and nowhere else.
+  readonly #fileAstNode: JsonAstNode;
+  readonly #scripts: Map<string, ScriptSyntaxInfo> = new Map();
+  readonly failures: readonly Failure[];
+  readonly scriptsSection: NamedAstNode | undefined = undefined;
+  readonly wireitSection: NamedAstNode | undefined = undefined;
+  constructor(jsonFile: JsonFile, fileAstNode: JsonAstNode) {
+    this.jsonFile = jsonFile;
+    this.#fileAstNode = fileAstNode;
+    const failures: Failure[] = [];
+    this.scriptsSection = this.#analyzeScriptsSection(failures);
+    this.wireitSection = this.#analyzeWireitSection(failures);
+    this.failures = failures;
+  }
+
+  getScriptInfo(name: string): ScriptSyntaxInfo | undefined {
+    return this.#scripts.get(name);
+  }
+
+  #getOrMakeScriptInfo(name: string): ScriptSyntaxInfo {
+    let info = this.#scripts.get(name);
+    if (info == null) {
+      info = {name};
+      this.#scripts.set(name, info);
+    }
+    return info;
+  }
+
+  /**
+   * Do some basic structural validation of the "scripts" section of this
+   * package.json file. Create placeholders for each of the declared scripts and
+   * add them to this.#scripts.
+   */
+  #analyzeScriptsSection(failures: Failure[]): undefined | NamedAstNode {
+    const scriptsSectionResult = findNamedNodeAtLocation(
+      this.#fileAstNode,
+      ['scripts'],
+      this.jsonFile
+    );
+    if (!scriptsSectionResult.ok) {
+      failures.push(scriptsSectionResult.error);
+      return;
+    }
+    const scriptsSection = scriptsSectionResult.value;
+    if (scriptsSection == null) {
+      return;
+    }
+    const fail = failIfNotJsonObject(scriptsSection, this.jsonFile);
+    if (fail != null) {
+      failures.push(fail);
+      return;
+    }
+    for (const child of scriptsSection.children ?? []) {
+      if (child.type !== 'property') {
+        continue;
+      }
+      const [rawName, rawValue] = child.children ?? [];
+      if (rawName == null || rawValue == null) {
+        continue;
+      }
+      const nameResult = assertNonBlankString(rawName, this.jsonFile);
+      if (!nameResult.ok) {
+        failures.push(nameResult.error);
+        continue;
+      }
+      const valueResult = assertNonBlankString(rawValue, this.jsonFile);
+      if (!valueResult.ok) {
+        failures.push(valueResult.error);
+        continue;
+      }
+      const scriptAstNode = valueResult.value as NamedAstNode<string>;
+      scriptAstNode.name = nameResult.value;
+      this.#getOrMakeScriptInfo(nameResult.value.value).scriptNode =
+        scriptAstNode;
+    }
+    return scriptsSectionResult.value;
+  }
+
+  /**
+   * Do some basic structural validation of the "wireit" section of this
+   * package.json file.
+   *
+   * Create placeholders for each of the declared scripts and
+   * add them to this.#scripts.
+   *
+   * Does not do any validation of any wireit configs themselves, that's done
+   * on demand when executing, or all at once when finding all diagnostics.
+   */
+  #analyzeWireitSection(failures: Failure[]): undefined | NamedAstNode {
+    const wireitSectionResult = findNamedNodeAtLocation(
+      this.#fileAstNode,
+      ['wireit'],
+      this.jsonFile
+    );
+    if (!wireitSectionResult.ok) {
+      failures.push(wireitSectionResult.error);
+      return;
+    }
+    const wireitSection = wireitSectionResult.value;
+    if (wireitSection == null) {
+      return;
+    }
+    const fail = failIfNotJsonObject(wireitSection, this.jsonFile);
+    if (fail != null) {
+      failures.push(fail);
+      return;
+    }
+    for (const child of wireitSection.children ?? []) {
+      if (child.type !== 'property') {
+        continue;
+      }
+      const [rawName, rawValue] = child.children ?? [];
+      if (rawName == null || rawValue == null) {
+        continue;
+      }
+      const nameResult = assertNonBlankString(rawName, this.jsonFile);
+      if (!nameResult.ok) {
+        failures.push(nameResult.error);
+        continue;
+      }
+      const fail = failIfNotJsonObject(rawValue, this.jsonFile);
+      if (fail != null) {
+        failures.push(fail);
+        continue;
+      }
+      const wireitConfigNode = rawValue as NamedAstNode;
+      wireitConfigNode.name = nameResult.value;
+      this.#getOrMakeScriptInfo(nameResult.value.value).wireitConfigNode =
+        wireitConfigNode;
+    }
+    return wireitSectionResult.value;
+  }
+}

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -1,5 +1,9 @@
-import {JsonFile} from './package-json-reader.js';
-import {findNamedNodeAtLocation} from './ast.js';
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {JsonAstNode, NamedAstNode} from './ast.js';
 import {Failure} from '../event.js';
 import {failUnlessJsonObject, failUnlessNonBlankString} from '../analyzer.js';

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -25,7 +25,7 @@ export interface ScriptSyntaxInfo {
  *
  * Makes it easy to find the syntax nodes for a script.
  *
- * Does not do any validation or analysis of the wirit script configs.
+ * Does not do any validation or analysis of the wireit script configs.
  *
  * This class exists in part so that we walk the package.json file only once,
  * and in part so that we generate file-level syntactic diagnostics only once,

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -2,7 +2,7 @@ import {JsonFile} from './package-json-reader.js';
 import {findNamedNodeAtLocation} from './ast.js';
 import {JsonAstNode, NamedAstNode} from './ast.js';
 import {Failure} from '../event.js';
-import {failIfNotJsonObject, assertNonBlankString} from '../analyzer.js';
+import {failUnlessJsonObject, failUnlessNonBlankString} from '../analyzer.js';
 
 export interface ScriptSyntaxInfo {
   name: string;
@@ -77,7 +77,7 @@ export class PackageJson {
     if (scriptsSection == null) {
       return;
     }
-    const fail = failIfNotJsonObject(scriptsSection, this.jsonFile);
+    const fail = failUnlessJsonObject(scriptsSection, this.jsonFile);
     if (fail != null) {
       failures.push(fail);
       return;
@@ -90,12 +90,12 @@ export class PackageJson {
       if (rawName == null || rawValue == null) {
         continue;
       }
-      const nameResult = assertNonBlankString(rawName, this.jsonFile);
+      const nameResult = failUnlessNonBlankString(rawName, this.jsonFile);
       if (!nameResult.ok) {
         failures.push(nameResult.error);
         continue;
       }
-      const valueResult = assertNonBlankString(rawValue, this.jsonFile);
+      const valueResult = failUnlessNonBlankString(rawValue, this.jsonFile);
       if (!valueResult.ok) {
         failures.push(valueResult.error);
         continue;
@@ -132,7 +132,7 @@ export class PackageJson {
     if (wireitSection == null) {
       return;
     }
-    const fail = failIfNotJsonObject(wireitSection, this.jsonFile);
+    const fail = failUnlessJsonObject(wireitSection, this.jsonFile);
     if (fail != null) {
       failures.push(fail);
       return;
@@ -145,12 +145,12 @@ export class PackageJson {
       if (rawName == null || rawValue == null) {
         continue;
       }
-      const nameResult = assertNonBlankString(rawName, this.jsonFile);
+      const nameResult = failUnlessNonBlankString(rawName, this.jsonFile);
       if (!nameResult.ok) {
         failures.push(nameResult.error);
         continue;
       }
-      const fail = failIfNotJsonObject(rawValue, this.jsonFile);
+      const fail = failUnlessJsonObject(rawValue, this.jsonFile);
       if (fail != null) {
         failures.push(fail);
         continue;


### PR DESCRIPTION
This way we can generate fewer duplicate diagnostics and walk the package.json file's large scale structure only once rather than once for each script.

Part of working towards IDE support, because what we _really_ want to do is say "give me all the diagnostics in these open files" or perhaps "starting from these files, give me all reachable diagnostics". However I think even just by itself this will be useful for deduplicating diagnostics.