### PR TITLE
Bump our own Wireit version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "prettier": "^2.6.2",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
-        "wireit": "^0.3.1",
+        "wireit": "^0.4.1",
         "yarn": "^1.22.18"
       },
       "engines": {
@@ -7765,14 +7765,17 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.3.1.tgz",
-      "integrity": "sha512-y7/2o6EdQqBiVJhoRsTzMB314m1AklydPXq7TvzZSGdSxhNm5U/9SjZDYH9BQje7AGiIBl7p9QJGZ3wQywChug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.4.1.tgz",
+      "integrity": "sha512-2uCuCcZtxVG0VQ8rbGGmGQQA/XY6pBy7QBRvdtoLmq8SfMlYLaR+fCCWJKY3IhSnhA8pR9/hLA1j0CunF7/Zrw==",
       "dev": true,
       "dependencies": {
         "@actions/cache": "=2.0.2",
+        "braces": "^3.0.2",
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "wireit": "bin/wireit.js"
@@ -13862,14 +13865,17 @@
       }
     },
     "wireit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.3.1.tgz",
-      "integrity": "sha512-y7/2o6EdQqBiVJhoRsTzMB314m1AklydPXq7TvzZSGdSxhNm5U/9SjZDYH9BQje7AGiIBl7p9QJGZ3wQywChug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.4.1.tgz",
+      "integrity": "sha512-2uCuCcZtxVG0VQ8rbGGmGQQA/XY6pBy7QBRvdtoLmq8SfMlYLaR+fCCWJKY3IhSnhA8pR9/hLA1j0CunF7/Zrw==",
       "dev": true,
       "requires": {
         "@actions/cache": "=2.0.2",
+        "braces": "^3.0.2",
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "jsonc-parser": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
       }
     },
     "wireit-extension": {

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "prettier": "^2.6.2",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
-    "wireit": "^0.3.1",
+    "wireit": "^0.4.1",
     "yarn": "^1.22.18"
   },
   "prettier": {


### PR DESCRIPTION
This brings in https://github.com/google/wireit/pull/203 and will hopefully result in fewer failures due to rate limits on the GitHub caching server.