### PR TITLE
Misc refactoring of OneShotExecutor

### DIFF
--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -5,7 +5,7 @@
  */
 
 import type {ScriptReference} from '../script.js';
-import type {FingerprintString} from '../fingerprint.js';
+import type {Fingerprint} from '../fingerprint.js';
 import type {RelativeEntry} from '../util/glob.js';
 
 /**
@@ -25,7 +25,7 @@ export interface Cache {
    */
   get(
     script: ScriptReference,
-    fingerprint: FingerprintString
+    fingerprint: Fingerprint
   ): Promise<CacheHit | undefined>;
 
   /**
@@ -42,7 +42,7 @@ export interface Cache {
    */
   set(
     script: ScriptReference,
-    fingerprint: FingerprintString,
+    fingerprint: Fingerprint,
     relativeFiles: RelativeEntry[]
   ): Promise<boolean>;
 }

--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {FingerprintString, ScriptReference} from '../script.js';
+import type {ScriptReference} from '../script.js';
+import type {FingerprintString} from '../fingerprint.js';
 import type {RelativeEntry} from '../util/glob.js';
 
 /**

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -15,7 +15,8 @@ import {createReadStream, createWriteStream} from 'fs';
 
 import type * as http from 'http';
 import type {Cache, CacheHit} from './cache.js';
-import type {ScriptReference, FingerprintString} from '../script.js';
+import type {ScriptReference} from '../script.js';
+import type {FingerprintString} from '../fingerprint.js';
 import type {Logger} from '../logging/logger.js';
 import type {RelativeEntry} from '../util/glob.js';
 import type {Result} from '../error.js';

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -16,7 +16,7 @@ import {createReadStream, createWriteStream} from 'fs';
 import type * as http from 'http';
 import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference} from '../script.js';
-import type {FingerprintString} from '../fingerprint.js';
+import type {Fingerprint} from '../fingerprint.js';
 import type {Logger} from '../logging/logger.js';
 import type {RelativeEntry} from '../util/glob.js';
 import type {Result} from '../error.js';
@@ -106,7 +106,7 @@ export class GitHubActionsCache implements Cache {
 
   async get(
     script: ScriptReference,
-    fingerprint: FingerprintString
+    fingerprint: Fingerprint
   ): Promise<CacheHit | undefined> {
     if (this.#hitRateLimit) {
       return undefined;
@@ -146,7 +146,7 @@ export class GitHubActionsCache implements Cache {
 
   async set(
     script: ScriptReference,
-    fingerprint: FingerprintString,
+    fingerprint: Fingerprint,
     relativeFiles: RelativeEntry[]
   ): Promise<boolean> {
     if (this.#hitRateLimit) {
@@ -176,7 +176,7 @@ export class GitHubActionsCache implements Cache {
    */
   async #reserveUploadAndCommitTarball(
     script: ScriptReference,
-    fingerprint: FingerprintString,
+    fingerprint: Fingerprint,
     tarballPath: string
   ): Promise<boolean> {
     const tarballStats = await fs.stat(tarballPath);
@@ -365,26 +365,27 @@ export class GitHubActionsCache implements Cache {
       .digest('hex');
   }
 
-  #computeVersion(fingerprint: FingerprintString): string {
+  #computeVersion(fingerprint: Fingerprint): string {
+    const parts: string[] = [
+      fingerprint.string,
+      'gzip', // e.g. zstd, gzip
+      // The ImageOS environment variable tells us which operating system
+      // version is being used for the worker VM (e.g. "ubuntu20",
+      // "macos11"). We already include process.platform in the fingerprint,
+      // but this is more specific.
+      //
+      // There is also an ImageVersion variable (e.g. "20220405.4") which we
+      // could consider including, but it probably changes frequently and is
+      // unlikely to affect output, so we prefer the higher cache hit rate.
+      process.env.ImageOS ?? '',
+      // Versioning salt:
+      //   - <omitted>: Initial version.
+      //   - 2: Removed empty directories manifest.
+      '2',
+    ];
     return createHash('sha256')
       .update(
-        [
-          fingerprint,
-          'gzip', // e.g. zstd, gzip
-          // The ImageOS environment variable tells us which operating system
-          // version is being used for the worker VM (e.g. "ubuntu20",
-          // "macos11"). We already include process.platform in the fingerprint,
-          // but this is more specific.
-          //
-          // There is also an ImageVersion variable (e.g. "20220405.4") which we
-          // could consider including, but it probably changes frequently and is
-          // unlikely to affect output, so we prefer the higher cache hit rate.
-          process.env.ImageOS ?? '',
-          // Versioning salt:
-          //   - <omitted>: Initial version.
-          //   - 2: Removed empty directories manifest.
-          '2',
-        ].join('\x1E') // ASCII record seperator
+        parts.join('\x1E') // ASCII record seperator
       )
       .digest('hex');
   }

