### PR TITLE
[ide] Be slightly more generous with certain locations

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -6,7 +6,7 @@
 
 import type {Failure} from './event.js';
 import * as pathlib from 'path';
-import {JsonFile} from './util/ast.js';
+import {JsonFile, NamedAstNode} from './util/ast.js';
 
 export type Result<T, E = Failure> =
   | {ok: true; value: T}
@@ -200,3 +200,15 @@ export function drawSquiggle(location: Location, indent: number): string {
 
 export const offsetInsideRange = (offset: number, range: Range): boolean =>
   offset >= range.offset && offset < range.offset + range.length;
+
+export const offsetInsideNamedNode = (
+  offset: number,
+  namedNode: NamedAstNode
+): boolean => {
+  const valueEnd = namedNode.offset + namedNode.length;
+  const totalLength = valueEnd - namedNode.name.offset;
+  return offsetInsideRange(offset, {
+    offset: namedNode.name.offset,
+    length: totalLength,
+  });
+};

--- a/src/test/ide.test.ts
+++ b/src/test/ide.test.ts
@@ -493,7 +493,7 @@ test('can jump from scripts section to wireit config', async ({rig}) => {
   });
 });
 
-test('can jump from from colon in scripts section to wireit config', async ({
+test('can jump from colon in scripts section to wireit config', async ({
   rig,
 }) => {
   const ide = new IdeAnalyzer();

--- a/src/test/ide.test.ts
+++ b/src/test/ide.test.ts
@@ -493,4 +493,43 @@ test('can jump from scripts section to wireit config', async ({rig}) => {
   });
 });
 
+test('can jump from from colon in scripts section to wireit config', async ({
+  rig,
+}) => {
+  const ide = new IdeAnalyzer();
+  await assertDefinition(ide, {
+    path: rig.resolve('package.json'),
+    contentsWithPipe: `
+    {
+      "scripts": {
+        "a":| "wireit",
+        "b": "wireit"
+      },
+      "wireit": {
+        "a": {
+          "dependencies": ["b"]
+        },
+        "b": {
+          "command": "echo"
+        }
+      }
+    }`,
+    expected: {
+      target: `
+        "a": {
+        ~~~~~~
+          "dependencies": ["b"]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        },
+~~~~~~~~~`,
+      targetSelection: `
+        "a": {
+        ~~~`,
+      originSelection: `
+          "a": "wireit",
+          ~~~~~~~~~~~~~`,
+    },
+  });
+});
+
 test.run();

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -54,7 +54,7 @@ export interface NamedAstNode<T extends ValueTypes = ValueTypes>
    *            ~~~~~~~
    * ```
    *
-   * Then this name represents:
+   * Then `this.name` represents:
    * ```json
    *     "key": "value",
    *     ~~~~~

--- a/src/util/package-json.ts
+++ b/src/util/package-json.ts
@@ -7,7 +7,7 @@ import {findNamedNodeAtLocation, JsonFile} from './ast.js';
 import {JsonAstNode, NamedAstNode} from './ast.js';
 import {Failure} from '../event.js';
 import {failUnlessJsonObject, failUnlessNonBlankString} from '../analyzer.js';
-import {offsetInsideRange} from '../error.js';
+import {offsetInsideNamedNode, offsetInsideRange} from '../error.js';
 
 export interface ScriptSyntaxInfo {
   name: string;
@@ -67,8 +67,7 @@ export class PackageJson {
       for (const scriptSyntaxInfo of this.scripts) {
         if (
           scriptSyntaxInfo.scriptNode &&
-          (offsetInsideRange(offset, scriptSyntaxInfo.scriptNode) ||
-            offsetInsideRange(offset, scriptSyntaxInfo.scriptNode.name))
+          offsetInsideNamedNode(offset, scriptSyntaxInfo.scriptNode)
         ) {
           return {kind: 'scripts-section-script', scriptSyntaxInfo};
         }
@@ -80,7 +79,7 @@ export class PackageJson {
       for (const scriptSyntaxInfo of this.scripts) {
         if (
           scriptSyntaxInfo.wireitConfigNode &&
-          offsetInsideRange(offset, scriptSyntaxInfo.wireitConfigNode)
+          offsetInsideNamedNode(offset, scriptSyntaxInfo.wireitConfigNode)
         ) {
           return {kind: 'wireit-section-script', scriptSyntaxInfo};
         }


### PR DESCRIPTION
When we're looking for the meaning of a location in a file, instead of only counting the name and the value of a property, also count the colon and whitespace in between.

i.e. if you're trying to jump to the definition of a wireit config from the scripts section, currently you can do so from either:

```
    "a": "wireit"
    ~~~
```

or

```
    "a": "wireit"
         ~~~~~~~~
```

but after this change you can do it anywhere in:

```
    "a": "wireit"
    ~~~~~~~~~~~~~
```