### PR TITLE
Recover from GitHub Actions cache rate limit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   process is spawned. Previously it would print even if it was blocked by
   parallelism contention.
 
+- Rate limit errors from GitHub Actions are no longer fatal. If it occurs, a
+  message will be logged, and caching will be disabled for the remainder of the
+  current Wireit process.
+
 ### Changed
 
 - If two or more scripts depend on the same invalid config, or if they both depend on a script that fails, we now only log about it once.

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -189,4 +189,94 @@ test(
   })
 );
 
+test(
+  'recovers from rate limit',
+  timeout(async ({rig, server}) => {
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: 'true',
+            files: ['input'],
+            output: [],
+            dependencies: ['b'],
+          },
+          b: {
+            command: 'true',
+            files: ['input'],
+            output: [],
+          },
+        },
+      },
+    });
+
+    // Check API
+    server.rateLimitNextRequest('check');
+    server.resetMetrics();
+    await rig.write('input', '0');
+    assert.equal((await rig.exec('npm run a').exit).code, 0);
+    assert.equal(server.metrics, {
+      // Note that because we turn off GitHub Actions Caching after the first
+      // rate limit error, "b" fails and then "a" skips, so this count is 1
+      // instead of 2.
+      check: 1,
+      reserve: 0,
+      upload: 0,
+      commit: 0,
+      download: 0,
+    });
+
+    // Reserve API
+    server.rateLimitNextRequest('reserve');
+    server.resetMetrics();
+    await rig.write('input', '1');
+    assert.equal((await rig.exec('npm run a').exit).code, 0);
+    assert.equal(server.metrics, {
+      check: 1,
+      reserve: 1,
+      upload: 0,
+      commit: 0,
+      download: 0,
+    });
+
+    // Upload API
+    server.rateLimitNextRequest('upload');
+    server.resetMetrics();
+    await rig.write('input', '2');
+    assert.equal((await rig.exec('npm run a').exit).code, 0);
+    assert.equal(server.metrics, {
+      check: 1,
+      reserve: 1,
+      upload: 1,
+      commit: 0,
+      download: 0,
+    });
+
+    // Commit API
+    server.rateLimitNextRequest('commit');
+    server.resetMetrics();
+    await rig.write('input', '3');
+    assert.equal((await rig.exec('npm run a').exit).code, 0);
+    assert.equal(server.metrics, {
+      check: 1,
+      reserve: 1,
+      upload: 1,
+      commit: 1,
+      download: 0,
+    });
+
+    // Download API
+    //
+    // TODO(aomarks) The GitHub Actions caching library doesn't surface HTTP
+    // errors during download. Instead it seems to create invalid tarballs. This
+    // might not really be a problem in reality, because tarballs come from a
+    // different CDN server, so probably have a separate rate limit from the
+    // rest of the caching APIs.
+  })
+);
+
 test.run();


### PR DESCRIPTION
We sometimes get 429 rate limit errors from the GitHub Actions Caching service. This PR is a quick fix which detects rate limit errors, makes them non-fatal, and then disables caching for the remainder of that Wireit process.

Just a quick fix, we could do some smarter things with backoff in the future, but I think this should cut down on build failures.