### PR TITLE
Active script termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Default failure mode changed from `continue` to `no-new` (see above for
   definitions).
 
-- A distinct event is now logged when a script is terminated intentionally by
+- A distinct event is now logged when a script is killed intentionally by
   Wireit.
 
 ## [0.4.1] - 2022-05-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Default failure mode changed from `continue` to `no-new` (see above for
   definitions).
 
+- A distinct event is now logged when a script is terminated intentionally by
+  Wireit.
+
 ## [0.4.1] - 2022-05-10
 
 ### Fixed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -278,7 +278,8 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       logger,
       workerPool,
       cache,
-      options.failureMode
+      options.failureMode,
+      abort
     );
     const result = await executor.execute(analyzedResult.value);
     if (!result.ok) {

--- a/src/event.ts
+++ b/src/event.ts
@@ -73,6 +73,7 @@ export type Failure =
   | ExitSignal
   | SpawnError
   | Cancelled
+  | Terminated
   | LaunchedIncorrectly
   | MissingPackageJson
   | NoScriptsSectionInPackageJson
@@ -123,6 +124,13 @@ export interface SpawnError extends ErrorBase<ScriptReference> {
  */
 export interface Cancelled extends ErrorBase<ScriptReference> {
   reason: 'cancelled';
+}
+
+/**
+ * A script was intentionally and successfully terminated by Wireit.
+ */
+export interface Terminated extends ErrorBase<ScriptReference> {
+  reason: 'terminated';
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -72,8 +72,8 @@ export type Failure =
   | ExitNonZero
   | ExitSignal
   | SpawnError
-  | Cancelled
-  | Terminated
+  | StartCancelled
+  | Killed
   | LaunchedIncorrectly
   | MissingPackageJson
   | NoScriptsSectionInPackageJson
@@ -120,17 +120,18 @@ export interface SpawnError extends ErrorBase<ScriptReference> {
 }
 
 /**
- * A script was cancelled before it started, due to e.g. another script failure.
+ * We decided not to start a script after all, due to e.g. another script
+ * failure.
  */
-export interface Cancelled extends ErrorBase<ScriptReference> {
-  reason: 'cancelled';
+export interface StartCancelled extends ErrorBase<ScriptReference> {
+  reason: 'start-cancelled';
 }
 
 /**
- * A script was intentionally and successfully terminated by Wireit.
+ * A script was intentionally and successfully killed by Wireit.
  */
-export interface Terminated extends ErrorBase<ScriptReference> {
-  reason: 'terminated';
+export interface Killed extends ErrorBase<ScriptReference> {
+  reason: 'killed';
 }
 
 /**

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -124,7 +124,7 @@ export class Executor {
    * A promise which resolves if we should terminate running scripts.
    */
   get shouldTerminateRunningScripts(): Promise<void> {
-    return this.#cancelNewScripts.promise;
+    return this.#terminateRunningScripts.promise;
   }
 
   async execute(script: ScriptConfig): Promise<ExecutionResult> {

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -175,6 +175,10 @@ export class DefaultLogger implements Logger {
             // fairly noisy. Maybe in a verbose mode.
             break;
           }
+          case 'terminated': {
+            console.error(`💀${prefix} Terminated`);
+            break;
+          }
           case 'unknown-error-thrown': {
             console.error(
               `❌${prefix} Internal error! Please file a bug at https://github.com/google/wireit/issues/new, mention this message, that you encountered it in wireit version ${getWireitVersion()}, and give information about your package.json files.\n    Unknown error thrown: ${String(

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -170,13 +170,13 @@ export class DefaultLogger implements Logger {
             console.error(`❌${prefix} Process spawn error: ${event.message}`);
             break;
           }
-          case 'cancelled': {
+          case 'start-cancelled': {
             // The script never started. We don't really need to log this, it's
             // fairly noisy. Maybe in a verbose mode.
             break;
           }
-          case 'terminated': {
-            console.error(`💀${prefix} Terminated`);
+          case 'killed': {
+            console.error(`💀${prefix} Killed`);
             break;
           }
           case 'unknown-error-thrown': {

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -6,12 +6,15 @@
 
 import * as pathlib from 'path';
 import {spawn} from 'child_process';
-import {augmentProcessEnvSafelyIfOnWindows} from './util/windows.js';
+import {
+  augmentProcessEnvSafelyIfOnWindows,
+  IS_WINDOWS,
+} from './util/windows.js';
 
 import type {Result} from './error.js';
 import type {ScriptConfigWithRequiredCommand} from './script.js';
 import type {ChildProcessWithoutNullStreams} from 'child_process';
-import type {ExitNonZero, ExitSignal, SpawnError} from './event.js';
+import type {ExitNonZero, ExitSignal, SpawnError, Terminated} from './event.js';
 
 /**
  * The PATH environment variable of this process, minus all of the leading
@@ -35,18 +38,25 @@ const PATH_ENV_SUFFIX = (() => {
   return entries.slice(endOfNodeModuleBins).join(pathlib.delimiter);
 })();
 
+export type ScriptChildProcessState =
+  | 'starting'
+  | 'started'
+  | 'stopping'
+  | 'stopped';
+
 /**
  * A child process spawned during execution of a script.
  */
 export class ScriptChildProcess {
   readonly #script: ScriptConfigWithRequiredCommand;
   readonly #child: ChildProcessWithoutNullStreams;
+  #state: ScriptChildProcessState = 'starting';
 
   /**
    * Resolves when this child process ends.
    */
   readonly completed: Promise<
-    Result<void, SpawnError | ExitSignal | ExitNonZero>
+    Result<void, SpawnError | ExitSignal | ExitNonZero | Terminated>
   >;
 
   get stdout() {
@@ -76,9 +86,58 @@ export class ScriptChildProcess {
       env: augmentProcessEnvSafelyIfOnWindows({
         PATH: this.#pathEnvironmentVariable,
       }),
+      // Set "detached" on Linux and macOS so that we create a new process
+      // group, instead of being added to the process group for this Wireit
+      // process.
+      //
+      // We need a new process group so that we can use "kill(-pid)" to kill all
+      // of the processes in the process group, instead of just the group leader
+      // "sh" process. "sh" does not forward signals to child processes, so a
+      // regular "kill(pid)" would not kill the actual process we care about.
+      //
+      // On Windows this works differently, and we use the "\t" flag to
+      // "taskkill" to kill child processes. However, if we do set "detached" on
+      // Windows, it causes the child process to open in a new terminal window,
+      // which we don't want.
+      detached: !IS_WINDOWS,
     });
 
-    this.completed = new Promise((resolve) => {
+    this.completed = new Promise((resolve, reject) => {
+      this.#child.on('spawn', () => {
+        switch (this.#state) {
+          case 'starting': {
+            this.#state = 'started';
+            break;
+          }
+          case 'stopping': {
+            // We received a termination request while we were still starting.
+            // Terminate now that we're started.
+            this.#actuallyTerminate();
+            break;
+          }
+          case 'started':
+          case 'stopped': {
+            reject(
+              new Error(
+                `Internal error: Expected ScriptChildProcessState ` +
+                  `to be "started" or "stopping" but was "${this.#state}"`
+              )
+            );
+            break;
+          }
+          default: {
+            const never: never = this.#state;
+            reject(
+              new Error(
+                `Internal error: unexpected ScriptChildProcessState: ${String(
+                  never
+                )}`
+              )
+            );
+          }
+        }
+      });
+
       this.#child.on('error', (error) => {
         resolve({
           ok: false,
@@ -89,10 +148,20 @@ export class ScriptChildProcess {
             message: error.message,
           },
         });
+        this.#state = 'stopped';
       });
 
       this.#child.on('close', (status, signal) => {
-        if (signal !== null) {
+        if (this.#state === 'stopping') {
+          resolve({
+            ok: false,
+            error: {
+              script,
+              type: 'failure',
+              reason: 'terminated',
+            },
+          });
+        } else if (signal !== null) {
           resolve({
             ok: false,
             error: {
@@ -119,8 +188,72 @@ export class ScriptChildProcess {
         } else {
           resolve({ok: true, value: undefined});
         }
+        this.#state = 'stopped';
       });
     });
+  }
+
+  /**
+   * Mark this child process for termination. On Linux/macOS, sends a `SIGINT`
+   * signal. On Windows, invokes `taskkill /pid PID /t /f`.
+   *
+   * Note this function returns immediately. To find out when the process
+   * actually terminates, use the {@link completed} promise.
+   */
+  terminate(): void {
+    switch (this.#state) {
+      case 'started': {
+        this.#actuallyTerminate();
+        return;
+      }
+      case 'starting': {
+        // We're still starting up, and it's not possible to abort. When we get
+        // the "spawn" event, we'll notice the "stopping" state and actually
+        // terminate then.
+        this.#state = 'stopping';
+        return;
+      }
+      case 'stopping':
+      case 'stopped': {
+        // No-op.
+        return;
+      }
+      default: {
+        const never: never = this.#state;
+        throw new Error(
+          `Internal error: unexpected ScriptChildProcessState: ${String(never)}`
+        );
+      }
+    }
+  }
+
+  #actuallyTerminate(): void {
+    if (this.#child.pid === undefined) {
+      throw new Error(
+        `Internal error: Can't terminate child process because it has no pid. ` +
+          `Command: ${JSON.stringify(this.#script.command)}.`
+      );
+    }
+    if (IS_WINDOWS) {
+      // Windows doesn't have signals. Node ChildProcess.kill() sort of emulates
+      // the behavior of SIGKILL (and ignores the signal you pass in), but this
+      // doesn't end child processes. We have child processes because the parent
+      // process is cmd.exe or PowerShell.
+      // https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill
+      spawn('taskkill', [
+        '/pid',
+        this.#child.pid.toString(),
+        /* End child processes */ '/t',
+        /* Forceful */ '/f',
+      ]);
+    } else {
+      // We used "detached" when we spawned, so our child is the leader of a
+      // process group. Passing the negative of a pid kills all processes in
+      // that group (without the negative, only the leader "sh" process would be
+      // killed).
+      process.kill(-this.#child.pid, 'SIGINT');
+    }
+    this.#state = 'stopping';
   }
 
   /**

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -1312,7 +1312,7 @@ test(
 
     const wireit = rig.exec('npm run main');
     const inv = await main.nextInvocation();
-    wireit.terminate();
+    wireit.kill();
     await inv.closed;
     await wireit.exit;
     assert.equal(main.numInvocations, 1);

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -1293,4 +1293,30 @@ test(
   })
 );
 
+test(
+  'top-level SIGINT kills running scripts',
+  timeout(async ({rig}) => {
+    const main = await rig.newCommand();
+    await rig.write({
+      'package.json': {
+        scripts: {
+          main: 'wireit',
+        },
+        wireit: {
+          main: {
+            command: main.command,
+          },
+        },
+      },
+    });
+
+    const wireit = rig.exec('npm run main');
+    const inv = await main.nextInvocation();
+    wireit.terminate();
+    await inv.closed;
+    await wireit.exit;
+    assert.equal(main.numInvocations, 1);
+  })
+);
+
 test.run();

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -112,7 +112,7 @@ export class WireitTestRig extends FilesystemTestRig {
    */
   async cleanup(): Promise<void> {
     for (const child of this.#activeChildProcesses) {
-      child.terminate();
+      child.kill();
       await child.exit;
     }
     await Promise.all(this.#commands.map((command) => command.close()));
@@ -253,10 +253,10 @@ class ExecResult {
       // do nothing. The process is a child of "sh" because we are using the
       // "shell" option.
       //
-      // On Windows this works completely differently, and we instead terminate
-      // child processes with "taskkill". If we set "detached" on Windows, it
-      // has the side effect of causing all child processes to open in new
-      // terminal windows.
+      // On Windows this works completely differently, and we instead kill child
+      // processes with "taskkill". If we set "detached" on Windows, it has the
+      // side effect of causing all child processes to open in new terminal
+      // windows.
       detached: !IS_WINDOWS,
     });
 
@@ -294,16 +294,14 @@ class ExecResult {
   }
 
   /**
-   * Terminate the child process.
+   * Kill the child process.
    */
-  terminate(): void {
+  kill(): void {
     if (!this.running) {
-      throw new Error(
-        "Can't terminate child process because it is not running"
-      );
+      throw new Error("Can't kill child process because it is not running");
     }
     if (this.#child.pid === undefined) {
-      throw new Error("Can't terminate child process because it has no pid");
+      throw new Error("Can't kill child process because it has no pid");
     }
     if (IS_WINDOWS) {
       // Windows doesn't have signals. Node ChildProcess.kill() sort of emulates

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -76,7 +76,7 @@ test(
     assert.ok(exec.running);
 
     // Should exit after a SIGINT signal (i.e. Ctrl-C).
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 1);
   })
@@ -119,7 +119,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -162,7 +162,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -203,7 +203,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -247,7 +247,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -300,7 +300,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA1.numInvocations, 1);
     assert.equal(cmdA2.numInvocations, 1);
@@ -370,7 +370,7 @@ test(
       await invB.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 3);
     assert.equal(cmdB.numInvocations, 2);
@@ -446,7 +446,7 @@ test(
       await invB.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 3);
     assert.equal(cmdB.numInvocations, 2);
@@ -491,7 +491,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -580,7 +580,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -624,7 +624,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 2);
   })
@@ -674,7 +674,7 @@ test(
       await inv.closed;
     }
 
-    exec.terminate();
+    exec.kill();
     await exec.exit;
     assert.equal(cmdA.numInvocations, 3);
   })

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -173,7 +173,8 @@ export class Watcher {
         this.#logger,
         this.#workerPool,
         this.#cache,
-        this.#failureMode
+        this.#failureMode,
+        this.#abort
       );
       const result = await executor.execute(analysis);
       if (!result.ok) {


### PR DESCRIPTION
Previously, we depended on the fact that we didn't use [`detached`](https://nodejs.org/api/child_process.html#optionsdetached) when spawning scripts, so that we didn't need to do anything special when the user sent a `SIGINT` to Wireit (e.g. via Ctrl-C). However, this meant that we didn't have the ability to terminate just one script; either Wireit and all child processes were killed, or none where.

Now, we enable `detached` mode (except on Windows where it isn't needed and is actually bad), so that we can control termination of specific scripts ourselves, and add a `terminate` method to `ScriptChildProcess`.  This is a prerequisite for the next PR, which will add `WIREIT_FAILURES=kill` (https://github.com/google/wireit/issues/31).

Also includes refactoring to the `Executor` to more clearly handle the 3 related events: `failureOccured`, `cancelNewScripts`, and `terminateRunningScripts`.

Fixes https://github.com/google/wireit/issues/30