--- a/src/caching/local-cache.ts
+++ b/src/caching/local-cache.ts
@@ -12,7 +12,8 @@ import {copyEntries} from '../util/copy.js';
 import {glob} from '../util/glob.js';
 
 import type {Cache, CacheHit} from './cache.js';
-import type {ScriptReference, FingerprintString} from '../script.js';
+import type {ScriptReference} from '../script.js';
+import type {FingerprintString} from '../fingerprint.js';
 import type {RelativeEntry} from '../util/glob.js';
 
 /**

--- a/src/caching/local-cache.ts
+++ b/src/caching/local-cache.ts
@@ -13,7 +13,7 @@ import {glob} from '../util/glob.js';
 
 import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference} from '../script.js';
-import type {FingerprintString} from '../fingerprint.js';
+import type {Fingerprint} from '../fingerprint.js';
 import type {RelativeEntry} from '../util/glob.js';
 
 /**
@@ -23,7 +23,7 @@ import type {RelativeEntry} from '../util/glob.js';
 export class LocalCache implements Cache {
   async get(
     script: ScriptReference,
-    fingerprint: FingerprintString
+    fingerprint: Fingerprint
   ): Promise<CacheHit | undefined> {
     const cacheDir = this.#getCacheDir(script, fingerprint);
     try {
@@ -39,7 +39,7 @@ export class LocalCache implements Cache {
 
   async set(
     script: ScriptReference,
-    fingerprint: FingerprintString,
+    fingerprint: Fingerprint,
     relativeFiles: RelativeEntry[]
   ): Promise<boolean> {
     // TODO(aomarks) A script's cache directory currently just grows forever.
@@ -61,14 +61,11 @@ export class LocalCache implements Cache {
     return true;
   }
 
-  #getCacheDir(
-    script: ScriptReference,
-    fingerprint: FingerprintString
-  ): string {
+  #getCacheDir(script: ScriptReference, fingerprint: Fingerprint): string {
     return pathlib.join(
       getScriptDataDir(script),
       'cache',
-      createHash('sha256').update(fingerprint).digest('hex')
+      createHash('sha256').update(fingerprint.string).digest('hex')
     );
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Failure} from './event.js';
 import * as pathlib from 'path';
-import {JsonFile, NamedAstNode} from './util/ast.js';
+
+import type {Failure, UnknownErrorThrown} from './event.js';
+import type {JsonFile, NamedAstNode} from './util/ast.js';
+import type {ScriptReference} from './script.js';
 
 export type Result<T, E = Failure> =
   | {ok: true; value: T}
@@ -212,3 +214,24 @@ export const offsetInsideNamedNode = (
     length: totalLength,
   });
 };
+
+/**
+ * Convert an unexpected exception to a {@link UnknownErrorThrown} failure,
+ * which includes the sript context for better debugging.
+ */
+export function convertExceptionToFailure(
+  error: unknown,
+  script: ScriptReference
+): {ok: false; error: [UnknownErrorThrown]} {
+  return {
+    ok: false,
+    error: [
+      {
+        type: 'failure',
+        reason: 'unknown-error-thrown',
+        script,
+        error,
+      },
+    ],
+  };
+}

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -13,13 +13,12 @@ import {shuffle} from '../util/shuffle.js';
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
 import {
-  Fingerprint,
   ScriptConfig,
   ScriptReference,
   ScriptReferenceString,
   scriptReferenceToString,
-  Sha256HexDigest,
 } from '../script.js';
