### PR TITLE
Add support for watch mode in yarn berry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   },
   ```
 
+### Fixed
+
+- Yarn Berry now supports watch mode.
+
 ### Changed
 
 - [**Breaking**] Watch mode is now set using `--watch` instead of `watch`, e.g.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ and replace the original script with the `wireit` command.
 </table>
 
 Now when you run `npm run build`, Wireit upgrades the script to be smarter and
-more efficient. Wireit works with [yarn](https://yarnpkg.com/) and
-[pnpm](https://pnpm.io/), too.
+more efficient. Wireit works with [yarn](https://yarnpkg.com/)
+(both 1.X "[Classic](https://classic.yarnpkg.com/)" and its successor "Berry")
+and [pnpm](https://pnpm.io/), too.
 
 You should also add `.wireit` to your `.gitignore` file. Wireit uses the
 `.wireit` directory to store caches and other data for your scripts.
@@ -626,7 +627,8 @@ Maintenance LTS (14). See [Node releases](https://nodejs.org/en/about/releases/)
 for the schedule.
 
 Wireit is supported on the npm versions that ship with the above supported Node
-versions (5 and 6), and on the latest versions of Yarn (1) and pnpm (7).
+versions (5 and 6), Yarn Classic (1), and on the latest versions of Yarn Berry
+(3) and pnpm (7).
 
 ## Related tools
 


### PR DESCRIPTION
As mentioned in the previous comments about yarn's handling of argv, Yarn Classic warns [that in a future version, argument handling will change](https://github.com/yarnpkg/yarn/blob/3119382885ea373d3c13d6a846de743eca8c914b/src/cli/index.js#L299).

Yarn Berry appears to pass arguments directly to argv.

`yarn run build` yields

	[
      '~/.nvm/versions/node/v16.14.0/bin/node',
      '~/Projects/…/node_modules/wireit/bin/wireit.js'
    ]

`yarn run build --watch` yields

	[
      '~/.nvm/versions/node/v16.14.0/bin/node',
      '~/Projects/…/node_modules/wireit/bin/wireit.js',
      '--watch'
    ]

`yarn run build -- --i-am-a-banana` yields

	[
      '~/.nvm/versions/node/v16.14.0/bin/node',
      '~/Projects/…/node_modules/wireit/bin/wireit.js',
      '--'
      '--i-am-a-banana'
    ]
    
    
(Sorry for the force-push noise.  I'm not used to how GitHub handles branches and PRs.)