### PR TITLE
Allow `yarn run -T -B wireit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - You can now pass arbitrary extra arguments to a script by setting them after
   two double-dashes, e.g. `npm run build -- -- --verbose`.
 
+- If you're using Yarn Berry, you can invoke the shared instance of wireit at
+  the root of your workspace from any package's `scripts` entry:
+
+  ```json
+  "scripts": {
+    "build": "yarn run -T -B wireit"
+  },
+  ```
+
 ### Changed
 
 - [**Breaking**] Setting unrecognized command-line arguments is now an error.

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -335,7 +335,11 @@ export class Analyzer {
     const scriptCommand = syntaxInfo.scriptNode;
     const wireitConfig = syntaxInfo.wireitConfigNode;
 
-    if (wireitConfig !== undefined && scriptCommand.value !== 'wireit') {
+    if (
+      wireitConfig !== undefined &&
+      scriptCommand.value !== 'wireit' &&
+      scriptCommand.value !== 'yarn run -T -B wireit'
+    ) {
       const configName = wireitConfig.name;
       placeholder.failures.push({
         type: 'failure',


### PR DESCRIPTION
yarn@2+ (Berry) distinguishes between local scripts (`yarn run script-name`) and scripts in the workspace root (`yarn run -T script-name`).  This PR relaxes the script assertion to allow wireit to be invoked with `yarn run -T wireit`, enabling projects managed by Berry to use a shared instance of yarn at the top level.

Note: I do not know how to properly write tests for this.

Fixes #286