+import type {Fingerprint, Sha256HexDigest} from '../fingerprint.js';
 import type {Logger} from '../logging/logger.js';
 import type {Failure} from '../event.js';
 

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -4,22 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {createReadStream} from 'fs';
-import {resolve} from 'path';
-import {createHash} from 'crypto';
-import {glob} from '../util/glob.js';
 import {shuffle} from '../util/shuffle.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
-import {
-  ScriptConfig,
-  ScriptReference,
-  ScriptReferenceString,
-  scriptReferenceToString,
-} from '../script.js';
-import type {FingerprintData, Sha256HexDigest} from '../fingerprint.js';
+import {ScriptConfig, ScriptReference} from '../script.js';
 import type {Logger} from '../logging/logger.js';
 import type {Failure} from '../event.js';
 
@@ -81,94 +71,5 @@ export abstract class BaseExecution<T extends ScriptConfig> {
       return {ok: false, error: [...errors]};
     }
     return {ok: true, value: results};
-  }
-
-  /**
-   * Generate the fingerprint data object for this script based on its current
-   * configuration, input files, and the fingerprints of its dependencies.
-   */
-  protected async computeFingerprint(
-    dependencyFingerprints: Array<[ScriptReference, Fingerprint]>
-  ): Promise<Fingerprint> {
-    let allDependenciesAreCacheable = true;
-    const filteredDependencyStates: Array<
-      [ScriptReferenceString, FingerprintData]
-    > = [];
-    for (const [dep, depFingerprint] of dependencyFingerprints) {
-      if (!depFingerprint.data.cacheable) {
-        allDependenciesAreCacheable = false;
-      }
-      filteredDependencyStates.push([
-        scriptReferenceToString(dep),
-        depFingerprint.data,
-      ]);
-    }
-
-    let fileHashes: Array<[string, Sha256HexDigest]>;
-    if (this.script.files?.values.length) {
-      const files = await glob(this.script.files.values, {
-        cwd: this.script.packageDir,
-        absolute: false,
-        followSymlinks: true,
-        // TODO(aomarks) This means that empty directories are not reflected in
-        // the fingerprint, however an empty directory could modify the behavior
-        // of a script. We should probably include empty directories; we'll just
-        // need special handling when we compute the fingerprint, because there
-        // is no hash we can compute.
-        includeDirectories: false,
-        // We must expand directories here, because we need the complete
-        // explicit list of files to hash.
-        expandDirectories: true,
-        throwIfOutsideCwd: false,
-      });
-      // TODO(aomarks) Instead of reading and hashing every input file on every
-      // build, use inode/mtime/ctime/size metadata (which is much faster to
-      // read) as a heuristic to detect files that have likely changed, and
-      // otherwise re-use cached hashes that we store in e.g.
-      // ".wireit/<script>/hashes".
-      fileHashes = await Promise.all(
-        files.map(async (file): Promise<[string, Sha256HexDigest]> => {
-          const absolutePath = resolve(this.script.packageDir, file.path);
-          const hash = createHash('sha256');
-          for await (const chunk of createReadStream(absolutePath)) {
-            hash.update(chunk as Buffer);
-          }
-          return [file.path, hash.digest('hex') as Sha256HexDigest];
-        })
-      );
-    } else {
-      fileHashes = [];
-    }
-
-    const cacheable =
-      // If command is undefined, then we simply propagate the fingerprints of
-      // our dependencies, and don't have any effect ourselves on cacheability.
-      this.script.command === undefined ||
-      // Otherwise, If files are undefined, then it's not safe to be cached,
-      // because we don't know what the inputs are, so we can't know if the
-      // output of this script could change.
-      (this.script.files !== undefined &&
-        // Similarly, if any of our dependencies are uncacheable, then we're
-        // uncacheable too, because that dependency could also have an effect on
-        // our output.
-        allDependenciesAreCacheable);
-
-    return Fingerprint.fromData({
-      cacheable,
-      platform: process.platform,
-      arch: process.arch,
-      nodeVersion: process.version,
-      command: this.script.command?.value,
-      clean: this.script.clean,
-      files: Object.fromEntries(
-        fileHashes.sort(([aFile], [bFile]) => aFile.localeCompare(bFile))
-      ),
-      output: this.script.output?.values ?? [],
-      dependencies: Object.fromEntries(
-        filteredDependencyStates.sort(([aRef], [bRef]) =>
-          aRef.localeCompare(bRef)
-        )
-      ),
-    });
   }
 }

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -9,7 +9,7 @@ import {Fingerprint} from '../fingerprint.js';
 
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
-import {ScriptConfig, ScriptReference} from '../script.js';
+import type {ScriptConfig, ScriptReference} from '../script.js';
 import type {Logger} from '../logging/logger.js';
 import type {Failure} from '../event.js';
 

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -9,7 +9,6 @@ import {resolve} from 'path';
 import {createHash} from 'crypto';
 import {glob} from '../util/glob.js';
 import {shuffle} from '../util/shuffle.js';
