### PR TITLE
Allow file-only scripts, and disallow output without command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- It is now possible to define a script that only defines `files`. This can be
+  useful for organizing groups of shared input files that multiple scripts can
+  depend on, such as configuration files.
+
 ### Changed
 
 - [**Breaking**] Setting `"output"` on a script that does not have a `"command"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- [**Breaking**] Setting `"output"` on a script that does not have a `"command"`
+  is now an error.
+
 - The internal `.wireit/*/state` file was renamed to `.wireit/*/fingerprint`.
   Should have no effect.
 

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -402,12 +402,15 @@ export class Analyzer {
       }
     }
 
+    const files = this.#processFiles(placeholder, packageJson, syntaxInfo);
+
     if (
       wireitConfig !== undefined &&
-      command === undefined &&
       dependencies.length === 0 &&
       !dependenciesErrored &&
-      !commandError
+      command === undefined &&
+      !commandError &&
+      (files === undefined || files.values.length === 0)
     ) {
       placeholder.failures.push({
         type: 'failure',
@@ -415,7 +418,7 @@ export class Analyzer {
         script: placeholder,
         diagnostic: {
           severity: 'error',
-          message: `A wireit config must set at least one of "command" or "dependencies", otherwise there is nothing for wireit to do.`,
+          message: `A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.`,
           location: {
             file: packageJson.jsonFile,
             range: {
@@ -427,7 +430,6 @@ export class Analyzer {
       });
     }
 
-    const files = this.#processFiles(placeholder, packageJson, syntaxInfo);
     const output = this.#processOutput(
       placeholder,
       packageJson,

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -860,7 +860,7 @@ test(
 );
 
 test(
-  'script has no command and no dependencies',
+  'script has no command, dependencies, or files',
   timeout(async ({rig}) => {
     await rig.write({
       'package.json': {
@@ -878,8 +878,37 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ package.json:6:5 A wireit config must set at least one of "command" or "dependencies", otherwise there is nothing for wireit to do.
+❌ package.json:6:5 A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.
         "a": {}
+        ~~~`
+    );
+  })
+);
+
+test(
+  'script has no command and empty dependencies and files',
+  timeout(async ({rig}) => {
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            files: [],
+            dependencies: [],
+          },
+        },
+      },
+    });
+    const result = rig.exec('npm run a');
+    const done = await result.exit;
+    assert.equal(done.code, 1);
+    assertScriptOutputEquals(
+      done.stderr,
+      `
+❌ package.json:6:5 A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.
+        "a": {
         ~~~`
     );
   })
@@ -1501,10 +1530,10 @@ test(
     assertScriptOutputEquals(
       done.stderr,
       `
-❌ package.json:15:5 A wireit config must set at least one of "command" or "dependencies", otherwise there is nothing for wireit to do.
+❌ package.json:15:5 A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.
         "b": {},
         ~~~
-❌ package.json:16:5 A wireit config must set at least one of "command" or "dependencies", otherwise there is nothing for wireit to do.
+❌ package.json:16:5 A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.
         "c": {}
         ~~~`
     );

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -1697,4 +1697,41 @@ test(`repro an issue with looking for a colon in missing dependency`, async ({
   );
 });
 
+test(
+  'script without command cannot have output',
+  timeout(async ({rig}) => {
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            dependencies: ['b'],
+            output: ['foo'],
+          },
+          b: {
+            command: 'true',
+          },
+        },
+      },
+    });
+    const result = rig.exec('npm run a');
+    const done = await result.exit;
+    assert.equal(done.code, 1);
+    assertScriptOutputEquals(
+      done.stderr,
+      `
+❌ package.json:11:7 "output" can only be set if "command" is also set.
+          "output": [
+          ~~~~~~~~~~~
+            "foo"
+    ~~~~~~~~~~~~~
+          ]
+    ~~~~~~~`
+    );
+  })
+);
+
 test.run();

--- a/vscode-extension/src/test/main.test.ts
+++ b/vscode-extension/src/test/main.test.ts
@@ -94,7 +94,7 @@ test('warns on a package.json based on semantic analysis in the language server'
     diagnostics.map((d) => d.message),
     [
       'This command should just be "wireit", as this script is configured in the wireit section.',
-      'A wireit config must set at least one of "command" or "dependencies", otherwise there is nothing for wireit to do.',
+      'A wireit config must set at least one of "command", "dependencies", or "files". Otherwise there is nothing for wireit to do.',
       'Script "not_in_scripts" not found in the scripts section of this package.json.',
     ],
     JSON.stringify(diagnostics.map((d) => d.message))


### PR DESCRIPTION
1. It is now possible to define a script that only defines input files. This can be useful for organizing groups of shared input files that multiple scripts depend on, such as configuration files. We've already been using this pattern in the Lit repo, but needed the workaround of setting a no-op `true` or `echo` command so that analysis passed.

2. Setting `"output"` on a script that does not have a `"command"` is now an error. It was possible before, and would even trigger caching, but that never made sense, because it couldn't have been that script that produced the output.