### PR TITLE
Factor out `ScriptChildProcess` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- The `Running command` log message now prints immediately before the child
+  process is spawned. Previously it would print even if it was blocked by
+  parallelism contention.
 
 ## [0.4.0] - 2022-05-06
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -380,13 +380,13 @@ class ScriptExecution {
       return {ok: true, value: undefined};
     }
 
-    this.#logger.log({
-      script: this.#script,
-      type: 'info',
-      detail: 'running',
-    });
-
     return this.#workerPool.run(async (): Promise<Result<void>> => {
+      this.#logger.log({
+        script: this.#script,
+        type: 'info',
+        detail: 'running',
+      });
+
       const child = new ScriptChildProcess(
         // Unfortunately TypeScript doesn't automatically narrow this type
         // based on the undefined-command check we did just above.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -8,7 +8,6 @@ import * as pathlib from 'path';
 import * as fs from 'fs/promises';
 import {createHash} from 'crypto';
 import {createReadStream, createWriteStream} from 'fs';
-import {spawn} from 'child_process';
 import {Result} from './error.js';
 import {scriptReferenceToString} from './script.js';
 import {shuffle} from './util/shuffle.js';
@@ -17,14 +16,13 @@ import {getScriptDataDir} from './util/script-data-dir.js';
 import {unreachable} from './util/unreachable.js';
 import {glob, GlobOutsideCwdError} from './util/glob.js';
 import {deleteEntries} from './util/delete.js';
-import {
-  augmentProcessEnvSafelyIfOnWindows,
-  posixifyPathIfOnWindows,
-} from './util/windows.js';
+import {posixifyPathIfOnWindows} from './util/windows.js';
 import lockfile from 'proper-lockfile';
+import {ScriptChildProcess} from './script-child-process.js';
 
 import type {
   ScriptConfig,
+  ScriptConfigWithRequiredCommand,
   ScriptReference,
   ScriptReferenceString,
   ScriptState,
@@ -34,29 +32,7 @@ import type {
 import type {Logger} from './logging/logger.js';
 import type {WriteStream} from 'fs';
 import type {Cache} from './caching/cache.js';
-import {Failure} from './event.js';
-
-/**
- * The PATH environment variable of this process, minus all of the leading
- * "node_modules/.bin" entries that the incoming "npm run" command already set.
- *
- * We want full control over which "node_modules/.bin" paths are in the PATH of
- * the processes we spawn, so that cross-package dependencies act as though we
- * are running "npm run" with each package as the cwd.
- *
- * We only need to do this once per Wireit process, because process.env never
- * changes.
- */
-const PATH_ENV_SUFFIX = (() => {
-  const path = process.env.PATH ?? '';
-  // Note the PATH delimiter is platform-dependent.
-  const entries = path.split(pathlib.delimiter);
-  const nodeModulesBinSuffix = pathlib.join('node_modules', '.bin');
-  const endOfNodeModuleBins = entries.findIndex(
-    (entry) => !entry.endsWith(nodeModulesBinSuffix)
-  );
-  return entries.slice(endOfNodeModuleBins).join(pathlib.delimiter);
-})();
+import type {Failure} from './event.js';
 
 type ExecutionResult = Result<ScriptState, Failure[]>;
 
@@ -410,149 +386,63 @@ class ScriptExecution {
       detail: 'running',
     });
 
-    const command = this.#script.command;
-    const result = await this.#workerPool.run(
-      async (): Promise<Result<void>> => {
-        // TODO(aomarks) Update npm_ environment variables to reflect the new
-        // package.
-        const child = spawn(command.value, {
-          cwd: this.#script.packageDir,
-          // Conveniently, "shell:true" has the same shell-selection behavior as
-          // "npm run", where on macOS and Linux it is "sh", and on Windows it is
-          // %COMSPEC% || "cmd.exe".
-          //
-          // References:
-          //   https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
-          //   https://nodejs.org/api/child_process.html#default-windows-shell
-          //   https://github.com/npm/run-script/blob/a5b03bdfc3a499bf7587d7414d5ea712888bfe93/lib/make-spawn-args.js#L11
-          shell: true,
-          env: augmentProcessEnvSafelyIfOnWindows({
-            PATH: this.#pathEnvironmentVariable,
-          }),
+    return this.#workerPool.run(async (): Promise<Result<void>> => {
+      const child = new ScriptChildProcess(
+        // Unfortunately TypeScript doesn't automatically narrow this type
+        // based on the undefined-command check we did just above.
+        this.#script as ScriptConfigWithRequiredCommand
+      );
+
+      // Only create the stdout/stderr replay files if we encounter anything on
+      // this streams.
+      let stdoutReplay: WriteStream | undefined;
+      let stderrReplay: WriteStream | undefined;
+
+      child.stdout.on('data', (data: string | Buffer) => {
+        this.#logger.log({
+          script: this.#script,
+          type: 'output',
+          stream: 'stdout',
+          data,
         });
+        if (stdoutReplay === undefined) {
+          stdoutReplay = createWriteStream(this.#stdoutReplayPath);
+        }
+        stdoutReplay.write(data);
+      });
 
-        // Only create the stdout/stderr replay files if we encounter anything on
-        // this streams.
-        let stdoutReplay: WriteStream | undefined;
-        let stderrReplay: WriteStream | undefined;
+      child.stderr.on('data', (data: string | Buffer) => {
+        this.#logger.log({
+          script: this.#script,
+          type: 'output',
+          stream: 'stderr',
+          data,
+        });
+        if (stderrReplay === undefined) {
+          stderrReplay = createWriteStream(this.#stderrReplayPath);
+        }
+        stderrReplay.write(data);
+      });
 
-        child.stdout.on('data', (data: string | Buffer) => {
+      try {
+        const result = await child.completed;
+        if (result.ok) {
           this.#logger.log({
             script: this.#script,
-            type: 'output',
-            stream: 'stdout',
-            data,
+            type: 'success',
+            reason: 'exit-zero',
           });
-          if (stdoutReplay === undefined) {
-            stdoutReplay = createWriteStream(this.#stdoutReplayPath);
-          }
-          stdoutReplay.write(data);
-        });
-
-        child.stderr.on('data', (data: string | Buffer) => {
-          this.#logger.log({
-            script: this.#script,
-            type: 'output',
-            stream: 'stderr',
-            data,
-          });
-          if (stderrReplay === undefined) {
-            stderrReplay = createWriteStream(this.#stderrReplayPath);
-          }
-          stderrReplay.write(data);
-        });
-
-        const completed = new Promise<Result<void>>((resolve) => {
-          child.on('error', (error) => {
-            resolve({
-              ok: false,
-              error: {
-                script: this.#script,
-                type: 'failure',
-                reason: 'spawn-error',
-                message: error.message,
-              },
-            });
-          });
-
-          child.on('close', (status, signal) => {
-            if (signal !== null) {
-              resolve({
-                ok: false,
-                error: {
-                  script: this.#script,
-                  type: 'failure',
-                  reason: 'signal',
-                  signal,
-                },
-              });
-            } else if (status !== 0) {
-              resolve({
-                ok: false,
-                error: {
-                  script: this.#script,
-                  type: 'failure',
-                  reason: 'exit-non-zero',
-                  // status should only ever be null if signal was not null, but
-                  // this isn't reflected in the TypeScript types. Just in case, and
-                  // to make TypeScript happy, fall back to -1 (which is a
-                  // conventional exit status used for "exited with signal").
-                  status: status ?? -1,
-                },
-              });
-            } else {
-              resolve({ok: true, value: undefined});
-            }
-          });
-        });
-
-        let result;
-        try {
-          result = await completed;
-        } finally {
-          if (stdoutReplay !== undefined) {
-            await closeWriteStream(stdoutReplay);
-          }
-          if (stderrReplay !== undefined) {
-            await closeWriteStream(stderrReplay);
-          }
         }
         return result;
+      } finally {
+        if (stdoutReplay !== undefined) {
+          await closeWriteStream(stdoutReplay);
+        }
+        if (stderrReplay !== undefined) {
+          await closeWriteStream(stderrReplay);
+        }
       }
-    );
-
-    if (result.ok) {
-      this.#logger.log({
-        script: this.#script,
-        type: 'success',
-        reason: 'exit-zero',
-      });
-    }
-    return result;
-  }
-
-  /**
-   * Generates the PATH environment variable that should be set when this
-   * script's command is spawned.
-   */
-  get #pathEnvironmentVariable(): string {
-    // Given package "/foo/bar", walk up the path hierarchy to generate
-    // "/foo/bar/node_modules/.bin:/foo/node_modules/.bin:/node_modules/.bin".
-    const entries = [];
-    let cur = this.#script.packageDir;
-    while (true) {
-      entries.push(pathlib.join(cur, 'node_modules', '.bin'));
-      const parent = pathlib.dirname(cur);
-      if (parent === cur) {
-        break;
-      }
-      cur = parent;
-    }
-    // Add the inherited PATH variable, minus any "node_modules/.bin" entries
-    // that were set by the "npm run" command that spawned Wireit.
-    entries.push(PATH_ENV_SUFFIX);
-    // Note the PATH delimiter is platform-dependent.
-    return entries.join(pathlib.delimiter);
+    });
   }
 
   /**

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -286,7 +286,7 @@ class ScriptExecution {
         reason: 'cached',
       });
     } else {
-      const result = await this.#executeCommandIfNeeded();
+      const result = await this.#spawnCommandIfNeeded();
       if (!result.ok) {
         return {ok: false, error: [result.error]};
       }
@@ -368,7 +368,7 @@ class ScriptExecution {
     return {ok: true, value: results};
   }
 
-  async #executeCommandIfNeeded(): Promise<Result<void>> {
+  async #spawnCommandIfNeeded(): Promise<Result<void>> {
     // It's valid to not have a command defined, since thats a useful way to
     // alias a group of dependency scripts. In this case, we can return early.
     if (!this.#script.command) {

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as pathlib from 'path';
+import {spawn} from 'child_process';
+import {augmentProcessEnvSafelyIfOnWindows} from './util/windows.js';
+
+import type {Result} from './error.js';
+import type {ScriptConfigWithRequiredCommand} from './script.js';
+import type {ChildProcessWithoutNullStreams} from 'child_process';
+import type {ExitNonZero, ExitSignal, SpawnError} from './event.js';
+
+/**
+ * The PATH environment variable of this process, minus all of the leading
+ * "node_modules/.bin" entries that the incoming "npm run" command already set.
+ *
+ * We want full control over which "node_modules/.bin" paths are in the PATH of
+ * the processes we spawn, so that cross-package dependencies act as though we
+ * are running "npm run" with each package as the cwd.
+ *
+ * We only need to do this once per Wireit process, because process.env never
+ * changes.
+ */
+const PATH_ENV_SUFFIX = (() => {
+  const path = process.env.PATH ?? '';
+  // Note the PATH delimiter is platform-dependent.
+  const entries = path.split(pathlib.delimiter);
+  const nodeModulesBinSuffix = pathlib.join('node_modules', '.bin');
+  const endOfNodeModuleBins = entries.findIndex(
+    (entry) => !entry.endsWith(nodeModulesBinSuffix)
+  );
+  return entries.slice(endOfNodeModuleBins).join(pathlib.delimiter);
+})();
+
+/**
+ * A child process spawned during execution of a script.
+ */
+export class ScriptChildProcess {
+  readonly #script: ScriptConfigWithRequiredCommand;
+  readonly #child: ChildProcessWithoutNullStreams;
+
+  /**
+   * Resolves when this child process ends.
+   */
+  readonly completed: Promise<
+    Result<void, SpawnError | ExitSignal | ExitNonZero>
+  >;
+
+  get stdout() {
+    return this.#child.stdout;
+  }
+
+  get stderr() {
+    return this.#child.stderr;
+  }
+
+  constructor(script: ScriptConfigWithRequiredCommand) {
+    this.#script = script;
+
+    // TODO(aomarks) Update npm_ environment variables to reflect the new
+    // package.
+    this.#child = spawn(script.command.value, {
+      cwd: script.packageDir,
+      // Conveniently, "shell:true" has the same shell-selection behavior as
+      // "npm run", where on macOS and Linux it is "sh", and on Windows it is
+      // %COMSPEC% || "cmd.exe".
+      //
+      // References:
+      //   https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
+      //   https://nodejs.org/api/child_process.html#default-windows-shell
+      //   https://github.com/npm/run-script/blob/a5b03bdfc3a499bf7587d7414d5ea712888bfe93/lib/make-spawn-args.js#L11
+      shell: true,
+      env: augmentProcessEnvSafelyIfOnWindows({
+        PATH: this.#pathEnvironmentVariable,
+      }),
+    });
+
+    this.completed = new Promise((resolve) => {
+      this.#child.on('error', (error) => {
+        resolve({
+          ok: false,
+          error: {
+            script,
+            type: 'failure',
+            reason: 'spawn-error',
+            message: error.message,
+          },
+        });
+      });
+
+      this.#child.on('close', (status, signal) => {
+        if (signal !== null) {
+          resolve({
+            ok: false,
+            error: {
+              script,
+              type: 'failure',
+              reason: 'signal',
+              signal,
+            },
+          });
+        } else if (status !== 0) {
+          resolve({
+            ok: false,
+            error: {
+              script,
+              type: 'failure',
+              reason: 'exit-non-zero',
+              // status should only ever be null if signal was not null, but
+              // this isn't reflected in the TypeScript types. Just in case, and
+              // to make TypeScript happy, fall back to -1 (which is a
+              // conventional exit status used for "exited with signal").
+              status: status ?? -1,
+            },
+          });
+        } else {
+          resolve({ok: true, value: undefined});
+        }
+      });
+    });
+  }
+
+  /**
+   * Generates the PATH environment variable that should be set when this
+   * script's command is spawned.
+   */
+  get #pathEnvironmentVariable(): string {
+    // Given package "/foo/bar", walk up the path hierarchy to generate
+    // "/foo/bar/node_modules/.bin:/foo/node_modules/.bin:/node_modules/.bin".
+    const entries = [];
+    let cur = this.#script.packageDir;
+    while (true) {
+      entries.push(pathlib.join(cur, 'node_modules', '.bin'));
+      const parent = pathlib.dirname(cur);
+      if (parent === cur) {
+        break;
+      }
+      cur = parent;
+    }
+    // Add the inherited PATH variable, minus any "node_modules/.bin" entries
+    // that were set by the "npm run" command that spawned Wireit.
+    entries.push(PATH_ENV_SUFFIX);
+    // Note the PATH delimiter is platform-dependent.
+    return entries.join(pathlib.delimiter);
+  }
+}

--- a/src/script.ts
+++ b/src/script.ts
@@ -100,6 +100,13 @@ export interface ScriptConfig extends ScriptReference {
 }
 
 /**
+ * A script config but the command is required.
+ */
+export type ScriptConfigWithRequiredCommand = ScriptConfig & {
+  command: Exclude<ScriptConfig['command'], undefined>;
+};
+
+/**
  * Convert a {@link ScriptReference} to a string that can be used as a key in a
  * Set, Map, etc.
  */


### PR DESCRIPTION
Factor out a new `ScriptChildProcess` class from the`#executeCommandIfNeeded` method. This class represents a spawned child process.

This will be useful for [server mode](https://github.com/google/wireit/issues/33), because it gives us a more discrete object that represents a running child process. The lifecycle of running processes will become more complex in server mode, especially in watch mode where we'll be persisting child processes potentially across different build graphs. In a follow up PR, it will gain a `state` property and a `terminate` method.

Also includes a small tweak to logging. We used to log the "Running" message before we tried to get a `WorkerPool` slot, which could give the impression that something was running that wasn't yet, when concurrency was constrained.