### PR TITLE
Higher fidelity GitHub Actions cache server fake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "jsonschema": "^1.4.0",
         "pnpm": "^7.0.0",
         "prettier": "^2.6.2",
+        "selfsigned": "^2.0.1",
         "typescript": "^4.6.3",
         "uvu": "^0.5.3",
         "wireit": "^0.4.1",
@@ -5393,6 +5394,15 @@
         }
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -6478,6 +6488,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "dev": true,
+      "dependencies": {
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -12047,6 +12069,12 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true
+    },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -12880,6 +12908,15 @@
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
+      }
+    },
+    "selfsigned": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^1"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "jsonschema": "^1.4.0",
     "pnpm": "^7.0.0",
     "prettier": "^2.6.2",
+    "selfsigned": "^2.0.1",
     "typescript": "^4.6.3",
     "uvu": "^0.5.3",
     "wireit": "^0.4.1",

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -23,11 +23,11 @@ test.before.each(async (ctx) => {
     // suite) because we want fresh cache state for each test.
     const authToken = String(Math.random()).slice(2);
     ctx.server = new FakeGitHubActionsCacheServer(authToken);
-    await ctx.server.listen();
+    const actionsCacheUrl = await ctx.server.listen();
     ctx.rig = new WireitTestRig();
     ctx.rig.env = {
       WIREIT_CACHE: 'github',
-      ACTIONS_CACHE_URL: `http://localhost:${ctx.server.port}/`,
+      ACTIONS_CACHE_URL: actionsCacheUrl,
       ACTIONS_RUNTIME_TOKEN: authToken,
       RUNNER_TEMP: pathlib.join(ctx.rig.temp, 'github-cache-temp'),
     };

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'url';
 import {WireitTestRig} from './util/test-rig.js';
 import {registerCommonCacheTests} from './cache-common.js';
 import {FakeGitHubActionsCacheServer} from './util/fake-github-actions-cache-server.js';
-import {timeout} from './util/uvu-timeout.js';
+import {timeout, DEFAULT_UVU_TIMEOUT} from './util/uvu-timeout.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = pathlib.dirname(__filename);
@@ -406,7 +406,7 @@ test(
       });
       assert.equal(await rig.read('output'), fileContent);
     }
-  })
+  }, Math.max(DEFAULT_UVU_TIMEOUT, 15_000))
 );
 
 test.run();

--- a/src/test/util/fake-github-actions-cache-server.ts
+++ b/src/test/util/fake-github-actions-cache-server.ts
@@ -471,6 +471,13 @@ export class FakeGitHubActionsCacheServer {
     const end = Number(parsedContentRange[2]);
     const expectedLength = end - start + 1;
 
+    // The real server might not be this strict, but we should make sure we
+    // aren't sending larger chunks than the official client library does.
+    // https://github.com/actions/toolkit/blob/500d0b42fee2552ae9eeb5933091fe2fbf14e72d/packages/cache/src/options.ts#L59
+    if (expectedLength > 32 * 1024 * 1024) {
+      return this.#respond(response, 400, 'Upload chunk was > 32MB');
+    }
+
     const buffer = await this.#readBody(request);
     if (buffer.length !== expectedLength) {
       return this.#respond(

--- a/src/test/util/fake-github-actions-cache-server.ts
+++ b/src/test/util/fake-github-actions-cache-server.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as http from 'http';
+import * as https from 'https';
+import type * as http from 'http';
 
 /**
  * Numeric ID for a cache entry.
@@ -107,9 +108,9 @@ export class FakeGitHubActionsCacheServer {
   readonly #keyAndVersionToEntryId = new Map<KeyAndVersion, EntryId>();
   readonly #tarballIdToEntryId = new Map<TarballId, EntryId>();
 
-  constructor(authToken: string) {
+  constructor(authToken: string, tlsCert: {cert: string; key: string}) {
     this.#authToken = authToken;
-    this.#server = http.createServer(this.#route);
+    this.#server = https.createServer(tlsCert, this.#route);
     this.resetMetrics();
   }
 
@@ -139,7 +140,7 @@ export class FakeGitHubActionsCacheServer {
     // include this in the fake because it ensures the client is preserving the
     // base path and not just using the origin.
     const randomBasePath = Math.random().toString().slice(2);
-    this.#url = new URL(`http://${host}:${address.port}/${randomBasePath}/`);
+    this.#url = new URL(`https://${host}:${address.port}/${randomBasePath}/`);
     return this.#url.href;
   }
 

--- a/src/test/util/fake-github-actions-cache-server.ts
+++ b/src/test/util/fake-github-actions-cache-server.ts
@@ -448,6 +448,17 @@ export class FakeGitHubActionsCacheServer {
     if (!this.#checkAccept(request, response, JSON_RESPONSE_TYPE)) {
       return;
     }
+    const expectedTransferEncoding = 'chunked';
+    const actualTransferEncoding = request.headers['transfer-encoding'];
+    if (actualTransferEncoding !== 'chunked') {
+      return this.#respond(
+        response,
+        /* Bad Request */ 400,
+        `Expected transfer-encoding ${JSON.stringify(
+          expectedTransferEncoding
+        )}. ` + `Got ${String(actualTransferEncoding)}.`
+      );
+    }
 
     if (idStr.match(/\d+/) === null) {
       return this.#respond(response, 400, 'Cache ID was not an integer');

--- a/src/test/util/fake-github-actions-cache-server.ts
+++ b/src/test/util/fake-github-actions-cache-server.ts
@@ -318,7 +318,11 @@ export class FakeGitHubActionsCacheServer {
         commited: false,
         tarballId,
       });
