### PR TITLE
Don't start new scripts after failure by default, add option for old behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `WIREIT_FAILURES` environment variable with the following options:
+- Added `WIREIT_FAILURES` environment variable that controls what happens when a
+  script fails (meaning it returned with a non-zero exit code) with the
+  following options:
 
   - `no-new` (default): Allow running scripts to continue, but don't start new
     ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `WIREIT_FAILURES` environment variable with the following options:
+
+  - `no-new` (default): Allow running scripts to continue, but don't start new
+    ones.
+  - `continue`: Allow running scripts to continue, and start new ones as long as
+    all of their dependencies succeeded.
+
+### Changed
+
+- Default failure mode changed from `continue` to `no-new` (see above for
+  definitions).
 
 ## [0.4.1] - 2022-05-10
 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,9 @@ The benefit of Wireit's watch mode over built-in watch modes are:
 
 ## Failures and errors
 
-By default, when a failure occurs in any script, all scripts that are already
-running are allowed to finish, but new scripts are not started.
+By default, when a script fails (meaning it returned with a non-zero exit code),
+all scripts that are already running are allowed to finish, but new scripts are
+not started.
 
 In some situations a different behavior may be better suited. There is an
 additional mode, which you can set with the `WIREIT_FAILURES` environment

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [GitHub Actions caching](#github-actions-caching)
 - [Cleaning output](#cleaning-output)
 - [Watch mode](#watch-mode)
+- [Failures and errors](#failures-and-errors)
 - [Package locks](#package-locks)
 - [Recipes](#recipes)
   - [TypeScript](#typescript)
@@ -378,6 +379,27 @@ The benefit of Wireit's watch mode over built-in watch modes are:
   simultaneously, such as build steps being triggered before all preceding steps
   have finished.
 
+## Failures and errors
+
+By default, when a failure occurs in any script, all scripts that are already
+running are allowed to finish, but new scripts are not started.
+
+In some situations a different behavior may be better suited. There is an
+additional mode, which you can set with the `WIREIT_FAILURES` environment
+variable. Note that Wireit always ultimately exits with a non-zero exit code if
+there was a failure, regardless of the mode.
+
+### Continue
+
+When a failure occurs in `continue` mode, running scripts continue, and new
+scripts are started as long as the failure did not affect their dependencies.
+This mode is useful if you want a complete picture of which scripts are
+succeeding and which are failing.
+
+```bash
+WIREIT_FAILURES=continue
+```
+
 ## Package locks
 
 By default, Wireit automatically treats
@@ -514,6 +536,7 @@ The following environment variables affect the behavior of Wireit:
 
 | Variable          | Description                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `WIREIT_FAILURES` | [How to handle script failures](#failures-and-errors).<br><br>Options:<br><ul><li>[`no-new`](#failures-and-errors) (default): Allow running scripts to finish, but don't start new ones.</li><li>[`continue`](#continue): Allow running scripts to continue, and start new ones unless any of their dependencies failed.</li></ul>                                                                                                   |
 | `WIREIT_PARALLEL` | [Maximum number of scripts to run at one time](#parallelism).<br><br>Defaults to 4×CPUs.<br><br>Must be a positive integer or `infinity`.                                                                                                                                                                                                                                                                                            |
 | `WIREIT_CACHE`    | [Caching mode](#caching).<br><br>Defaults to `local` unless `CI` is `true`, in which case defaults to `none`.<br><br>Automatically set to `github` by the [`google/wireit@setup-github-actions-caching/v1`](#github-actions-caching) action.<br><br>Options:<ul><li>[`local`](#local-caching): Cache to local disk.</li><li>[`github`](#github-actions-caching): Cache to GitHub Actions.</li><li>`none`: Disable caching.</li></ul> |
 | `CI`              | Affects the default value of `WIREIT_CACHE`.<br><br>Automatically set to `true` by [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) and most other CI (continuous integration) services.<br><br>Must be exactly `true`. If unset or any other value, interpreted as `false`.                                                                            |

--- a/src/event.ts
+++ b/src/event.ts
@@ -71,6 +71,7 @@ export type Failure =
   | ExitNonZero
   | ExitSignal
   | SpawnError
+  | Cancelled
   | LaunchedIncorrectly
   | MissingPackageJson
   | NoScriptsSectionInPackageJson
@@ -113,6 +114,13 @@ export interface ExitSignal extends ErrorBase<ScriptConfig> {
 export interface SpawnError extends ErrorBase<ScriptReference> {
   reason: 'spawn-error';
   message: string;
+}
+
+/**
+ * A script was cancelled before it started, due to e.g. another script failure.
+ */
+export interface Cancelled extends ErrorBase<ScriptReference> {
+  reason: 'cancelled';
 }
 
 /**

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -168,7 +168,7 @@ class ScriptExecution {
     }
     const releaseLock = await this.#acquireLock();
     if (!releaseLock.ok) {
-      return releaseLock;
+      return {ok: false, error: [releaseLock.error]};
     }
     try {
       return await this.#executeScript(dependencyStatesResult.value);
@@ -217,7 +217,7 @@ class ScriptExecution {
   /**
    * Acquire a system-wide lock on the execution of this script.
    */
-  async #acquireLock(): Promise<Result<() => Promise<void>, [Cancelled]>> {
+  async #acquireLock(): Promise<Result<() => Promise<void>, Cancelled>> {
     // The proper-lockfile library is designed to give an exclusive lock for a
     // *file*. That's slightly misaligned with our use-case, because there's no
     // particular file we need a lock for -- our lock is for the execution of
@@ -266,7 +266,7 @@ class ScriptExecution {
           // Wait a moment before attempting to acquire the lock again.
           await new Promise((resolve) => setTimeout(resolve, 200));
           if (this.#shouldCancel) {
-            return {ok: false, error: [this.#cancelledEvent]};
+            return {ok: false, error: this.#cancelledEvent};
           }
         } else {
           throw error;

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -69,10 +69,20 @@ export class Executor {
     this.#failureMode = failureMode;
   }
 
+  /**
+   * Signal that a script has failed, which will potentially cancel/kill other
+   * scripts depending on their {@link FailureMode}.
+   *
+   * This method will be called automatically in the normal flow of execution,
+   * but scripts can also call it directly to synchronously signal a failure.
+   */
   notifyFailure(): void {
     this.#failureDeferred.resolve();
   }
 
+  /**
+   * Whether any failures have occured in any script.
+   */
   get failureEncountered(): boolean {
     return this.#failureDeferred.settled;
   }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -37,6 +37,15 @@ import type {Failure} from './event.js';
 type ExecutionResult = Result<ScriptState, Failure[]>;
 
 /**
+ * What to do when a script failure occurs:
+ *
+ * - `no-new`: Allow running scripts to finish, but don't start new ones.
+ * - `continue`: Allow running scripts to finish, and start new ones unless a
+ *   dependency failed.
+ */
+export type FailureMode = 'no-new' | 'continue';
+
+/**
  * Executes a script that has been analyzed and validated by the Analyzer.
  */
 export class Executor {
@@ -44,15 +53,18 @@ export class Executor {
   readonly #logger: Logger;
   readonly #workerPool: WorkerPool;
   readonly #cache?: Cache;
+  readonly #failureMode: FailureMode;
 
   constructor(
     logger: Logger,
     workerPool: WorkerPool,
-    cache: Cache | undefined
+    cache: Cache | undefined,
+    failureMode: FailureMode
   ) {
     this.#logger = logger;
     this.#workerPool = workerPool;
     this.#cache = cache;
+    this.#failureMode = failureMode;
   }
 
   async execute(script: ScriptConfig): Promise<ExecutionResult> {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -155,6 +155,11 @@ export class DefaultLogger implements Logger {
             console.error(`❌${prefix} Process spawn error: ${event.message}`);
             break;
           }
+          case 'cancelled': {
+            // The script never started. We don't really need to log this, it's
+            // fairly noisy. Maybe in a verbose mode.
+            break;
+          }
           case 'unknown-error-thrown': {
             console.error(
               `❌${prefix} Internal error! Unknown error thrown: ${String(

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -1042,7 +1042,7 @@ test(
 
 for (const envSetting of ['no-new', undefined]) {
   test(
-    `don't start new script after unrelated failure when WIREIT_PARALLEL=${
+    `don't start new script after unrelated failure when WIREIT_FAILURES=${
       envSetting ?? '<unset>'
     }`,
     timeout(async ({rig}) => {
@@ -1144,7 +1144,7 @@ for (const envSetting of ['no-new', undefined]) {
       // cover the case where the branch that failed has not yet reached the root
       // of the graph, because it's easy to imagine an implementation that relies
       // on that. Wait a moment first to ensure Wireit unblocks `cancel` before
-      // `fail`.
+      // it unblocks `failParent`.
       await new Promise((resolve) => setTimeout(resolve, 50));
       failParentBlockerInv.exit(0);
 
@@ -1204,9 +1204,6 @@ test(
     // First one fails (doesn't matter which).
     const first = await Promise.race([a.nextInvocation(), b.nextInvocation()]);
     first.exit(1);
-
-    // Wait a moment to ensure Wireit notices the failure before the success.
-    await new Promise((resolve) => setTimeout(resolve, 50));
 
     // Cancel is now unblocked because there is a free worker pool slot, so it
     // could start. But there was a failure elsewhere in the build, so it

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -1040,4 +1040,260 @@ test(
   })
 );
 
+for (const envSetting of ['no-new', undefined]) {
+  test(
+    `don't start new script after unrelated failure when WIREIT_PARALLEL=${
+      envSetting ?? '<unset>'
+    }`,
+    timeout(async ({rig}) => {
+      //   main
+      //    / \
+      //   |   \
+      //   |    v
+      //   |  failParent
+      //   |    /  \
+      //   |   |    |
+      //   |   v    |
+      //   |  fail  |
+      //   |        v
+      //   |    failParentBlocker
+      //   v
+      // cancel
+      //   |
+      //   v
+      // cancelBlocker
+
+      /**
+       * The script that will fail.
+       */
+      const fail = await rig.newCommand();
+
+      /**
+       * The script that we expect to be cancelled.
+       *
+       * It's important that this script does not depend on the one that fails,
+       * because that would be the easy case.
+       */
+      const cancel = await rig.newCommand();
+
+      /**
+       * Gives us control over when the `cancel` script starts.
+       */
+      const cancelBlocker = await rig.newCommand();
+
+      /**
+       * Gives us control over when the `failParent` script resolves.
+       */
+      const failParentBlocker = await rig.newCommand();
+
+      await rig.write({
+        'package.json': {
+          scripts: {
+            main: 'wireit',
+            failParent: 'wireit',
+            failParentBlocker: 'wireit',
+            fail: 'wireit',
+            cancel: 'wireit',
+            cancelBlocker: 'wireit',
+          },
+          wireit: {
+            main: {
+              dependencies: ['failParent', 'cancel'],
+            },
+            failParent: {
+              dependencies: ['fail', 'failParentBlocker'],
+            },
+            failParentBlocker: {
+              command: failParentBlocker.command,
+            },
+            fail: {
+              command: fail.command,
+            },
+            cancel: {
+              command: cancel.command,
+              dependencies: ['cancelBlocker'],
+            },
+            cancelBlocker: {
+              command: cancelBlocker.command,
+            },
+          },
+        },
+      });
+
+      const wireit = rig.exec('npm run main', {
+        env: {
+          WIREIT_FAILURES: envSetting,
+        },
+      });
+
+      // `fail`, `failParentBlocker`, and `cancelBlocker` start
+      const failInv = await fail.nextInvocation();
+      const failParentBlockerInv = await failParentBlocker.nextInvocation();
+      const cancelBlockerInv = await cancelBlocker.nextInvocation();
+
+      // The failure occurs.
+      failInv.exit(1);
+
+      // Unblock `cancel`. It could start, but it shouldn't, because a failure has
+      // occured elsewhere in the graph. Wait a moment first to ensure Wireit
+      // notices the failure before we unblock.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      cancelBlockerInv.exit(0);
+
+      // Unblock `failParent`. We do this after unblocking `cancel` so that we
+      // cover the case where the branch that failed has not yet reached the root
+      // of the graph, because it's easy to imagine an implementation that relies
+      // on that. Wait a moment first to ensure Wireit unblocks `cancel` before
+      // `fail`.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      failParentBlockerInv.exit(0);
+
+      assert.equal((await wireit.exit).code, 1);
+      assert.equal(fail.numInvocations, 1);
+      assert.equal(failParentBlocker.numInvocations, 1);
+      assert.equal(cancel.numInvocations, 0);
+      assert.equal(cancelBlocker.numInvocations, 1);
+    })
+  );
+}
+
+test(
+  "don't start new script after unrelated failure with constrained parallelism in no-new mode",
+  timeout(async ({rig}) => {
+    // This test covers handling for a race condition that occurs where the
+    // WorkerPool might release a slot and let the next script start before a
+    // failure has asynchronously propagated to the Executor.
+
+    //    main
+    //    / \
+    //   |   v
+    //   |  fail
+    //   v
+    // cancel
+
+    const a = await rig.newCommand();
+    const b = await rig.newCommand();
+
+    await rig.write({
+      'package.json': {
+        scripts: {
+          main: 'wireit',
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          main: {
+            dependencies: ['a', 'b'],
+          },
+          a: {
+            command: a.command,
+          },
+          b: {
+            command: b.command,
+          },
+        },
+      },
+    });
+
+    const wireit = rig.exec('npm run main', {
+      env: {
+        WIREIT_PARALLEL: '1',
+      },
+    });
+
+    // First one fails (doesn't matter which).
+    const first = await Promise.race([a.nextInvocation(), b.nextInvocation()]);
+    first.exit(1);
+
+    // Wait a moment to ensure Wireit notices the failure before the success.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Cancel is now unblocked because there is a free worker pool slot, so it
+    // could start. But there was a failure elsewhere in the build, so it
+    // shouldn't.
+
+    assert.equal((await wireit.exit).code, 1);
+
+    if (a.numInvocations === 1) {
+      assert.equal(a.numInvocations, 1);
+      assert.equal(b.numInvocations, 0);
+    } else {
+      assert.equal(a.numInvocations, 0);
+      assert.equal(b.numInvocations, 1);
+    }
+  })
+);
+
+test(
+  'allow unrelated scripts to start after failure in continue mode',
+  timeout(async ({rig}) => {
+    //   main
+    //    /\
+    //   |  |
+    //   |  v
+    //   | fail
+    //   v
+    // continues
+    //   |
+    //   v
+    // continuesBlocker
+
+    const fail = await rig.newCommand();
+    const continues = await rig.newCommand();
+    const continuesBlocker = await rig.newCommand();
+
+    await rig.write({
+      'package.json': {
+        scripts: {
+          main: 'wireit',
+          fail: 'wireit',
+          continues: 'wireit',
+          continuesBlocker: 'wireit',
+        },
+        wireit: {
+          main: {
+            dependencies: ['continues', 'fail'],
+          },
+          fail: {
+            command: fail.command,
+          },
+          continues: {
+            command: continues.command,
+            dependencies: ['continuesBlocker'],
+          },
+          continuesBlocker: {
+            command: continuesBlocker.command,
+          },
+        },
+      },
+    });
+
+    const wireit = rig.exec('npm run main', {
+      env: {
+        WIREIT_FAILURES: 'continue',
+      },
+    });
+
+    // `fail` and `continuesBlocker` start
+    const failInv = await fail.nextInvocation();
+    const continuesBlockerInv = await continuesBlocker.nextInvocation();
+
+    // The failure occurs.
+    failInv.exit(1);
+
+    // Unblock `continues`. Even though there was a failure, it still starts,
+    // because we're in "continue" mode. Wait a moment first to ensure Wireit
+    // notices the failure before we unblock.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    continuesBlockerInv.exit(0);
+    const continuesInv = await continues.nextInvocation();
+    continuesInv.exit(0);
+
+    assert.equal((await wireit.exit).code, 1);
+    assert.equal(fail.numInvocations, 1);
+    assert.equal(continues.numInvocations, 1);
+    assert.equal(continuesBlocker.numInvocations, 1);
+  })
+);
+
 test.run();


### PR DESCRIPTION
### Before

Previously, if a script failed, a new script could still start as long as the failure didn't occur in its transitive dependencies.

For example in this graph, after `fail` fails, `bar` would not start, but `foo` would:

```
 main
  / \
 |   |
 v   v
foo  bar
      |
      v
     fail
```

### After

Now, by default, as soon as a failure occurs anywhere in the build graph, new scripts will not be started, but ones that are already running will be allowed to finish.

The old behavior is still useful, e.g. when you want to have a complete picture of which scripts are passing vs failing, so the old behavior can be enabled by setting:

```bash
WIREIT_FAILURES=continue
```

The default can be set explicitly with (not sure about this name, open to suggestions):

```bash
WIREIT_FAILURES=no-new
```

Fixes https://github.com/google/wireit/issues/29

### Follow up

In a follow-up PR, I am planning to add a `WIREIT_FAILURES=kill` mode, which will be even more aggressive, and terminate running scripts as soon as the first one fails. I think this is also useful in some situations, for when you want to be notified about a failure as soon as possible.
