### PR TITLE
Support extra arguments on command-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- You can now pass arbitrary extra arguments to a script by setting them after
+  two double-dashes, e.g. `npm run build -- -- --verbose`.
+
+### Changed
+
+- [**Breaking**] Setting unrecognized command-line arguments is now an error.
 
 ## [0.5.0] - 2022-05-31
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ npm run build -- -- --verbose
 
 The first double-dash tells `npm` to pass the remaining arguments to Wireit, and
 the second double-dash tells Wireit to pass the remaining arguments to the
-command.
+command. Only the `build` script will receive the `--verbose` argument.
 
 ## Input and output files
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Vanilla scripts](#vanilla-scripts)
   - [Cross-package dependencies](#cross-package-dependencies)
 - [Parallelism](#parallelism)
+- [Extra arguments](#extra-arguments)
 - [Input and output files](#input-and-output-files)
 - [Incremental build](#incremental-build)
 - [Caching](#caching)
@@ -204,6 +205,18 @@ simultaneously, then only one instance will be allowed to run at a time, while
 the others wait their turn. This prevents coordination problems that can result
 in incorrect output files being produced. If `output` is set to an empty array,
 then this restriction is removed.
+
+## Extra arguments
+
+You can pass extra arguments to a Wireit script with _two_ double-dashes:
+
+```sh
+npm run build -- -- --verbose
+```
+
+The first double-dash tells `npm` to pass the remaining arguments to Wireit, and
+the second double-dash tells Wireit to pass the remaining arguments to the
+command.
 
 ## Input and output files
 
@@ -589,6 +602,7 @@ build](#incremental-build), and whether its output can be [restored from
 cache](#caching).
 
 - The `command` setting.
+- The [extra arguments](#extra-arguments) set on the command-line.
 - The `clean` setting.
 - The `output` glob patterns.
 - The SHA256 content hashes of all files matching `files`.

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -144,7 +144,10 @@ export class Analyzer {
    * dependencies don't exist, are configured in an invalid way, or if there is
    * a cycle in the dependency graph.
    */
-  async analyze(root: ScriptReference): Promise<AnalyzeResult> {
+  async analyze(
+    root: ScriptReference,
+    extraArgs: string[] | undefined
+  ): Promise<AnalyzeResult> {
     // We do 2 walks through the dependency graph:
     //
     // 1. A non-deterministically ordered walk, where we traverse edges as soon
@@ -199,6 +202,7 @@ export class Analyzer {
       };
     }
     const validRootConfig = cycleResult.value;
+    validRootConfig.extraArgs = extraArgs;
     return {
       config: {ok: true, value: validRootConfig},
       relevantConfigFilePaths: this.#relevantConfigFilePaths,
@@ -208,7 +212,7 @@ export class Analyzer {
   async analyzeIgnoringErrors(
     scriptReference: ScriptReference
   ): Promise<PotentiallyValidScriptConfig> {
-    await this.analyze(scriptReference);
+    await this.analyze(scriptReference, []);
     return this.#getPlaceholder(scriptReference).placeholder;
   }
 
@@ -461,6 +465,7 @@ export class Analyzer {
       state: 'locally-valid',
       failures: placeholder.failures,
       command,
+      extraArgs: undefined,
       dependencies,
       files,
       output,
@@ -989,6 +994,7 @@ export class Analyzer {
     {
       const validConfig: ScriptConfig = {
         ...config,
+        extraArgs: undefined,
         state: 'valid',
         dependencies: config.dependencies as Array<Dependency<ScriptConfig>>,
       };

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -50,6 +50,11 @@ export interface FingerprintData {
   command: string | undefined;
 
   /**
+   * Extra arguments to pass to the command.
+   */
+  extraArgs: string[];
+
+  /**
    * The "clean" setting from the Wireit config.
    *
    * This is included in the fingerprint because switching from "false" to "true"
@@ -178,12 +183,13 @@ export class Fingerprint {
 
     // Note: The order of all fields is important so that we can do fast string
     // comparison.
-    fingerprint.#data = {
+    const data: Omit<FingerprintData, '__FingerprintDataBrand__'> = {
       cacheable,
       platform: process.platform,
       arch: process.arch,
       nodeVersion: process.version,
       command: script.command?.value,
+      extraArgs: script.extraArgs ?? [],
       clean: script.clean,
       files: Object.fromEntries(
         fileHashes.sort(([aFile], [bFile]) => aFile.localeCompare(bFile))
@@ -194,7 +200,8 @@ export class Fingerprint {
           aRef.localeCompare(bRef)
         )
       ),
-    } as FingerprintData;
+    };
+    fingerprint.#data = data as FingerprintData;
     return fingerprint;
   }
 

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -79,7 +79,7 @@ export class ScriptChildProcess {
 
     // TODO(aomarks) Update npm_ environment variables to reflect the new
     // package.
-    this.#child = spawn(script.command.value, {
+    this.#child = spawn(script.command.value, script.extraArgs, {
       cwd: script.packageDir,
       // Conveniently, "shell:true" has the same shell-selection behavior as
       // "npm run", where on macOS and Linux it is "sh", and on Windows it is

--- a/src/script.ts
+++ b/src/script.ts
@@ -42,6 +42,7 @@ export type ScriptConfig = NoOpScriptConfig | OneShotScriptConfig;
  */
 export interface NoOpScriptConfig extends BaseScriptConfig {
   command: undefined;
+  extraArgs: undefined;
 }
 
 /**
@@ -52,6 +53,11 @@ export interface OneShotScriptConfig extends BaseScriptConfig {
    * The shell command to execute.
    */
   command: JsonAstNode<string>;
+
+  /**
+   * Extra arguments to pass to the command.
+   */
+  extraArgs: string[] | undefined;
 }
 
 /**

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -939,4 +939,58 @@ test(
   })
 );
 
+test(
+  'can pass extra args with -- --',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            // Explicit empty input files so that we can be fresh.
+            files: [],
+          },
+        },
+      },
+    });
+
+    // Initially stale.
+    {
+      const wireit = rig.exec('npm run a -- -- foo -bar --baz');
+      const inv = await cmdA.nextInvocation();
+      assert.equal((await inv.environment()).argv.slice(3), [
+        'foo',
+        '-bar',
+        '--baz',
+      ]);
+      inv.exit(0);
+      assert.equal((await wireit.exit).code, 0);
+    }
+
+    // Nothing changed, fresh.
+    {
+      const wireit = rig.exec('npm run a -- -- foo -bar --baz');
+      assert.equal((await wireit.exit).code, 0);
+    }
+
+    // Changing the extra args should change the fingerprint so that we're
+    // stale.
+    {
+      const wireit = rig.exec('npm run a -- -- FOO -BAR --BAZ');
+      const inv = await cmdA.nextInvocation();
+      assert.equal((await inv.environment()).argv.slice(3), [
+        'FOO',
+        '-BAR',
+        '--BAZ',
+      ]);
+      inv.exit(0);
+      assert.equal((await wireit.exit).code, 0);
+    }
+  })
+);
+
 test.run();

--- a/src/test/errors-usage.test.ts
+++ b/src/test/errors-usage.test.ts
@@ -291,4 +291,28 @@ test(
   })
 );
 
+test(
+  'unknown args',
+  timeout(async ({rig}) => {
+    await rig.write({
+      'package.json': {
+        scripts: {
+          main: 'wireit',
+        },
+        wireit: {
+          main: {command: 'true'},
+        },
+      },
+    });
+    const wireit = rig.exec('npm run main -- --foo -bar baz');
+    const result = await wireit.exit;
+    assert.equal(result.code, 1);
+    assert.match(
+      result.stderr,
+      `
+❌ [main] Invalid usage: Unrecognized Wireit argument(s) ["--foo","-bar","baz"]. To pass arguments to the command, use two sets of double-dashes, e.g. "npm run build -- -- --extra-arg"`.trim()
+    );
+  })
+);
+
 test.run();

--- a/src/test/util/test-rig-command-child.ts
+++ b/src/test/util/test-rig-command-child.ts
@@ -15,46 +15,47 @@ import {
   RigToChildMessage,
 } from './test-rig-command-interface.js';
 
+class ChildIpcClient extends IpcClient<RigToChildMessage, ChildToRigMessage> {
+  protected override _onMessage(message: RigToChildMessage): void {
+    switch (message.type) {
+      case 'exit': {
+        process.exit(message.code);
+        break;
+      }
+      case 'stdout': {
+        process.stdout.write(message.str);
+        break;
+      }
+      case 'stderr': {
+        process.stderr.write(message.str);
+        break;
+      }
+      case 'environmentRequest': {
+        this._send({
+          type: 'environmentResponse',
+          cwd: process.cwd(),
+          argv: process.argv,
+          env: process.env,
+        });
+        break;
+      }
+      default: {
+        console.error(
+          `Unhandled message type ${
+            (unreachable(message) as RigToChildMessage).type
+          }`
+        );
+        process.exit(1);
+        break;
+      }
+    }
+  }
+}
+
 const ipcPath = process.argv[2];
 if (!ipcPath) {
   console.error('Error: expected first argument to be a socket/pipe filename.');
   process.exit(1);
 }
-
 const socket = net.createConnection(ipcPath);
-const client = new IpcClient<RigToChildMessage, ChildToRigMessage>(socket);
-
-for await (const message of client.receive()) {
-  switch (message.type) {
-    case 'exit': {
-      process.exit(message.code);
-      break;
-    }
-    case 'stdout': {
-      process.stdout.write(message.str);
-      break;
-    }
-    case 'stderr': {
-      process.stderr.write(message.str);
-      break;
-    }
-    case 'environmentRequest': {
-      client.send({
-        type: 'environmentResponse',
-        cwd: process.cwd(),
-        argv: process.argv,
-        env: process.env,
-      });
-      break;
-    }
-    default: {
-      console.error(
-        `Unhandled message type ${
-          (unreachable(message) as RigToChildMessage).type
-        }`
-      );
-      process.exit(1);
-      break;
-    }
-  }
-}
+new ChildIpcClient(socket);

--- a/src/test/util/test-rig-command-child.ts
+++ b/src/test/util/test-rig-command-child.ts
@@ -38,6 +38,15 @@ for await (const message of client.receive()) {
       process.stderr.write(message.str);
       break;
     }
+    case 'environmentRequest': {
+      client.send({
+        type: 'environmentResponse',
+        cwd: process.cwd(),
+        argv: process.argv,
+        env: process.env,
+      });
+      break;
+    }
     default: {
       console.error(
         `Unhandled message type ${

--- a/src/test/util/test-rig-command-child.ts
+++ b/src/test/util/test-rig-command-child.ts
@@ -10,8 +10,9 @@
 import * as net from 'net';
 import {unreachable} from '../../util/unreachable.js';
 import {
-  type Message,
-  MESSAGE_END_MARKER,
+  IpcClient,
+  ChildToRigMessage,
+  RigToChildMessage,
 } from './test-rig-command-interface.js';
 
 const ipcPath = process.argv[2];
@@ -20,38 +21,11 @@ if (!ipcPath) {
   process.exit(1);
 }
 
-const client = net.createConnection(ipcPath);
+const socket = net.createConnection(ipcPath);
+const client = new IpcClient<RigToChildMessage, ChildToRigMessage>(socket);
 
-let messageBuffer = '';
-
-/**
- * Handle some message data from the parent rig.
- *
- * Note that each data event could contain a partial message, or multiple
- * messages. The special MESSAGE_END_MARKER character is used to detect the end
- * of each complete JSON message in the stream.
- */
-client.on('data', (data: Buffer) => {
-  for (const char of data.toString()) {
-    if (char === MESSAGE_END_MARKER) {
-      const message = JSON.parse(messageBuffer) as Message;
-      messageBuffer = '';
-      handleMessage(message);
-    } else {
-      messageBuffer += char;
-    }
-  }
-});
-
-const handleMessage = (message: Message): void => {
+for await (const message of client.receive()) {
   switch (message.type) {
-    default: {
-      console.error(
-        `Unhandled message type ${(unreachable(message) as Message).type}`
-      );
-      process.exit(1);
-      break;
-    }
     case 'exit': {
       process.exit(message.code);
       break;
@@ -64,5 +38,14 @@ const handleMessage = (message: Message): void => {
       process.stderr.write(message.str);
       break;
     }
+    default: {
+      console.error(
+        `Unhandled message type ${
+          (unreachable(message) as RigToChildMessage).type
+        }`
+      );
+      process.exit(1);
+      break;
+    }
   }
-};
+}

--- a/src/test/util/test-rig-command-interface.ts
+++ b/src/test/util/test-rig-command-interface.ts
@@ -4,17 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * A message sent between a Wireit test rig instance and a spawned test rig
- * command.
- */
-export type Message = StdoutMessage | StderrMessage | ExitMessage;
+import * as net from 'net';
+import {Deferred} from '../../util/deferred.js';
 
 /**
- * Indicates the end of a JSON message on an IPC data stream. This is the
- * "record separator" ASCII character.
+ * A message sent from the test rig to a spawned command.
  */
-export const MESSAGE_END_MARKER = '\x1e';
+export type RigToChildMessage = StdoutMessage | StderrMessage | ExitMessage;
 
 /**
  * Tell the command to emit the given string to its stdout stream.
@@ -38,4 +34,91 @@ export interface StderrMessage {
 export interface ExitMessage {
   type: 'exit';
   code: number;
+}
+
+/**
+ * A message sent from a spawned command to the test rig.
+ */
+export type ChildToRigMessage = unknown;
+
+/**
+ * Indicates the end of a JSON message on an IPC data stream. This is the
+ * "record separator" ASCII character.
+ */
+export const MESSAGE_END_MARKER = '\x1e';
+
+/**
+ * Sends and receives messages over an IPC data stream.
+ */
+export class IpcClient<Incoming, Outgoing> {
+  readonly #socket: net.Socket;
+  readonly #closed = new Deferred<void>();
+  readonly #incomingMessagesBuffer: Incoming[] = [];
+  #incomingDataBuffer = '';
+  #messageReceivedNotice = new Deferred<void>();
+
+  constructor(socket: net.Socket) {
+    this.#socket = socket;
+    socket.on('data', this.#onData);
+    socket.once('close', () => {
+      this.#closed.resolve();
+      socket.removeListener('data', this.#onData);
+    });
+  }
+
+  send(message: Outgoing): void {
+    if (this.#closed.settled) {
+      throw new Error('Connection is closed');
+    }
+    this.#socket.write(JSON.stringify(message));
+    this.#socket.write(MESSAGE_END_MARKER);
+  }
+
+  async *receive(): AsyncIterableIterator<Incoming> {
+    while (!this.#closed.settled) {
+      while (this.#incomingMessagesBuffer.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        yield this.#incomingMessagesBuffer.shift()!;
+      }
+      await Promise.race([
+        this.#closed.promise,
+        this.#messageReceivedNotice.promise,
+      ]);
+    }
+    while (this.#incomingMessagesBuffer.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      yield this.#incomingMessagesBuffer.shift()!;
+    }
+  }
+
+  /**
+   * Handle an incoming message.
+   *
+   * Note that each data event could contain a partial message, or multiple
+   * messages. The special MESSAGE_END_MARKER character is used to detect the end
+   * of each complete JSON message in the stream.
+   */
+  #onData = (data: Buffer) => {
+    if (this.#closed.settled) {
+      throw new Error('Connection is closed');
+    }
+    for (const char of data.toString()) {
+      if (char === MESSAGE_END_MARKER) {
+        const message = JSON.parse(this.#incomingDataBuffer) as Incoming;
+        this.#incomingDataBuffer = '';
+        this.#onMessage(message);
+      } else {
+        this.#incomingDataBuffer += char;
+      }
+    }
+  };
+
+  #onMessage(message: Incoming) {
+    if (this.#closed.settled) {
+      throw new Error('Connection is closed');
+    }
+    this.#incomingMessagesBuffer.push(message);
+    this.#messageReceivedNotice.resolve();
+    this.#messageReceivedNotice = new Deferred<void>();
+  }
 }

--- a/src/test/util/test-rig-command-interface.ts
+++ b/src/test/util/test-rig-command-interface.ts
@@ -10,7 +10,11 @@ import {Deferred} from '../../util/deferred.js';
 /**
  * A message sent from the test rig to a spawned command.
  */
-export type RigToChildMessage = StdoutMessage | StderrMessage | ExitMessage;
+export type RigToChildMessage =
+  | StdoutMessage
+  | StderrMessage
+  | ExitMessage
+  | EnvironmentRequestMessage;
 
 /**
  * Tell the command to emit the given string to its stdout stream.
@@ -37,9 +41,27 @@ export interface ExitMessage {
 }
 
 /**
+ * Ask the command for information about its environment (argv, cwd, env).
+ */
+export interface EnvironmentRequestMessage {
+  type: 'environmentRequest';
+}
+
+/**
  * A message sent from a spawned command to the test rig.
  */
-export type ChildToRigMessage = unknown;
+export type ChildToRigMessage = EnvironmentResponseMessage;
+
+/**
+ * Report to the rig what cwd, argv, and environment variables were set when
+ * Wireit spawned this command.
+ */
+export interface EnvironmentResponseMessage {
+  type: 'environmentResponse';
+  cwd: string;
+  argv: string[];
+  env: {[key: string]: string | undefined};
+}
 
 /**
  * Indicates the end of a JSON message on an IPC data stream. This is the

--- a/src/test/util/test-rig-command.ts
+++ b/src/test/util/test-rig-command.ts
@@ -7,11 +7,10 @@
 import * as net from 'net';
 import * as pathlib from 'path';
 import {fileURLToPath} from 'url';
-
 import {Deferred} from '../../util/deferred.js';
 import {
-  type Message,
   MESSAGE_END_MARKER,
+  RigToChildMessage,
 } from './test-rig-command-interface.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -178,7 +177,7 @@ export class WireitTestRigCommandInvocation {
     this.#sendMessage({type: 'stderr', str});
   }
 
-  #sendMessage(message: Message): void {
+  #sendMessage(message: RigToChildMessage): void {
     this.#assertState('connected');
     this.#socket.write(JSON.stringify(message));
     this.#socket.write(MESSAGE_END_MARKER);

--- a/src/test/util/test-rig-command.ts
+++ b/src/test/util/test-rig-command.ts
@@ -8,8 +8,8 @@ import * as net from 'net';
 import * as pathlib from 'path';
 import {fileURLToPath} from 'url';
 import {Deferred} from '../../util/deferred.js';
+import {unreachable} from '../../util/unreachable.js';
 import {
-  MESSAGE_END_MARKER,
   IpcClient,
   RigToChildMessage,
   ChildToRigMessage,
@@ -128,37 +128,23 @@ export class WireitTestRigCommand {
 /**
  * One invocation of a {@link WireitTestRigCommand}.
  */
-export class WireitTestRigCommandInvocation {
-  readonly #socket: net.Socket;
-  readonly #socketClosed = new Deferred<void>();
+export class WireitTestRigCommandInvocation extends IpcClient<
+  ChildToRigMessage,
+  RigToChildMessage
+> {
   readonly command: WireitTestRigCommand;
-  #state: 'connected' | 'closed' = 'connected';
+  #state: 'connected' | 'closing' | 'closed' = 'connected';
+  #environmentResponse?: Deferred<EnvironmentResponseMessage>;
 
   constructor(socket: net.Socket, command: WireitTestRigCommand) {
-    this.#socket = socket;
-    this.#socket.on('close', () => {
-      this.#socketClosed.resolve();
-    });
+    super(socket);
     this.command = command;
+    void this.closed.then(() => {
+      this.#state = 'closed';
+    });
   }
 
-  async environment(): Promise<Exclude<EnvironmentResponseMessage, 'type'>> {
-    this.#assertState('connected');
-    const client = new IpcClient<ChildToRigMessage, RigToChildMessage>(
-      this.#socket
-    );
-    client.send({type: 'environmentRequest'});
-    for await (const message of client.receive()) {
-      switch (message.type) {
-        case 'environmentResponse': {
-          return message;
-        }
-      }
-    }
-    throw new Error('Connection closed before environmentResponse received');
-  }
-
-  #assertState(expected: 'connected' | 'closed') {
+  #assertState(expected: 'connected' | 'closing' | 'closed') {
     if (this.#state !== expected) {
       throw new Error(
         `Expected state to be ${expected} but was ${this.#state}`
@@ -166,12 +152,38 @@ export class WireitTestRigCommandInvocation {
     }
   }
 
-  /**
-   * Tell this invocation to exit with the given code.
-   */
-  exit(code: number): void {
-    this.#sendMessage({type: 'exit', code});
-    this.#state = 'closed';
+  protected override _onMessage(message: ChildToRigMessage): void {
+    switch (message.type) {
+      case 'environmentResponse': {
+        if (
+          this.#environmentResponse === undefined ||
+          this.#environmentResponse.settled
+        ) {
+          throw new Error('Unexpected environmentResponse');
+        }
+        this.#environmentResponse.resolve(message);
+        break;
+      }
+      default: {
+        throw new Error(
+          `Unhandled message type ${String(unreachable(message.type))}`
+        );
+        break;
+      }
+    }
+  }
+
+  environment(): Promise<Exclude<EnvironmentResponseMessage, 'type'>> {
+    this.#assertState('connected');
+    // TODO(aomarks) If we end up with a more complex API, we might want to
+    // create a proper RPC system with unique IDs for each request that can be
+    // used to map specific responses back to specific requests. But for now our
+    // API is very basic and doesn't require that.
+    if (this.#environmentResponse === undefined) {
+      this.#environmentResponse = new Deferred();
+      this._send({type: 'environmentRequest'});
+    }
+    return this.#environmentResponse.promise;
   }
 
   /**
@@ -179,26 +191,31 @@ export class WireitTestRigCommandInvocation {
    * that the process has exited (or is just about to exit).
    */
   get closed(): Promise<void> {
-    return this.#socketClosed.promise;
+    return this._closed.promise;
+  }
+
+  /**
+   * Tell this invocation to exit with the given code.
+   */
+  exit(code: number): void {
+    this.#assertState('connected');
+    this._send({type: 'exit', code});
+    this.#state = 'closing';
   }
 
   /**
    * Tell this invocation to write the given string to its stdout stream.
    */
   stdout(str: string): void {
-    this.#sendMessage({type: 'stdout', str});
+    this.#assertState('connected');
+    this._send({type: 'stdout', str});
   }
 
   /**
    * Tell this invocation to write the given string to its stderr stream.
    */
   stderr(str: string): void {
-    this.#sendMessage({type: 'stderr', str});
-  }
-
-  #sendMessage(message: RigToChildMessage): void {
     this.#assertState('connected');
-    this.#socket.write(JSON.stringify(message));
-    this.#socket.write(MESSAGE_END_MARKER);
+    this._send({type: 'stderr', str});
   }
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -65,6 +65,7 @@ interface FileWatcher {
 export class Watcher {
   static async watch(
     rootScript: ScriptReference,
+    extraArgs: string[] | undefined,
     logger: Logger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
@@ -73,6 +74,7 @@ export class Watcher {
   ): Promise<void> {
     const watcher = new Watcher(
       rootScript,
+      extraArgs,
       logger,
       workerPool,
       cache,
@@ -90,6 +92,7 @@ export class Watcher {
   #state: WatcherState = 'watching';
 
   readonly #rootScript: ScriptReference;
+  readonly #extraArgs: string[] | undefined;
   readonly #logger: Logger;
   readonly #workerPool: WorkerPool;
   readonly #cache?: Cache;
@@ -120,6 +123,7 @@ export class Watcher {
 
   private constructor(
     rootScript: ScriptReference,
+    extraArgs: string[] | undefined,
     logger: Logger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
@@ -127,6 +131,7 @@ export class Watcher {
     abort: Deferred<void>
   ) {
     this.#rootScript = rootScript;
+    this.#extraArgs = extraArgs;
     this.#logger = logger;
     this.#workerPool = workerPool;
     this.#failureMode = failureMode;
@@ -167,7 +172,7 @@ export class Watcher {
     }
 
     const analyzer = new Analyzer();
-    const result = await analyzer.analyze(this.#rootScript);
+    const result = await analyzer.analyze(this.#rootScript, this.#extraArgs);
     if ((this.#state as WatcherState) === 'aborted') {
       return;
     }


### PR DESCRIPTION
You can now pass extra arguments to a script from the command-line like this:

```shell
npm run build -- -- --verbose
```

The two double-dashes are needed because the first one tells npm to forward arguments to wireit, and the second one tells wireit to forward arguments to the script.

It is also now an error to pass any unexpected argument to wireit (expected argument are currently just `watch` and `--`). Previously they were silently eaten.

It would be possible for us to relax the requirement for the second double-dash, and automatically pass through any arguments which we don't recognize as our own. However, that means every time we add a new argument, we'll need a breaking change. I think this is something we could relax in the future, but unless we get rid of arguments entirely, we'll still want `--` to mean "the following argument is for the script, not wireit" (e.g. if you wanted to pass a `watch` argument to the script). So I think this PR is a good starting point, with the option to relax later.

Fixes https://github.com/google/wireit/issues/34
cc @jpzwarte