### PR TITLE
Refactor watcher to support analysis recovery and be more efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   should have no user-facing effect apart from a very minor performance
   improvement.
 
+- Analysis errors encountered in watch mode are no longer fatal. If any
+  `package.json` file that was encountered in the failed analysis was modified,
+  a new analysis attempt will start.
+
+- Performance improvements to watch mode. Re-analysis of configuration now only
+  occurs when a relevant `package.json` file was modified, instead of if any
+  file was modified. Filesystem watchers are now re-used across iterations
+  unless they are changed by a config update.
+
 ## [0.4.3] - 2022-05-15
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,9 +270,9 @@ const run = async (): Promise<Result<void, Failure[]>> => {
     );
   } else {
     const analyzer = new Analyzer();
-    const analyzedResult = await analyzer.analyze(options.script);
-    if (!analyzedResult.ok) {
-      return analyzedResult;
+    const {config} = await analyzer.analyze(options.script);
+    if (!config.ok) {
+      return config;
     }
     const executor = new Executor(
       logger,
@@ -281,7 +281,7 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       options.failureMode,
       abort
     );
-    const result = await executor.execute(analyzedResult.value);
+    const result = await executor.execute(config.value);
     if (!result.ok) {
       return result;
     }

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -38,7 +38,7 @@ test(
   'runs initially and waits for SIGINT',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -86,7 +86,7 @@ test(
   'runs again when input file changes after execution',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -111,7 +111,7 @@ test(
 
     // Changing an input file should cause another run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'input.txt': 'v1',
       });
       const inv = await cmdA.nextInvocation();
@@ -129,7 +129,7 @@ test(
   'runs again when new input file created',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -154,7 +154,7 @@ test(
 
     // Adding another input file should cause another run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'input2.txt': 'v0',
       });
       const inv = await cmdA.nextInvocation();
@@ -172,7 +172,7 @@ test(
   'runs again when input file deleted',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -213,7 +213,7 @@ test(
   'runs again when input file changes in the middle of execution',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -234,7 +234,7 @@ test(
     {
       const inv = await cmdA.nextInvocation();
       // Change the input while the first invocation is still running.
-      await rig.write({
+      await rig.writeAtomic({
         'input.txt': 'v1',
       });
       inv.exit(0);
@@ -258,7 +258,7 @@ test(
   timeout(async ({rig}) => {
     const cmdA1 = await rig.newCommand();
     const cmdA2 = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -283,7 +283,7 @@ test(
     // package.json. That change should be detected, the new config should be
     // analyzed, and the new command should run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'package.json': {
           scripts: {
             a: 'wireit',
@@ -312,7 +312,7 @@ test(
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
     const cmdB = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -348,7 +348,7 @@ test(
 
     // Changing an input of A should cause A to run again, but not B.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'a.txt': 'v1',
       });
       const invA = await cmdA.nextInvocation();
@@ -359,7 +359,7 @@ test(
 
     // Changing an input of B should cause both scripts to run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'b.txt': 'v1',
       });
       const invB = await cmdB.nextInvocation();
@@ -382,7 +382,7 @@ test(
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
     const cmdB = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'foo/package.json': {
         scripts: {
           a: 'wireit',
@@ -424,7 +424,7 @@ test(
 
     // Changing an input of A should cause A to run again, but not B.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'foo/a.txt': 'v1',
       });
       const invA = await cmdA.nextInvocation();
@@ -435,7 +435,7 @@ test(
 
     // Changing an input of B should cause both scripts to run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'bar/b.txt': 'v1',
       });
       const invB = await cmdB.nextInvocation();
@@ -457,7 +457,7 @@ test(
   'error from script is not fatal',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -483,7 +483,7 @@ test(
 
     // Changing input file triggers another run. Script succeeds this time.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'a.txt': 'v1',
       });
       const inv = await cmdA.nextInvocation();
@@ -601,7 +601,7 @@ test(
   'watchers understand negations',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -628,7 +628,7 @@ test(
 
     // Changing an excluded file should not trigger a run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'excluded.txt': 'v1',
       });
       // Wait a while to ensure the command doesn't run.
@@ -643,7 +643,7 @@ test(
 
     // Changing an included file should trigger a run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         'included.txt': 'v1',
       });
       const inv = await cmdA.nextInvocation();
@@ -661,7 +661,7 @@ test(
   '.dotfiles are watched',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'package.json': {
         scripts: {
           a: 'wireit',
@@ -687,7 +687,7 @@ test(
 
     // Changing input file should trigger another run.
     {
-      await rig.write({
+      await rig.writeAtomic({
         '.dotfile.txt': 'v1',
       });
       const inv = await cmdA.nextInvocation();
@@ -705,7 +705,7 @@ test(
   'package-lock.json files are watched',
   timeout(async ({rig}) => {
     const cmdA = await rig.newCommand();
-    await rig.write({
+    await rig.writeAtomic({
       'foo/package.json': {
         scripts: {
           a: 'wireit',
@@ -732,14 +732,14 @@ test(
 
     // Change foo's package-lock.json file. Expect another run.
     {
-      await rig.write({'foo/package-lock.json': 'v1'});
+      await rig.writeAtomic({'foo/package-lock.json': 'v1'});
       const inv = await cmdA.nextInvocation();
       inv.exit(0);
     }
 
     // Create parent's package-lock.json file. Expect another run.
     {
-      await rig.write({'package-lock.json': 'v0'});
+      await rig.writeAtomic({'package-lock.json': 'v0'});
       const inv = await cmdA.nextInvocation();
       inv.exit(0);
       await inv.closed;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -320,14 +320,14 @@ export class Watcher {
 
   #onAbort(): void {
     switch (this.#state) {
-      case 'watching':
-      case 'queued': {
+      case 'watching': {
         this.#state = 'aborted';
         this.#closeAllFileWatchers();
         this.#finished.resolve();
         return;
       }
-      case 'running': {
+      case 'running':
+      case 'queued': {
         this.#state = 'aborted';
         this.#closeAllFileWatchers();
         // Don't resolve #finished immediately so that we will wait for #analyze

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -5,21 +5,54 @@
  */
 
 import chokidar from 'chokidar';
-import * as pathlib from 'path';
 import {Analyzer} from './analyzer.js';
-import {Executor} from './executor.js';
+import {Cache} from './caching/cache.js';
+import {Executor, FailureMode} from './executor.js';
+import {Logger} from './logging/logger.js';
 import {Deferred} from './util/deferred.js';
-import {scriptReferenceToString} from './script.js';
 import {WorkerPool} from './util/worker-pool.js';
-
-import type {Logger} from './logging/logger.js';
-import type {
+import {
   ScriptConfig,
   ScriptReference,
   ScriptReferenceString,
+  scriptReferenceToString,
 } from './script.js';
-import type {Cache} from './caching/cache.js';
-import type {FailureMode} from './executor.js';
+
+/**
+ * ```
+ *                                  <START>
+ *                                     │
+ *       ╭────◄──── RUN_DONE ──◄────╮  │  ╭──◄─── RUN_DONE ────◄───╮
+ *       │                          │  │  │                        │
+ *  ┌────▼─────┐                  ┌─┴──▼──▼─┐                  ┌───┴────┐
+ *  │ watching ├── FILE_CHANGED ──► running ├── FILE_CHANGED ──► queued │
+ *  └────┬─────┘                  └────┬────┘                  └───┬────┘
+ *       │                             │                           │
+ *     ABORT                         ABORT                       ABORT
+ *       │                             │                           │
+ *       ▼                        ┌────▼────┐                      ▼
+ *       ╰────────────►───────────► aborted ◄───────────◄──────────╯
+ *                                └─────────┘
+ * ```
+ */
+type WatcherState = 'watching' | 'running' | 'queued' | 'aborted';
+
+function unknownState(state: never) {
+  throw new Error(`Unknown watcher state ${String(state)}`);
+}
+
+function unexpectedState(state: WatcherState) {
+  throw new Error(`Unexpected watcher state ${state}`);
+}
+
+/**
+ * A chokidar file watcher along with the file patterns it was configured to
+ * watch.
+ */
+interface FileWatcher {
+  patterns: string[];
+  watcher: chokidar.FSWatcher;
+}
 
 /**
  * Watches a script for changes in its input files, and in the input files of
@@ -28,245 +61,333 @@ import type {FailureMode} from './executor.js';
  *
  * Also watches all related package.json files and reloads script configuration
  * when they change.
- *
- * State diagram:
- *
- *              ┌──────────────────────────────────┐
- *              |  ┌──────────────┐                |
- *              ▼  ▼              |                |
- *           ┌───────┐      ┌───────────┐      ┌───────┐
- * START ───►| stale | ───► | executing | ───► | fresh |
- *           └───────┘      └───────────┘      └───────┘
- *               │                │                │
- *               |                ▼                |
- *               |           ┌─────────┐           |
- *               └─────────► | aborted | ◄─────────┘
- *                           └─────────┘
  */
 export class Watcher {
-  /**
-   * Execute the script, and continue executing it every time a file related to
-   * the configured script changes.
-   *
-   * @returns When the abort promise resolves.
-   * @throws If an unexpected error occurs during analysis or execution.
-   */
-  static watch(
-    script: ScriptReference,
+  static async watch(
+    rootScript: ScriptReference,
     logger: Logger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
     failureMode: FailureMode,
     abort: Deferred<void>
   ): Promise<void> {
-    return new Watcher(
-      script,
+    const watcher = new Watcher(
+      rootScript,
       logger,
       workerPool,
       cache,
       failureMode,
       abort
-    ).#watch();
+    );
+    void watcher.#startRun();
+    void abort.promise.then(() => {
+      watcher.#onAbort();
+    });
+    return watcher.#finished.promise;
   }
 
-  readonly #script: ScriptReference;
+  /** See {@link WatcherState} */
+  #state: WatcherState = 'watching';
+
+  readonly #rootScript: ScriptReference;
   readonly #logger: Logger;
   readonly #workerPool: WorkerPool;
-  readonly #watchers: Array<chokidar.FSWatcher> = [];
   readonly #cache?: Cache;
   readonly #failureMode: FailureMode;
   readonly #abort: Deferred<void>;
 
-  /** Whether an executor is currently running. */
-  #executing = false;
+  /**
+   * The most recent analysis of the root script. As soon as we detect it might
+   * be stale because a package.json file was modified, this becomes undefined
+   * again.
+   */
+  #latestRootScriptConfig?: ScriptConfig;
 
-  /** Whether a file has changed since the last time we executed. */
-  #stale = true;
+  /**
+   * The file watcher for all package.json files relevant to this build graph.
+   */
+  #configFilesWatcher?: FileWatcher;
 
-  /** Whether the watcher has been aborted. */
-  get #aborted() {
-    return this.#abort.settled;
-  }
+  /**
+   * File watchers for the input files of all scripts in this build graph.
+   */
+  readonly #inputFileWatchers = new Map<ScriptReferenceString, FileWatcher>();
 
-  /** Notification that some state has changed. */
-  #update = new Deferred<void>();
+  /**
+   * Resolves when this watcher has been aborted and the last run finished.
+   */
+  readonly #finished = new Deferred<void>();
 
   private constructor(
-    script: ScriptReference,
+    rootScript: ScriptReference,
     logger: Logger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
     failureMode: FailureMode,
     abort: Deferred<void>
   ) {
-    this.#script = script;
+    this.#rootScript = rootScript;
     this.#logger = logger;
     this.#workerPool = workerPool;
-    this.#abort = abort;
     this.#failureMode = failureMode;
     this.#cache = cache;
-
-    if (!this.#aborted) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      abort.promise.then(() => {
-        // TODO(aomarks) Aborting should also cause the analyzer and executors to
-        // stop if they are running. Currently we only stop after the current
-        // build entirely finishes.
-        this.#update.resolve();
-      });
-    }
+    this.#abort = abort;
   }
 
-  /**
-   * The main watch loop.
-   */
-  async #watch(): Promise<void> {
-    try {
-      while (!this.#aborted) {
-        if (this.#stale && !this.#executing) {
-          await this.#analyzeAndExecute();
+  #startRun(): void {
+    switch (this.#state) {
+      case 'watching':
+      case 'queued': {
+        this.#state = 'running';
+        this.#logger.log({
+          script: this.#rootScript,
+          type: 'info',
+          detail: 'watch-run-start',
+        });
+        if (this.#latestRootScriptConfig === undefined) {
+          void this.#analyze();
+        } else {
+          void this.#execute(this.#latestRootScriptConfig);
         }
-        await this.#update.promise;
-        this.#update = new Deferred();
+        return;
       }
-    } finally {
-      // It's important to close all chokidar watchers, because they will
-      // prevent the Node program from ever exiting as long as they are active.
-      await this.#clearWatchers();
+      case 'running':
+      case 'aborted': {
+        throw unexpectedState(this.#state);
+      }
+      default: {
+        throw unknownState(this.#state);
+      }
     }
   }
 
-  /**
-   * Perform an analysis and execution.
-   */
-  async #analyzeAndExecute(): Promise<void> {
-    this.#logger.log({
-      script: this.#script,
-      type: 'info',
-      detail: 'watch-run-start',
-    });
+  async #analyze(): Promise<void> {
+    if (this.#state !== 'running') {
+      throw unexpectedState(this.#state);
+    }
 
-    // Reset _stale before execution, not after, because a file could change
-    // during execution, and we must not clobber that.
-    this.#stale = false;
-    this.#executing = true;
-
-    // TODO(aomarks) We only need to reset watchers and re-analyze if a
-    // package.json file changed.
     const analyzer = new Analyzer();
+    const result = await analyzer.analyze(this.#rootScript);
+    if ((this.#state as WatcherState) === 'aborted') {
+      return;
+    }
 
-    // TODO(aomarks) Add support for recovering from analysis errors. We'll need
-    // to track the package.json files that we encountered, and watch them.
-    const analysisResult = await analyzer.analyze(this.#script);
-    await this.#clearWatchers();
-    if (!analysisResult.ok) {
-      for (const failure of analysisResult.error) {
-        this.#logger.log(failure);
-      }
-      process.exit(1);
-    } else {
-      const analysis = analysisResult.value;
-      for (const {patterns, cwd} of this.#getWatchPathGroups(analysis)) {
-        this.#watchPatterns(patterns, cwd);
-      }
-      const executor = new Executor(
-        this.#logger,
-        this.#workerPool,
-        this.#cache,
-        this.#failureMode,
-        this.#abort
+    // Set up watchers for all relevant config files even if there were errors
+    // so that we'll try again when the user modifies a config file.
+    const configFiles = [...result.relevantConfigFilePaths];
+    // Order doesn't matter because we know we don't have any !negated patterns,
+    // but we're going to compare arrays exactly so the order should be
+    // deterministic.
+    configFiles.sort();
+    const oldWatcher = this.#configFilesWatcher;
+    if (!watchPathsEqual(configFiles, oldWatcher?.patterns)) {
+      this.#configFilesWatcher = makeWatcher(
+        configFiles,
+        '/',
+        this.#onConfigFileChanged
       );
-      const result = await executor.execute(analysis);
-      if (!result.ok) {
-        for (const error of result.error) {
-          this.#logger.log(error);
-        }
+      if (oldWatcher !== undefined) {
+        void oldWatcher.watcher.close();
       }
     }
 
-    this.#executing = false;
-    this.#update.resolve();
+    if (!result.config.ok) {
+      for (const error of result.config.error) {
+        this.#logger.log(error);
+      }
+      this.#onRunDone();
+      return;
+    }
+
+    this.#latestRootScriptConfig = result.config.value;
+    this.#synchronizeInputFileWatchers(this.#latestRootScriptConfig);
+    void this.#execute(this.#latestRootScriptConfig);
+  }
+
+  async #execute(script: ScriptConfig): Promise<void> {
+    if (this.#state !== 'running') {
+      throw unexpectedState(this.#state);
+    }
+    const executor = new Executor(
+      this.#logger,
+      this.#workerPool,
+      this.#cache,
+      this.#failureMode,
+      this.#abort
+    );
+    const result = await executor.execute(script);
+    if (!result.ok) {
+      for (const error of result.error) {
+        this.#logger.log(error);
+      }
+    }
+    this.#onRunDone();
+  }
+
+  #onRunDone(): void {
     this.#logger.log({
-      script: this.#script,
+      script: this.#rootScript,
       type: 'info',
       detail: 'watch-run-end',
     });
+    switch (this.#state) {
+      case 'queued': {
+        void this.#startRun();
+        return;
+      }
+      case 'running': {
+        this.#state = 'watching';
+        return;
+      }
+      case 'aborted': {
+        this.#finished.resolve();
+        return;
+      }
+      case 'watching': {
+        throw unexpectedState(this.#state);
+      }
+      default: {
+        throw unknownState(this.#state);
+      }
+    }
   }
 
-  /**
-   * Start watching some glob patterns.
-   */
-  #watchPatterns(patterns: string[], cwd: string): void {
-    const watcher = chokidar.watch(patterns, {
-      cwd,
-      // Ignore the initial "add" events emitted when chokidar first discovers
-      // each file. We already do an initial run, so these events are just noise
-      // that may trigger an unnecessary second run.
-      // https://github.com/paulmillr/chokidar#path-filtering
-      ignoreInitial: true,
-    });
-    this.#watchers.push(watcher);
-    watcher.on('add', this.#fileAddedOrChanged);
-    watcher.on('unlink', this.#fileAddedOrChanged);
-    watcher.on('change', this.#fileAddedOrChanged);
-  }
-
-  /**
-   * One of the paths we are watching has been created or modified.
-   */
-  readonly #fileAddedOrChanged = (): void => {
-    // TODO(aomarks) Cache package JSONS, globs, and hashes.
-    this.#stale = true;
-    this.#update.resolve();
+  #onConfigFileChanged = (): void => {
+    this.#latestRootScriptConfig = undefined;
+    this.#fileChanged();
   };
 
-  /**
-   * Shut down all active file watchers and clear the list.
-   */
-  async #clearWatchers(): Promise<void> {
-    const watchers = this.#watchers.splice(0, this.#watchers.length);
-    await Promise.all(watchers.map((watcher) => watcher.close()));
-  }
+  #fileChanged = (): void => {
+    switch (this.#state) {
+      case 'watching': {
+        void this.#startRun();
+        return;
+      }
+      case 'running': {
+        this.#state = 'queued';
+        return;
+      }
+      case 'queued':
+      case 'aborted': {
+        return;
+      }
+      default: {
+        throw unknownState(this.#state);
+      }
+    }
+  };
 
-  /**
-   * Walk through a script config and return a list of absolute filesystem paths
-   * that we should watch for changes.
-   */
-  #getWatchPathGroups(
-    script: ScriptConfig
-  ): Array<{patterns: string[]; cwd: string}> {
-    const packageJsons = new Set<string>();
-    const groups: Array<{patterns: string[]; cwd: string}> = [];
+  #synchronizeInputFileWatchers(root: ScriptConfig): void {
     const visited = new Set<ScriptReferenceString>();
-
     const visit = (script: ScriptConfig) => {
       const key = scriptReferenceToString(script);
       if (visited.has(key)) {
         return;
       }
       visited.add(key);
-      packageJsons.add(pathlib.join(script.packageDir, 'package.json'));
-      if (script.files !== undefined) {
-        // TODO(aomarks) We could optimize to create fewer watchers, but we have
-        // to be careful to deal with "!"-prefixed negation entries, because
-        // those negations only apply to the previous entries **in that specific
-        // "files" array**. A simple solution could be that if a "files" array
-        // has any "!"-prefixed entry, then it gets its own watcher, otherwise
-        // we can group watchers by packageDir.
-        groups.push({patterns: script.files.values, cwd: script.packageDir});
+
+      const newInputFiles = script.files?.values;
+      const oldWatcher = this.#inputFileWatchers.get(key);
+      if (!watchPathsEqual(newInputFiles, oldWatcher?.patterns)) {
+        if (newInputFiles === undefined || newInputFiles.length === 0) {
+          this.#inputFileWatchers.delete(key);
+        } else {
+          const newWatcher = makeWatcher(
+            newInputFiles,
+            script.packageDir,
+            this.#fileChanged
+          );
+          this.#inputFileWatchers.set(key, newWatcher);
+        }
+        if (oldWatcher !== undefined) {
+          void oldWatcher.watcher.close();
+        }
       }
-      for (const dependency of script.dependencies) {
-        visit(dependency.config);
+      for (const dep of script.dependencies) {
+        visit(dep.config);
       }
     };
+    visit(root);
 
-    visit(script);
-    groups.push({
-      // The package.json group is already resolved to absolute paths, so cwd is
-      // arbitrary.
-      cwd: process.cwd(),
-      patterns: [...packageJsons],
-    });
-    return groups;
+    // There also could be some scripts that have been removed entirely.
+    for (const [oldKey, oldWatcher] of this.#inputFileWatchers) {
+      if (!visited.has(oldKey)) {
+        void oldWatcher.watcher.close();
+        this.#inputFileWatchers.delete(oldKey);
+      }
+    }
+  }
+
+  #onAbort(): void {
+    switch (this.#state) {
+      case 'watching':
+      case 'queued': {
+        this.#state = 'aborted';
+        this.#closeAllFileWatchers();
+        this.#finished.resolve();
+        return;
+      }
+      case 'running': {
+        this.#state = 'aborted';
+        this.#closeAllFileWatchers();
+        // Don't resolve #finished immediately so that we will wait for #analyze
+        // or #execute to finish.
+        return;
+      }
+      case 'aborted': {
+        return;
+      }
+      default: {
+        throw unknownState(this.#state);
+      }
+    }
+  }
+
+  #closeAllFileWatchers() {
+    void this.#configFilesWatcher?.watcher.close();
+    for (const value of this.#inputFileWatchers.values()) {
+      void value.watcher.close();
+    }
   }
 }
+
+const watchPathsEqual = (
+  a: Array<string> | undefined,
+  b: Array<string> | undefined
+) => {
+  if (a === undefined && b === undefined) {
+    return true;
+  }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const makeWatcher = (
+  patterns: string[],
+  cwd: string,
+  callback: () => void
+): FileWatcher => {
+  const watcher = chokidar.watch(patterns, {
+    cwd,
+    // Ignore the initial "add" events emitted when chokidar first discovers
+    // each file. We already do an initial run, so these events are just noise
+    // that may trigger an unnecessary second run.
+    // https://github.com/paulmillr/chokidar#path-filtering
+    ignoreInitial: true,
+  });
+  watcher.on('all', callback);
+  return {
+    patterns,
+    watcher,
+  };
+};


### PR DESCRIPTION
- Refactored the `Watcher` class to be easier to follow. Follows the (updated) state machine diagram more directly now.

- Analysis errors are no longer fatal. We collect all relevant `package.json` files during analysis even in the case of a failure, and then analyze again if any of them change.

- Analysis is now re-used across iterations as long as the `package.json` files didn't change, instead of re-analyzing on every iteration.

- Filesystem watchers are re-used across iterations as long as the script's input file config didn't change, instead of re-creating all watchers on every iteration.

Fixes https://github.com/google/wireit/issues/48
Supersedes https://github.com/google/wireit/pull/188