### PR TITLE
Make tests workflow run with correct node versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,12 @@ jobs:
       # We support Node Latest, Active LTS, and the most recent Maintenance LTS.
       # See https://nodejs.org/en/about/releases/ for Node release schedule.
       matrix:
-        version: [14, 16, 18]
+        version: [
+            # Skip 14 for now. See https://github.com/google/wireit/issues/294
+            # 14,
+            16,
+            18,
+          ]
         os: [ubuntu-20.04, macos-11, windows-2022]
 
       # Allow all matrix configurations to complete, instead of cancelling as

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
 
       - uses: google/wireit@setup-github-actions-caching/v1
 
+      - run: node --version; npm --version
+
       - run: npm ci
 
       # Don't bother running the vscode-extension tests on Node 14, because the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       # We support Node Latest, Active LTS, and the most recent Maintenance LTS.
       # See https://nodejs.org/en/about/releases/ for Node release schedule.
       matrix:
-        version: [
+        node: [
             # Skip 14 for now. See https://github.com/google/wireit/issues/294
             # 14,
             16,
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.version }}
+          node-version: ${{ matrix.node }}
           cache: npm
 
       - uses: google/wireit@setup-github-actions-caching/v1
@@ -47,14 +47,14 @@ jobs:
 
       # Don't bother running the vscode-extension tests on Node 14, because the
       # minimum version of VSCode we support uses Node 16.
-      - if: matrix.version == 14
+      - if: matrix.node == 14
         run: npm run test:headless
 
       # See https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions for why we need xvfb-run
       - run: npm test
-        if: runner.os != 'Linux' && matrix.version != 14
+        if: runner.os != 'Linux' && matrix.node != 14
       - run: xvfb-run -a npm test
-        if: runner.os == 'Linux' && matrix.version != 14
+        if: runner.os == 'Linux' && matrix.node != 14
 
   lint-and-format:
     timeout-minutes: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.version }}
           cache: npm
 
       - uses: google/wireit@setup-github-actions-caching/v1
@@ -42,14 +42,14 @@ jobs:
 
       # Don't bother running the vscode-extension tests on Node 14, because the
       # minimum version of VSCode we support uses Node 16.
-      - if: matrix.node == 14
+      - if: matrix.version == 14
         run: npm run test:headless
 
       # See https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions for why we need xvfb-run
       - run: npm test
-        if: runner.os != 'Linux' && matrix.node != 14
+        if: runner.os != 'Linux' && matrix.version != 14
       - run: xvfb-run -a npm test
-        if: runner.os == 'Linux' && matrix.node != 14
+        if: runner.os == 'Linux' && matrix.version != 14
 
   lint-and-format:
     timeout-minutes: 5


### PR DESCRIPTION
Previously all the workflows were running in node 16 as the matrix key was not correct. This fixes the workflow yaml to actually use the correct versions. Also added a step to check the versions of node and npm within the workflow.

However, this did surface an issue for node 14. https://github.com/google/wireit/issues/294
I've commented out 14 from the matrix for now but if this is to be merged as is, the repo workflow requirement would need to be loosened to not require 14.