### PR TITLE
Rename cache key/script state to fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- The internal `.wireit/*/state` file was renamed to `.wireit/*/fingerprint`.
+  Should have no effect.
 
 ## [0.4.3] - 2022-05-15
 
@@ -139,7 +144,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `output`
   - `packageLocks`
 
-- The cache key now additionally includes the following fields:
+- The fingerprint now additionally includes the following fields:
 
   - The system platform (e.g. `linux`, `win32`).
   - The system CPU architecture (e.g. `x64`).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
   - [Dependency syntax](#dependency-syntax)
   - [Environment variables](#environment-variables)
   - [Glob patterns](#glob-patterns)
-  - [Cache key](#cache-key)
+  - [Fingerprint](#fingerprint)
 - [Requirements](#requirements)
 - [Related tools](#related-tools)
 - [Contributing](#contributing)
@@ -527,7 +527,7 @@ The following properties can be set inside `wireit.<script>` objects in
 | -------------- | ------------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `command`      | `string`                       | `undefined`             | The shell command to run.                                                                                   |
 | `dependencies` | `string[]`                     | `undefined`             | [Scripts that must run before this one](#dependencies).                                                     |
-| `files`        | `string[]`                     | `undefined`             | Input file [glob patterns](#glob-patterns), used to determine the [cache key](#cache-key).                  |
+| `files`        | `string[]`                     | `undefined`             | Input file [glob patterns](#glob-patterns), used to determine the [fingerprint](#fingerprint).              |
 | `output`       | `string[]`                     | `undefined`             | Output file [glob patterns](#glob-patterns), used for [caching](#caching) and [cleaning](#cleaning-output). |
 | `clean`        | `boolean \| "if-file-deleted"` | `true`                  | [Delete output files before running](#cleaning-output).                                                     |
 | `packageLocks` | `string[]`                     | `['package-lock.json']` | [Names of package lock files](#package-locks).                                                              |
@@ -581,10 +581,10 @@ Also note these details:
 - Hidden/dot files are matched by `*` and `**`.
 - Patterns are case-sensitive (if supported by the filesystem).
 
-### Cache key
+### Fingerprint
 
-The following inputs determine the _cache key_ for a script. This key is used to
-determine whether a script can be skipped for [incremental
+The following inputs determine the _fingerprint_ for a script. This value is
+used to determine whether a script can be skipped for [incremental
 build](#incremental-build), and whether its output can be [restored from
 cache](#caching).
 
@@ -597,10 +597,10 @@ cache](#caching).
 - The system platform (e.g. `linux`, `win32`).
 - The system CPU architecture (e.g. `x64`).
 - The system Node version (e.g. `16.7.0`).
-- The cache key of all transitive dependencies.
+- The fingerprint of all transitive dependencies.
 
 When using [GitHub Actions caching](#github-actions-caching), the following
-input also affects the cache key:
+input also affects the fingerprint:
 
 - The `ImageOS` environment variable (e.g. `ubuntu20`, `macos11`).
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -252,8 +252,8 @@ export class Analyzer {
    * given script reference.
    */
   #getPlaceholder(reference: ScriptReference): PlaceholderInfo {
-    const cacheKey = scriptReferenceToString(reference);
-    let placeholderInfo = this.#placeholders.get(cacheKey);
+    const scriptKey = scriptReferenceToString(reference);
+    let placeholderInfo = this.#placeholders.get(scriptKey);
     if (placeholderInfo === undefined) {
       const placeholder: UnvalidatedConfig = {
         ...reference,
@@ -264,7 +264,7 @@ export class Analyzer {
         placeholder: placeholder,
         upgradeComplete: this.#upgradePlaceholder(placeholder),
       };
-      this.#placeholders.set(cacheKey, placeholderInfo);
+      this.#placeholders.set(scriptKey, placeholderInfo);
       this.#ongoingWorkPromises.push(placeholderInfo.upgradeComplete);
     }
     return placeholderInfo;

--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ScriptStateString, ScriptReference} from '../script.js';
+import type {FingerprintString, ScriptReference} from '../script.js';
 import type {RelativeEntry} from '../util/glob.js';
 
 /**
@@ -13,35 +13,35 @@ import type {RelativeEntry} from '../util/glob.js';
  */
 export interface Cache {
   /**
-   * Check for a cache hit for the given script and cache key. Don't write it to
+   * Check for a cache hit for the given script and fingerprint. Don't write it to
    * disk yet, instead return a {@link CacheHit} which can be used to control
    * when writing occurs.
    *
    * @param script The script whose output will be read from the cache.
-   * @param cacheKey The string-encoded cache key for the script.
+   * @param fingerprint The string-encoded fingerprint for the script.
    * @return Promise of a {@link CacheHit} if there was an entry in the cache,
    * or undefined if there was not.
    */
   get(
     script: ScriptReference,
-    cacheKey: ScriptStateString
+    fingerprint: FingerprintString
   ): Promise<CacheHit | undefined>;
 
   /**
    * Write the given file paths to the cache if possible, keyed by the given
-   * script and cache key.
+   * script and fingerprint.
    *
    * It is valid for an implementation to decide not to write to the cache and
    * return false, for example if the contents are too large.
    *
    * @param script The script whose output will be saved to the cache.
-   * @param cacheKey The string-encoded cache key for the script.
+   * @param fingerprint The string-encoded fingerprint for the script.
    * @param relativeFiles The package-relative output files to cache.
    * @returns Whether the cache was written.
    */
   set(
     script: ScriptReference,
-    cacheKey: ScriptStateString,
+    fingerprint: FingerprintString,
     relativeFiles: RelativeEntry[]
   ): Promise<boolean>;
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -26,8 +26,8 @@ import type {
   ScriptConfigWithRequiredCommand,
   ScriptReference,
   ScriptReferenceString,
-  ScriptState,
-  ScriptStateString,
+  Fingerprint,
+  FingerprintString,
   Sha256HexDigest,
 } from './script.js';
 import type {Logger} from './logging/logger.js';
@@ -35,7 +35,7 @@ import type {WriteStream} from 'fs';
 import type {Cache} from './caching/cache.js';
 import type {Failure, StartCancelled} from './event.js';
 
-type ExecutionResult = Result<ScriptState, Failure[]>;
+type ExecutionResult = Result<Fingerprint, Failure[]>;
 
 /**
  * What to do when a script failure occurs:
@@ -199,10 +199,10 @@ class ScriptExecution {
     if (this.#shouldNotStart) {
       return {ok: false, error: [this.#startCancelledEvent]};
     }
-    const dependencyStatesResult = await this.#executeDependencies();
-    if (!dependencyStatesResult.ok) {
-      dependencyStatesResult.error.push(this.#startCancelledEvent);
-      return dependencyStatesResult;
+    const dependencyFingerprints = await this.#executeDependencies();
+    if (!dependencyFingerprints.ok) {
+      dependencyFingerprints.error.push(this.#startCancelledEvent);
+      return dependencyFingerprints;
     }
 
     // Significant time could have elapsed since we last checked because our
@@ -214,14 +214,14 @@ class ScriptExecution {
     if (this.#script.output?.values.length === 0) {
       // If there are explicitly no output files, then it's not actually
       // important to maintain an exclusive lock.
-      return this.#executeScript(dependencyStatesResult.value);
+      return this.#executeScript(dependencyFingerprints.value);
     }
     const releaseLock = await this.#acquireLock();
     if (!releaseLock.ok) {
       return {ok: false, error: [releaseLock.error]};
     }
     try {
-      return await this.#executeScript(dependencyStatesResult.value);
+      return await this.#executeScript(dependencyFingerprints.value);
     } finally {
       await releaseLock.value();
     }
@@ -310,18 +310,20 @@ class ScriptExecution {
   }
 
   async #executeScript(
-    dependencyStates: Array<[ScriptReference, ScriptState]>
+    dependencyFingerprints: Array<[ScriptReference, Fingerprint]>
   ): Promise<ExecutionResult> {
     // Note we must wait for dependencies to finish before generating the cache
     // key, because a dependency could create or modify an input file to this
     // script, which would affect the key.
-    const state = await this.#computeState(dependencyStates);
-    const stateStr = JSON.stringify(state) as ScriptStateString;
-    const prevStateStr = await this.#readPreviousState();
+    const fingerprintData = await this.#computeFingerprint(
+      dependencyFingerprints
+    );
+    const fingerprint = JSON.stringify(fingerprintData) as FingerprintString;
+    const prevFingerprint = await this.#readPreviousFingerprint();
     if (
-      state.cacheable &&
-      prevStateStr !== undefined &&
-      prevStateStr === stateStr
+      fingerprintData.cacheable &&
+      prevFingerprint !== undefined &&
+      prevFingerprint === fingerprint
     ) {
       // TODO(aomarks) Does not preserve original order of stdout vs stderr
       // chunks. See https://github.com/google/wireit/issues/74.
@@ -334,22 +336,23 @@ class ScriptExecution {
         type: 'success',
         reason: 'fresh',
       });
-      return {ok: true, value: state};
+      return {ok: true, value: fingerprintData};
     }
 
-    // Computing state can take some time, and the next operation is
+    // Computing the fingerprint can take some time, and the next operation is
     // destructive. Another good opportunity to check if we should still start.
     if (this.#shouldNotStart) {
       return {ok: false, error: [this.#startCancelledEvent]};
     }
 
-    // It's important that we delete any previous state before running the
-    // command or restoring from cache, because if either fails mid-flight, we
-    // don't want to think that the previous state is still valid.
+    // It's important that we delete the previous fingerprint and stdio replay
+    // files before running the command or restoring from cache, because if
+    // either fails mid-flight, we don't want to think that the previous
+    // fingerprint is still valid.
     await this.#prepareDataDir();
 
-    const cacheHit = state.cacheable
-      ? await this.#cache?.get(this.#script, stateStr)
+    const cacheHit = fingerprintData.cacheable
+      ? await this.#cache?.get(this.#script, fingerprint)
       : undefined;
 
     const shouldClean = (() => {
@@ -373,15 +376,15 @@ class ScriptExecution {
           return false;
         }
         case 'if-file-deleted': {
-          if (prevStateStr === undefined) {
-            // If we don't know the previous state, then we can't know whether
-            // any input files were removed. It's safer to err on the side of
-            // cleaning.
+          if (prevFingerprint === undefined) {
+            // If we don't know the previous fingerprint, then we can't know
+            // whether any input files were removed. It's safer to err on the
+            // side of cleaning.
             return true;
           }
           return this.#anyInputFilesDeletedSinceLastRun(
-            state,
-            JSON.parse(prevStateStr) as ScriptState
+            fingerprintData,
+            JSON.parse(prevFingerprint) as Fingerprint
           );
         }
         default: {
@@ -423,15 +426,15 @@ class ScriptExecution {
     // TODO(aomarks) We don't technically need to wait for these to finish to
     // return, we only need to wait in the top-level call to execute. The same
     // will go for saving output to the cache.
-    await this.#writeStateFile(stateStr);
-    if (cacheHit === undefined && state.cacheable) {
-      const result = await this.#saveToCacheIfPossible(stateStr);
+    await this.#writeFingerprintFile(fingerprint);
+    if (cacheHit === undefined && fingerprintData.cacheable) {
+      const result = await this.#saveToCacheIfPossible(fingerprint);
       if (!result.ok) {
         return {ok: false, error: [result.error]};
       }
     }
 
-    return {ok: true, value: state};
+    return {ok: true, value: fingerprintData};
   }
 
   /**
@@ -439,8 +442,8 @@ class ScriptExecution {
    * file names, and returns whether any files have been removed.
    */
   #anyInputFilesDeletedSinceLastRun(
-    curState: ScriptState,
-    prevState: ScriptState
+    curState: Fingerprint,
+    prevState: Fingerprint
   ): boolean {
     const curFiles = Object.keys(curState.files);
     const prevFiles = Object.keys(prevState.files);
@@ -457,7 +460,7 @@ class ScriptExecution {
   }
 
   async #executeDependencies(): Promise<
-    Result<Array<[ScriptReference, ScriptState]>, Failure[]>
+    Result<Array<[ScriptReference, Fingerprint]>, Failure[]>
   > {
     // Randomize the order we execute dependencies to make it less likely for a
     // user to inadvertently depend on any specific order, which could indicate
@@ -471,7 +474,7 @@ class ScriptExecution {
       })
     );
     const errors = new Set<Failure>();
-    const results: Array<[ScriptReference, ScriptState]> = [];
+    const results: Array<[ScriptReference, Fingerprint]> = [];
     for (let i = 0; i < dependencyResults.length; i++) {
       const result = dependencyResults[i];
       if (result.status === 'rejected') {
@@ -605,7 +608,7 @@ class ScriptExecution {
    * Save the current output files to the configured cache if possible.
    */
   async #saveToCacheIfPossible(
-    stateStr: ScriptStateString
+    fingerprint: FingerprintString
   ): Promise<Result<void>> {
     if (this.#cache === undefined || this.#script.output === undefined) {
       return {ok: true, value: undefined};
@@ -673,22 +676,22 @@ class ScriptExecution {
       }
       throw error;
     }
-    await this.#cache.set(this.#script, stateStr, paths);
+    await this.#cache.set(this.#script, fingerprint, paths);
     return {ok: true, value: undefined};
   }
 
   /**
-   * Generate the state object for this script based on its current input files,
-   * and the state of its dependencies.
+   * Generate the fingerprint data object for this script based on its current
+   * configuration, input files, and the fingerprints of its dependencies.
    */
-  async #computeState(
-    dependencyStates: Array<[ScriptReference, ScriptState]>
-  ): Promise<ScriptState> {
+  async #computeFingerprint(
+    dependencyFingerprints: Array<[ScriptReference, Fingerprint]>
+  ): Promise<Fingerprint> {
     let allDependenciesAreCacheable = true;
     const filteredDependencyStates: Array<
-      [ScriptReferenceString, ScriptState]
+      [ScriptReferenceString, Fingerprint]
     > = [];
-    for (const [dep, depState] of dependencyStates) {
+    for (const [dep, depState] of dependencyFingerprints) {
       if (!depState.cacheable) {
         allDependenciesAreCacheable = false;
       }
@@ -702,10 +705,10 @@ class ScriptExecution {
         absolute: false,
         followSymlinks: true,
         // TODO(aomarks) This means that empty directories are not reflected in
-        // the state, however an empty directory could modify the behavior of a
-        // script. We should probably include empty directories; we'll just need
-        // special handling when we compute the state key, because there is no
-        // hash we can compute.
+        // the fingerprint, however an empty directory could modify the behavior
+        // of a script. We should probably include empty directories; we'll just
+        // need special handling when we compute the fingerprint, because there
+        // is no hash we can compute.
         includeDirectories: false,
         // We must expand directories here, because we need the complete
         // explicit list of files to hash.
@@ -736,8 +739,8 @@ class ScriptExecution {
 
     const cacheable =
       // If command is undefined, then it's always safe to be cached, because
-      // the script isn't going to do anything anyway. In these cases, the state
-      // is essentially just the state of the dependencies.
+      // the script isn't going to do anything anyway. In these cases, the
+      // fingerprint is essentially just the fingerprint of the dependencies.
       this.#script.command === undefined ||
       // Otherwise, If files are undefined, then it's not safe to be cached,
       // because we don't know what the inputs are, so we can't know if the
@@ -775,10 +778,10 @@ class ScriptExecution {
   }
 
   /**
-   * Get the path where the current cache key is saved for this script.
+   * Get the path where the current fingerprint is saved for this script.
    */
-  get #statePath(): string {
-    return pathlib.join(this.#dataDir, 'state');
+  get #fingerprintFilePath(): string {
+    return pathlib.join(this.#dataDir, 'fingerprint');
   }
 
   /**
@@ -796,11 +799,14 @@ class ScriptExecution {
   }
 
   /**
-   * Read this script's ".wireit/<hex-script-name>/state" file.
+   * Read this script's fingerprint file.
    */
-  async #readPreviousState(): Promise<ScriptStateString | undefined> {
+  async #readPreviousFingerprint(): Promise<FingerprintString | undefined> {
     try {
-      return (await fs.readFile(this.#statePath, 'utf8')) as ScriptStateString;
+      return (await fs.readFile(
+        this.#fingerprintFilePath,
+        'utf8'
+      )) as FingerprintString;
     } catch (error) {
       if ((error as {code?: string}).code === 'ENOENT') {
         return undefined;
@@ -810,20 +816,20 @@ class ScriptExecution {
   }
 
   /**
-   * Write this script's ".wireit/<hex-script-name>/state" file.
+   * Write this script's fingerprint file.
    */
-  async #writeStateFile(stateStr: ScriptStateString): Promise<void> {
+  async #writeFingerprintFile(fingerprint: FingerprintString): Promise<void> {
     await fs.mkdir(this.#dataDir, {recursive: true});
-    await fs.writeFile(this.#statePath, stateStr, 'utf8');
+    await fs.writeFile(this.#fingerprintFilePath, fingerprint, 'utf8');
   }
 
   /**
-   * Delete all state for this script from the previous run, and ensure the data
-   * directory is created.
+   * Delete the fingerprint file and any stdio replays for this script from the
+   * previous run, and ensure the data directory exists.
    */
   async #prepareDataDir(): Promise<void> {
     await Promise.all([
-      fs.rm(this.#statePath, {force: true}),
+      fs.rm(this.#fingerprintFilePath, {force: true}),
       fs.rm(this.#stdoutReplayPath, {force: true}),
       fs.rm(this.#stderrReplayPath, {force: true}),
       fs.mkdir(this.#dataDir, {recursive: true}),

--- a/src/script.ts
+++ b/src/script.ts
@@ -148,10 +148,10 @@ export type ScriptReferenceString = string & {
 };
 
 /**
- * All meaningful input state of a script. Used for determining if a script is
- * fresh, and as the key for storing cached output.
+ * All meaningful inputs of a script. Used for determining if a script is fresh,
+ * and as the key for storing cached output.
  */
-export interface ScriptState {
+export interface Fingerprint {
   /**
    * Whether the output for this script can be fresh or cached.
    *
@@ -177,7 +177,7 @@ export interface ScriptState {
   /**
    * The "clean" setting from the Wireit config.
    *
-   * This is included in the cache key because switching from "false" to "true"
+   * This is included in the fingerprint because switching from "false" to "true"
    * could produce different output, so a re-run should be triggered even if
    * nothing else changed.
    */
@@ -189,7 +189,7 @@ export interface ScriptState {
   /**
    * The "output" glob patterns from the Wireit config.
    *
-   * This is included in the cache key because changing the output patterns
+   * This is included in the fingerprint because changing the output patterns
    * could produce different output when "clean" is true, and because it affects
    * which files get included in a cache entry.
    *
@@ -200,14 +200,14 @@ export interface ScriptState {
   output: string[];
 
   // Must be sorted.
-  dependencies: {[dependency: ScriptReferenceString]: ScriptState};
+  dependencies: {[dependency: ScriptReferenceString]: Fingerprint};
 }
 
 /**
- * String serialization of a {@link ScriptState}.
+ * String serialization of a {@link Fingerprint}.
  */
-export type ScriptStateString = string & {
-  __ScriptStateStringBrand__: never;
+export type FingerprintString = string & {
+  __FingerprintStringBrand__: never;
 };
 
 /**

--- a/src/test/clean.test.ts
+++ b/src/test/clean.test.ts
@@ -339,12 +339,12 @@ test(
             // Include a dependency on a script with no input files to cover an
             // edge case that was broken in an earlier implementation.
             //
-            // We use the ".wireit/<script>/state" file to find out which input
-            // files were present in the previous run, so that we can compare
-            // them to the current input files. However, in an earlier
-            // implementation we did not save a "state" file for scripts with a
-            // dependency that have no input files (because that makes the
-            // script "uncacheable").
+            // We use the ".wireit/<script>/fingerprint" file to find out which
+            // input files were present in the previous run, so that we can
+            // compare them to the current input files. However, in an earlier
+            // implementation we did not save a "fingerprint" file for scripts
+            // with a dependency that have no input files (because that makes
+            // the script "uncacheable").
             dependencies: ['b'],
           },
           b: {

--- a/src/test/freshness.test.ts
+++ b/src/test/freshness.test.ts
@@ -371,7 +371,7 @@ test(
             dependencies: ['b'],
           },
           b: {
-            // B has undefined input files, but it can still have a cache key,
+            // B has undefined input files, but it can still have a fingerprint,
             // because it has no command. In effect, it is just an alias for C,
             // which does have its files defined.
             dependencies: ['c'],
@@ -450,7 +450,7 @@ test(
 );
 
 test(
-  'empty directory is not included in cache key',
+  'empty directory is not included in fingerprint',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
     await rig.write({
@@ -800,9 +800,9 @@ test(
 test(
   'fresh script is skipped with unsafe characters in script name',
   timeout(async ({rig}) => {
-    // This test confirms that we are serializing the previous state in a way
-    // that doesn't try to put forbidden characters in filenames (as would be
-    // the case if we used the script name directly).
+    // This test confirms that we are serializing the previous fingerprint file
+    // in a way that doesn't try to put forbidden characters in filenames (as
+    // would be the case if we used the script name directly).
     const name = '🔥<>:/\\|?*';
 
     const cmdA = await rig.newCommand();
@@ -831,15 +831,15 @@ test(
       assert.equal(cmdA.numInvocations, 1);
     }
 
-    // Check that we created a state file using the hex encoding of the script
-    // name.
+    // Check that we created a fingerprint file using the hex encoding of the
+    // script name.
     assert.ok(
       await rig.exists(
         pathlib.join(
           '.wireit',
           // Buffer.from(name).toString('hex')
           'f09f94a53c3e3a2f5c7c3f2a',
-          'state'
+          'fingerprint'
         )
       )
     );
@@ -897,7 +897,7 @@ test(
 );
 
 test(
-  'state is deleted before invoking command',
+  'fingerprint file is deleted before invoking command',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
     await rig.write({
@@ -915,8 +915,8 @@ test(
       'input.txt': 'v0',
     });
 
-    // Initially stale, so command is invoked. It succeeds, so a state file is
-    // written.
+    // Initially stale, so command is invoked. It succeeds, so a fingerprint
+    // file is written.
     {
       const exec = rig.exec('npm run a');
       const inv = await cmdA.nextInvocation();
@@ -927,10 +927,11 @@ test(
     }
 
     // Input file changed, so script is stale, and command is invoked. It fails,
-    // so a state file is not written. However, before the command is invoked,
-    // the previous state file must be deleted, because we can no longer be sure
-    // that the previous state is still reflected in the output (this failed
-    // invocation could have written some output before failing).
+    // so a fingerprint file is not written. However, before the command is
+    // invoked, the previous fingerprint file must be deleted, because we can no
+    // longer be sure that the previous fingerprint is still reflected in the
+    // output (this failed invocation could have written some output before
+    // failing).
     {
       await rig.write({
         'input.txt': 'v1',
@@ -943,10 +944,10 @@ test(
       assert.equal(cmdA.numInvocations, 2);
     }
 
-    // Input file reverts back to v0. Since the previous state file was deleted,
-    // the script is stale, and command is invoked. If we didn't pre-emptively
-    // delete the state file in the previous step, we would wrongly think we
-    // were fresh.
+    // Input file reverts back to v0. Since the previous fingerprint file was
+    // deleted, the script is stale, and command is invoked. If we didn't
+    // pre-emptively delete the fingerprint file in the previous step, we would
+    // wrongly think we were fresh.
     {
       await rig.write({
         'input.txt': 'v0',
@@ -1265,7 +1266,7 @@ test(
 );
 
 test(
-  'cache key is independent of file ordering',
+  'fingerprint is independent of file ordering',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
     await rig.write({
@@ -1321,7 +1322,7 @@ test(
 );
 
 test(
-  'cache key is independent of dependency ordering',
+  'fingerprint is independent of dependency ordering',
   timeout(async ({rig}) => {
     //         a
     //         |

--- a/website/content/12-reference.md
+++ b/website/content/12-reference.md
@@ -18,7 +18,7 @@ The following properties can be set inside `wireit.<script>` objects in
 | -------------- | ------------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `command`      | `string`                       | `undefined`             | The shell command to run.                                                                                  |
 | `dependencies` | `string[]`                     | `undefined`             | [Scripts that must run before this one](../dependencies/).                                                 |
-| `files`        | `string[]`                     | `undefined`             | Input file [glob patterns](#glob-patterns), used to determine the [cache key](#cache-key).                 |
+| `files`        | `string[]`                     | `undefined`             | Input file [glob patterns](#glob-patterns), used to determine the [fingerprint](#fingerprint).             |
 | `output`       | `string[]`                     | `undefined`             | Output file [glob patterns](#glob-patterns), used for [caching](../caching/) and [cleaning](../cleaning/). |
 | `clean`        | `boolean \| "if-file-deleted"` | `true`                  | [Delete output files before running](../cleaning/).                                                        |
 | `packageLocks` | `string[]`                     | `['package-lock.json']` | [Names of package lock files](../package-locks/).                                                          |
@@ -71,10 +71,10 @@ Also note these details:
 - Hidden/dot files are matched by `*` and `**`.
 - Patterns are case-sensitive (if supported by the filesystem).
 
-### Cache key
+### Fingerprint
 
-The following inputs determine the _cache key_ for a script. This key is used to
-determine whether a script can be skipped for [incremental
+The following inputs determine the _fingerprint_ for a script. This value is
+used to determine whether a script can be skipped for [incremental
 build](../incremental-build/), and whether its output can be [restored from
 cache](../caching/).
 
@@ -87,9 +87,9 @@ cache](../caching/).
 - The system platform (e.g. `linux`, `win32`).
 - The system CPU architecture (e.g. `x64`).
 - The system Node version (e.g. `16.7.0`).
-- The cache key of all transitive dependencies.
+- The fingerprint of all transitive dependencies.
 
 When using [GitHub Actions caching](../caching/#github-actions-caching), the following
-input also affects the cache key:
+input also affects the fingerprint:
 
 - The `ImageOS` environment variable (e.g. `ubuntu20`, `macos11`).


### PR DESCRIPTION
When a script executes, a JSON object is generated for it which represents all of the inputs to that script at that time: its configuration, its input files and their content hashes, plus the inherited state of its dependencies. This value is then used to determine whether a script can be skipped, and as the key for cache entries.

Previously, this was variously referred to as either the "cache key" or the "state" of the script, and was saved to a file at `.wireit/<script>/state`.

Now, this concept is consistently referred to as the "fingerprint", and is saved to `.wireit/<script>/fingerprint`.

I think having a distinct consistent name will help readability and documentation. I noticed this term being used in the Turborepo docs for its equivalent concept, and it seems like a good choice.