-      this.#respond(response, 200, JSON.stringify({cacheId: entryId}));
+      this.#respond(
+        response,
+        /* Created */ 201,
+        JSON.stringify({cacheId: entryId})
+      );
     });
   }
 
@@ -370,7 +374,7 @@ export class FakeGitHubActionsCacheServer {
     });
 
     request.on('end', () => {
-      this.#respond(response, 200);
+      this.#respond(response, /* No Content */ 204);
     });
   }
 
@@ -404,7 +408,7 @@ export class FakeGitHubActionsCacheServer {
     }
 
     entry.commited = true;
-    this.#respond(response, 200);
+    this.#respond(response, /* No Content */ 204);
   }
 
   /**

--- a/src/test/util/uvu-timeout.ts
+++ b/src/test/util/uvu-timeout.ts
@@ -6,7 +6,7 @@
 
 import type * as uvu from 'uvu';
 
-const DEFAULT_TIMEOUT = Number(process.env.TEST_TIMEOUT ?? 60_000);
+export const DEFAULT_UVU_TIMEOUT = Number(process.env.TEST_TIMEOUT ?? 60_000);
 
 /**
  * Returns a promise that resolves after the given period of time.
@@ -24,7 +24,7 @@ export const wait = async (ms: number) =>
  */
 export const timeout = <T>(
   handler: uvu.Callback<T>,
-  ms = DEFAULT_TIMEOUT
+  ms = DEFAULT_UVU_TIMEOUT
 ): uvu.Callback<T> => {
   return (...args) => {
     let timerId: ReturnType<typeof setTimeout>;

--- a/src/types/selfsigned.d.ts
+++ b/src/types/selfsigned.d.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Typings for https://github.com/jfromaniello/selfsigned which are not
+// available in DefinitelyTyped.
+
+declare module 'selfsigned' {
+  export function generate(attrs: Array<{name: string; value: string}>): {
+    cert: string;
+    public: string;
+    private: string;
+  };
+}


### PR DESCRIPTION
I'm working on a clean implementation of our GitHub Caching client, which will be much simpler because we'll have full control over cache keys and tarball generation, and will drop our install size and deps significantly.

As part of this, I wanted to improve the fidelity of the GitHub Actions cache server fake that we use in testing, plus add an extra test.

- Returns `201` and `204` status codes in some cases
- Has a unique identifier in the base path
- Requires that you provide an expected total size when you commit a cache entry and validates it
- Handles splitting up upload requests into multiple chunks
- Validates that each upload chunk is <= `32MB`
- Validates `Content-Range` headers when tarball chunks are uploaded
- Validates `Content-Type`, `Accept`, `Transfer-Encoding`, and `User-Agent` headers
- Runs on HTTPS

Part of https://github.com/google/wireit/issues/107