-import {getScriptDataDir} from '../util/script-data-dir.js';
 
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
@@ -22,7 +21,7 @@ import {
   Sha256HexDigest,
 } from '../script.js';
 import type {Logger} from '../logging/logger.js';
-import type {Failure, StartCancelled} from '../event.js';
+import type {Failure} from '../event.js';
 
 export type ExecutionResult = Result<Fingerprint, Failure[]>;
 
@@ -48,34 +47,6 @@ export abstract class BaseExecution<T extends ScriptConfig> {
     this.script = script;
     this.executor = executor;
     this.logger = logger;
-  }
-
-  /**
-   * Whether we should return early instead of starting this script.
-   *
-   * We should check this as the first thing we do, and then after any
-   * significant amount of time might have elapsed.
-   */
-  protected get shouldNotStart(): boolean {
-    return this.executor.shouldStopStartingNewScripts;
-  }
-
-  /**
-   * Convenience to generate a cancellation failure event for this script.
-   */
-  protected get startCancelledEvent(): StartCancelled {
-    return {
-      script: this.script,
-      type: 'failure',
-      reason: 'start-cancelled',
-    };
-  }
-
-  /**
-   * Get the directory name where Wireit data can be saved for this script.
-   */
-  protected get dataDir(): string {
-    return getScriptDataDir(this.script);
   }
 
   /**

--- a/src/execution/no-op.ts
+++ b/src/execution/no-op.ts
@@ -24,10 +24,6 @@ export class NoOpExecution extends BaseExecution<NoOpScriptConfig> {
   }
 
   async #execute(): Promise<ExecutionResult> {
-    if (this.shouldNotStart) {
-      return {ok: false, error: [this.startCancelledEvent]};
-    }
-
     const dependencyFingerprints = await this.executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;

--- a/src/execution/no-op.ts
+++ b/src/execution/no-op.ts
@@ -5,6 +5,7 @@
  */
 
 import {BaseExecution} from './base.js';
+import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
 import type {Executor} from '../executor.js';
@@ -28,7 +29,8 @@ export class NoOpExecution extends BaseExecution<NoOpScriptConfig> {
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;
     }
-    const fingerprint = await this.computeFingerprint(
+    const fingerprint = await Fingerprint.compute(
+      this.script,
       dependencyFingerprints.value
     );
     this.logger.log({

--- a/src/execution/one-shot.ts
+++ b/src/execution/one-shot.ts
@@ -80,7 +80,8 @@ export class OneShotExecution extends BaseExecution<OneShotScriptConfig> {
       // Note we must wait for dependencies to finish before generating the
       // cache key, because a dependency could create or modify an input file to
       // this script, which would affect the key.
-      const fingerprint = await this.computeFingerprint(
+      const fingerprint = await Fingerprint.compute(
+        this.script,
         dependencyFingerprints.value
       );
       if (await this.#fingerprintIsFresh(fingerprint)) {

--- a/src/execution/one-shot.ts
+++ b/src/execution/one-shot.ts
@@ -67,9 +67,6 @@ export class OneShotExecution extends BaseExecution<OneShotScriptConfig> {
   }
 
   async #execute(): Promise<ExecutionResult> {
-    if (this.#shouldNotStart) {
-      return {ok: false, error: [this.#startCancelledEvent]};
-    }
     const dependencyFingerprints = await this.executeDependencies();
     if (!dependencyFingerprints.ok) {
       dependencyFingerprints.error.push(this.#startCancelledEvent);

--- a/src/execution/one-shot.ts
+++ b/src/execution/one-shot.ts
@@ -20,12 +20,8 @@ import {BaseExecution} from './base.js';
 import type {Result} from '../error.js';
 import type {ExecutionResult} from './base.js';
 import type {Executor} from '../executor.js';
-import type {
-  OneShotScriptConfig,
-  ScriptReference,
-  Fingerprint,
-  FingerprintString,
-} from '../script.js';
+import type {OneShotScriptConfig, ScriptReference} from '../script.js';
+import type {Fingerprint, FingerprintString} from '../fingerprint.js';
 import type {Logger} from '../logging/logger.js';
 import type {WriteStream} from 'fs';
 import type {Cache} from '../caching/cache.js';

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -112,14 +112,14 @@ export class Fingerprint {
     dependencyFingerprints: Array<[ScriptReference, Fingerprint]>
   ): Promise<Fingerprint> {
     let allDependenciesAreCacheable = true;
-    const filteredDependencyStates: Array<
+    const filteredDependencyFingerprints: Array<
       [ScriptReferenceString, FingerprintData]
     > = [];
     for (const [dep, depFingerprint] of dependencyFingerprints) {
       if (!depFingerprint.data.cacheable) {
         allDependenciesAreCacheable = false;
       }
-      filteredDependencyStates.push([
+      filteredDependencyFingerprints.push([
         scriptReferenceToString(dep),
         depFingerprint.data,
       ]);
@@ -190,7 +190,7 @@ export class Fingerprint {
       ),
       output: script.output?.values ?? [],
       dependencies: Object.fromEntries(
-        filteredDependencyStates.sort(([aRef], [bRef]) =>
+        filteredDependencyFingerprints.sort(([aRef], [bRef]) =>
           aRef.localeCompare(bRef)
         )
       ),

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {ScriptReferenceString} from './script.js';
+
+/**
+ * All meaningful inputs of a script. Used for determining if a script is fresh,
+ * and as the key for storing cached output.
+ */
+export interface Fingerprint {
+  /**
+   * Whether the output for this script can be fresh or cached.
+   *
+   * True only if the "files" array was defined for this script, and for all of
+   * this script's transitive dependencies.
+   */
+  cacheable: boolean;
+
+  /** E.g. linux, win32 */
+  platform: NodeJS.Platform;
+
+  /** E.g. x64 */
+  arch: string;
+
+  /** E.g. 16.7.0 */
+  nodeVersion: string;
+
+  /**
+   * The shell command from the Wireit config.
+   */
+  command: string | undefined;
+
+  /**
+   * The "clean" setting from the Wireit config.
+   *
+   * This is included in the fingerprint because switching from "false" to "true"
+   * could produce different output, so a re-run should be triggered even if
+   * nothing else changed.
+   */
+  clean: boolean | 'if-file-deleted';
+
+  // Must be sorted.
+  files: {[packageDirRelativeFilename: string]: Sha256HexDigest};
+
+  /**
+   * The "output" glob patterns from the Wireit config.
+   *
+   * This is included in the fingerprint because changing the output patterns
+   * could produce different output when "clean" is true, and because it affects
+   * which files get included in a cache entry.
+   *
+   * Note the undefined vs empty-array distinction is not meaningful here,
+   * because both cases cause no files to be deleted, and the undefined case is
+   * never cached anyway.
+   */
+  output: string[];
+
+  // Must be sorted.
+  dependencies: {[dependency: ScriptReferenceString]: Fingerprint};
+}
+
+/**
+ * String serialization of a {@link Fingerprint}.
+ */
+export type FingerprintString = string & {
+  __FingerprintStringBrand__: never;
+};
+
+/**
+ * SHA256 hash hexadecimal digest of a file's content.
+ */
+export type Sha256HexDigest = string & {
+  __Sha256HexDigestBrand__: never;
+};

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -4,13 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ScriptReferenceString} from './script.js';
+import {createHash} from 'crypto';
+import {createReadStream} from 'fs';
+import {resolve} from 'path';
+import {glob} from './util/glob.js';
+import {scriptReferenceToString} from './script.js';
+
+import type {
+  ScriptConfig,
+  ScriptReference,
+  ScriptReferenceString,
+} from './script.js';
 
 /**
  * All meaningful inputs of a script. Used for determining if a script is fresh,
  * and as the key for storing cached output.
  */
 export interface FingerprintData {
+  /**
+   * Brand to make it slightly harder to create one of these interfaces, because
+   * that should only ever be done via {@link Fingerprint.compute}.
+   */
+  __FingerprintDataBrand__: never;
+
   /**
    * Whether the output for this script can be fresh or cached.
    *
@@ -77,8 +93,8 @@ export type Sha256HexDigest = string & {
 };
 
 /**
- * A script fingerprint. Can be initialized from either an object or a string,
- * and converts to the other form lazily with caching.
+ * The fingerprint of a script. Converts lazily between string and data object
+ * forms.
  */
 export class Fingerprint {
   static fromString(string: FingerprintString): Fingerprint {
@@ -87,9 +103,98 @@ export class Fingerprint {
     return fingerprint;
   }
 
-  static fromData(data: FingerprintData): Fingerprint {
+  /**
+   * Generate the fingerprint data object for a script based on its current
+   * configuration, input files, and the fingerprints of its dependencies.
+   */
+  static async compute(
+    script: ScriptConfig,
+    dependencyFingerprints: Array<[ScriptReference, Fingerprint]>
+  ): Promise<Fingerprint> {
+    let allDependenciesAreCacheable = true;
+    const filteredDependencyStates: Array<
+      [ScriptReferenceString, FingerprintData]
+    > = [];
+    for (const [dep, depFingerprint] of dependencyFingerprints) {
+      if (!depFingerprint.data.cacheable) {
+        allDependenciesAreCacheable = false;
+      }
+      filteredDependencyStates.push([
+        scriptReferenceToString(dep),
+        depFingerprint.data,
+      ]);
+    }
+
+    let fileHashes: Array<[string, Sha256HexDigest]>;
+    if (script.files?.values.length) {
+      const files = await glob(script.files.values, {
+        cwd: script.packageDir,
+        absolute: false,
+        followSymlinks: true,
+        // TODO(aomarks) This means that empty directories are not reflected in
+        // the fingerprint, however an empty directory could modify the behavior
+        // of a script. We should probably include empty directories; we'll just
+        // need special handling when we compute the fingerprint, because there
+        // is no hash we can compute.
+        includeDirectories: false,
+        // We must expand directories here, because we need the complete
+        // explicit list of files to hash.
+        expandDirectories: true,
+        throwIfOutsideCwd: false,
+      });
+      // TODO(aomarks) Instead of reading and hashing every input file on every
+      // build, use inode/mtime/ctime/size metadata (which is much faster to
+      // read) as a heuristic to detect files that have likely changed, and
+      // otherwise re-use cached hashes that we store in e.g.
+      // ".wireit/<script>/hashes".
+      fileHashes = await Promise.all(
+        files.map(async (file): Promise<[string, Sha256HexDigest]> => {
+          const absolutePath = resolve(script.packageDir, file.path);
+          const hash = createHash('sha256');
+          for await (const chunk of createReadStream(absolutePath)) {
+            hash.update(chunk as Buffer);
+          }
+          return [file.path, hash.digest('hex') as Sha256HexDigest];
+        })
+      );
+    } else {
+      fileHashes = [];
+    }
+
+    const cacheable =
+      // If command is undefined, then we simply propagate the fingerprints of
+      // our dependencies, and don't have any effect ourselves on cacheability.
+      script.command === undefined ||
+      // Otherwise, If files are undefined, then it's not safe to be cached,
+      // because we don't know what the inputs are, so we can't know if the
+      // output of this script could change.
+      (script.files !== undefined &&
+        // Similarly, if any of our dependencies are uncacheable, then we're
+        // uncacheable too, because that dependency could also have an effect on
+        // our output.
+        allDependenciesAreCacheable);
+
     const fingerprint = new Fingerprint();
-    fingerprint.#data = data;
+
+    // Note: The order of all fields is important so that we can do fast string
+    // comparison.
+    fingerprint.#data = {
+      cacheable,
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      command: script.command?.value,
+      clean: script.clean,
+      files: Object.fromEntries(
+        fileHashes.sort(([aFile], [bFile]) => aFile.localeCompare(bFile))
+      ),
+      output: script.output?.values ?? [],
+      dependencies: Object.fromEntries(
+        filteredDependencyStates.sort(([aRef], [bRef]) =>
+          aRef.localeCompare(bRef)
+        )
+      ),
+    } as FingerprintData;
     return fingerprint;
   }
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -11,7 +11,7 @@ import type {
   NamedAstNode,
 } from './util/ast.js';
 import type {Failure} from './event.js';
-import {PotentiallyValidScriptConfig} from './analyzer.js';
+import type {PotentiallyValidScriptConfig} from './analyzer.js';
 
 /**
  * The location on disk of an npm package.
@@ -150,74 +150,4 @@ export const stringToScriptReference = (
  */
 export type ScriptReferenceString = string & {
   __ScriptReferenceStringBrand__: never;
-};
-
-/**
- * All meaningful inputs of a script. Used for determining if a script is fresh,
- * and as the key for storing cached output.
- */
-export interface Fingerprint {
-  /**
-   * Whether the output for this script can be fresh or cached.
-   *
-   * True only if the "files" array was defined for this script, and for all of
-   * this script's transitive dependencies.
-   */
-  cacheable: boolean;
-
-  /** E.g. linux, win32 */
-  platform: NodeJS.Platform;
-
-  /** E.g. x64 */
-  arch: string;
-
-  /** E.g. 16.7.0 */
-  nodeVersion: string;
-
-  /**
-   * The shell command from the Wireit config.
-   */
-  command: string | undefined;
-
-  /**
-   * The "clean" setting from the Wireit config.
-   *
-   * This is included in the fingerprint because switching from "false" to "true"
-   * could produce different output, so a re-run should be triggered even if
-   * nothing else changed.
-   */
-  clean: boolean | 'if-file-deleted';
-
-  // Must be sorted.
-  files: {[packageDirRelativeFilename: string]: Sha256HexDigest};
-
-  /**
-   * The "output" glob patterns from the Wireit config.
-   *
-   * This is included in the fingerprint because changing the output patterns
-   * could produce different output when "clean" is true, and because it affects
-   * which files get included in a cache entry.
-   *
-   * Note the undefined vs empty-array distinction is not meaningful here,
-   * because both cases cause no files to be deleted, and the undefined case is
-   * never cached anyway.
-   */
-  output: string[];
-
-  // Must be sorted.
-  dependencies: {[dependency: ScriptReferenceString]: Fingerprint};
-}
-
-/**
- * String serialization of a {@link Fingerprint}.
- */
-export type FingerprintString = string & {
-  __FingerprintStringBrand__: never;
-};
-
-/**
- * SHA256 hash hexadecimal digest of a file's content.
- */
-export type Sha256HexDigest = string & {
-  __Sha256HexDigestBrand__: never;
 };


### PR DESCRIPTION
⚠️ **Note to reviewer**: I recommend reading commits 1-by-1.

Some refactoring to make `OneShotExecution` easier to follow.

There are 3 outcomes for an execution: 1. fresh, 2. stale with a cache hit, 3. stale and we run the script. Previously handling for the 3 cases were sort of mixed up together in the `#execute` method, so it was a little hard to follow what happened in each case. Now the `#execute` method delegates to a distinct method for each outcome (`#handleFresh`, `#handleCacheHit`, `#handleNeedsRun`).

Also:

- Moved unexpected exception handling into the `Executor`, which simplifies dependency handling so that we don't have to use `Promise.allSettled`.

- Removed some unnecessary abort checks. `NoOp` executors don't need to worry about aborting at all, because so little time is spent in them, so the upstream or downstream scripts will handle aborts just fine. Similarly, `OneShotExecution` scripts also don't need to check for aborts before traversing dependencies, because we are doing a depth-first walk, so we will hit the leafs immediately anyway.

- Made the API for acquiring system-wide locks take a callback instead of returning a release function. More foolproof, and more similar to the `WorkerPool` API.

- Made a `Fingerprint` class which handles fingerprint creation plus lazy conversion between object and string forms. Gets rid of a bunch of `fingerprintStr` vs `fingerprintData` sort of variables we had to track before. Also added a brand to make it harder to directly create a `FingerprintData` without using the class.