### PR TITLE
Verify output files before treating a script as fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   an upcoming release, at which point it will be sent to the underlying script,
   consistent with how npm usually behaves.
 
+- Scripts are no longer skipped as fresh if any `output` files were changed,
+  added, or removed since the previous run.
+
+- In order for a script to be skipped as fresh, it is now required to specify
+  the `output` files. Previously only input `files` were required.
+
 ## [0.5.0] - 2022-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ Setting these properties allow you to use more features of Wireit:
 |                                             | Requires<br>`files` | Requires<br>`output` |
 | ------------------------------------------: | :-----------------: | :------------------: |
 |       [**Dependency graph**](#dependencies) |          -          |          -           |
-| [**Incremental build**](#incremental-build) |         ☑️          |          -           |
 |               [**Watch mode**](#watch-mode) |         ☑️          |          -           |
 |         [**Clean build**](#cleaning-output) |          -          |          ☑️          |
+| [**Incremental build**](#incremental-build) |         ☑️          |          ☑️          |
 |                     [**Caching**](#caching) |         ☑️          |          ☑️          |
 
 #### Example configuration
@@ -266,13 +266,15 @@ would cause it to produce different output since the last time it ran. This is
 called _incremental build_. When a script is skipped, any `stdout` or `stderr`
 that it produced in the previous run is replayed.
 
-To enable incremental build, configure the input files for each script by
-specifying [glob patterns](#glob-patterns) in the `wireit.<script>.files` list.
+To enable incremental build, configure the input and output files for each
+script by specifying [glob patterns](#glob-patterns) in the
+`wireit.<script>.files` and `wireit.<script>.output` arrays.
 
-> ℹ️ If a script doesn't have a `files` list defined at all, then it will _always_
-> run, because Wireit doesn't know which files to check for changes. To tell
-> Wireit it is safe to skip execution of a script that definitely has no input
-> files, set `files` to an empty array (`files: []`).
+> ℹ️ If a script doesn't have a `files` or `output` list defined at all, then it
+> will _always_ run, because Wireit doesn't know which files to check for
+> changes. To tell Wireit it is safe to skip execution of a script that
+> definitely has no input and/or files, set `files` and/or `output` to an empty
+> array (`files: [], output: []`).
 
 ## Caching
 

--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -6,7 +6,7 @@
 
 import type {ScriptReference} from '../script.js';
 import type {Fingerprint} from '../fingerprint.js';
-import type {RelativeEntry} from '../util/glob.js';
+import type {AbsoluteEntry} from '../util/glob.js';
 
 /**
  * Saves and restores output files to some cache store (e.g. local disk or
@@ -43,7 +43,7 @@ export interface Cache {
   set(
     script: ScriptReference,
     fingerprint: Fingerprint,
-    relativeFiles: RelativeEntry[]
+    relativeFiles: AbsoluteEntry[]
   ): Promise<boolean>;
 }
 

--- a/src/caching/cache.ts
+++ b/src/caching/cache.ts
@@ -37,13 +37,13 @@ export interface Cache {
    *
    * @param script The script whose output will be saved to the cache.
    * @param fingerprint The string-encoded fingerprint for the script.
-   * @param relativeFiles The package-relative output files to cache.
+   * @param absoluteFiles The absolute output files to cache.
    * @returns Whether the cache was written.
    */
   set(
     script: ScriptReference,
     fingerprint: Fingerprint,
-    relativeFiles: AbsoluteEntry[]
+    absoluteFiles: AbsoluteEntry[]
   ): Promise<boolean>;
 }
 

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -18,7 +18,7 @@ import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference} from '../script.js';
 import type {Fingerprint} from '../fingerprint.js';
 import type {Logger} from '../logging/logger.js';
-import type {RelativeEntry} from '../util/glob.js';
+import type {AbsoluteEntry} from '../util/glob.js';
 import type {Result} from '../error.js';
 
 /**
@@ -147,18 +147,18 @@ export class GitHubActionsCache implements Cache {
   async set(
     script: ScriptReference,
     fingerprint: Fingerprint,
-    relativeFiles: RelativeEntry[]
+    absFiles: AbsoluteEntry[]
   ): Promise<boolean> {
     if (this.#hitRateLimit) {
       return false;
     }
 
-    const absFiles = relativeFiles.map((rel) =>
-      pathlib.join(script.packageDir, rel.path)
-    );
     const tempDir = await makeTempDir(script);
     try {
-      const tarballPath = await this.#makeTarball([...absFiles], tempDir);
+      const tarballPath = await this.#makeTarball(
+        [...absFiles.map((file) => file.path)],
+        tempDir
+      );
       return await this.#reserveUploadAndCommitTarball(
         script,
         fingerprint,

--- a/src/caching/local-cache.ts
+++ b/src/caching/local-cache.ts
@@ -14,7 +14,7 @@ import {glob} from '../util/glob.js';
 import type {Cache, CacheHit} from './cache.js';
 import type {ScriptReference} from '../script.js';
 import type {Fingerprint} from '../fingerprint.js';
-import type {RelativeEntry} from '../util/glob.js';
+import type {AbsoluteEntry} from '../util/glob.js';
 
 /**
  * Caches script output to each package's
@@ -40,7 +40,7 @@ export class LocalCache implements Cache {
   async set(
     script: ScriptReference,
     fingerprint: Fingerprint,
-    relativeFiles: RelativeEntry[]
+    absoluteFiles: AbsoluteEntry[]
   ): Promise<boolean> {
     // TODO(aomarks) A script's cache directory currently just grows forever.
     // We'll have the "clean" command to help with manual cleanup, but we'll
@@ -57,7 +57,7 @@ export class LocalCache implements Cache {
       // checked for an existing cache hit.
       throw new Error(`Did not expect ${absCacheDir} to already exist.`);
     }
-    await copyEntries(relativeFiles, script.packageDir, absCacheDir);
+    await copyEntries(absoluteFiles, script.packageDir, absCacheDir);
     return true;
   }
 
@@ -90,7 +90,6 @@ class LocalCacheHit implements CacheHit {
   async apply(): Promise<void> {
     const entries = await glob(['**'], {
       cwd: this.#source,
-      absolute: false,
       followSymlinks: false,
       includeDirectories: true,
       expandDirectories: true,

--- a/src/event.ts
+++ b/src/event.ts
@@ -305,6 +305,7 @@ export interface Stderr extends OutputBase {
 type Info =
   | ScriptRunning
   | ScriptLocked
+  | OutputModified
   | WatchRunStart
   | WatchRunEnd
   | GenericInfo;
@@ -326,6 +327,15 @@ export interface ScriptRunning extends InfoBase<ScriptConfig> {
  */
 export interface ScriptLocked extends InfoBase<ScriptConfig> {
   detail: 'locked';
+}
+
+/**
+ * A script that would otherwise have been skipped as fresh is being treated as
+ * stale, because one or more output files from the previous run have been
+ * added, removed, or changed.
+ */
+export interface OutputModified extends InfoBase<ScriptConfig> {
+  detail: 'output-modified';
 }
 
 /**

--- a/src/execution/one-shot.ts
+++ b/src/execution/one-shot.ts
@@ -490,7 +490,6 @@ export class OneShotExecution extends BaseExecution<OneShotScriptConfig> {
         ],
         {
           cwd: this.script.packageDir,
-          absolute: false,
           followSymlinks: false,
           includeDirectories: true,
           expandDirectories: true,
@@ -614,7 +613,6 @@ export class OneShotExecution extends BaseExecution<OneShotScriptConfig> {
     try {
       absFiles = await glob(this.script.output.values, {
         cwd: this.script.packageDir,
-        absolute: true,
         followSymlinks: false,
         includeDirectories: true,
         expandDirectories: true,

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -168,13 +168,18 @@ export class Fingerprint {
       // If command is undefined, then we simply propagate the fingerprints of
       // our dependencies, and don't have any effect ourselves on cacheability.
       script.command === undefined ||
-      // Otherwise, If files are undefined, then it's not safe to be cached,
-      // because we don't know what the inputs are, so we can't know if the
-      // output of this script could change.
+      // If input files are undefined, then it's not safe to be fresh or cached,
+      // because we wouldn't know when an input file has changed that could
+      // affect the output.
       (script.files !== undefined &&
-        // Similarly, if any of our dependencies are uncacheable, then we're
-        // uncacheable too, because that dependency could also have an effect on
-        // our output.
+        // If output files are undefined, then it's not safe to be fresh,
+        // because we aren't able to check whether the output files were
+        // independently modified since the last run. It's also not possible to
+        // be cached, because we wouldn't know what to put in the cache.
+        script.output !== undefined &&
+        // If any of our dependencies are uncacheable, then we're uncacheable
+        // too, because that dependency could be producing an output that is an
+        // untracked input of ours.
         allDependenciesAreCacheable);
 
     const fingerprint = new Fingerprint();

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -6,7 +6,6 @@
 
 import {createHash} from 'crypto';
 import {createReadStream} from 'fs';
-import {resolve} from 'path';
 import {glob} from './util/glob.js';
 import {scriptReferenceToString} from './script.js';
 
@@ -134,7 +133,6 @@ export class Fingerprint {
     if (script.files?.values.length) {
       const files = await glob(script.files.values, {
         cwd: script.packageDir,
-        absolute: false,
         followSymlinks: true,
         // TODO(aomarks) This means that empty directories are not reflected in
         // the fingerprint, however an empty directory could modify the behavior
@@ -154,7 +152,7 @@ export class Fingerprint {
       // ".wireit/<script>/hashes".
       fileHashes = await Promise.all(
         files.map(async (file): Promise<[string, Sha256HexDigest]> => {
-          const absolutePath = resolve(script.packageDir, file.path);
+          const absolutePath = file.path;
           const hash = createHash('sha256');
           for await (const chunk of createReadStream(absolutePath)) {
             hash.update(chunk as Buffer);

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -243,7 +243,13 @@ export class DefaultLogger implements Logger {
           }
           case 'locked': {
             console.log(
-              `💤 ${prefix} Waiting for another process which is already running this script.`
+              `💤${prefix} Waiting for another process which is already running this script.`
+            );
+            break;
+          }
+          case 'output-modified': {
+            console.log(
+              `ℹ️${prefix} Output files were modified since the previous run.`
             );
             break;
           }

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -952,8 +952,9 @@ for (const agent of ['npm', 'yarn', 'pnpm']) {
           wireit: {
             a: {
               command: cmdA.command,
-              // Explicit empty input files so that we can be fresh.
+              // Explicit empty input and output files so that we can be fresh.
               files: [],
+              output: [],
             },
           },
         },

--- a/src/test/stdio-replay.test.ts
+++ b/src/test/stdio-replay.test.ts
@@ -47,6 +47,7 @@ test(
           a: {
             command: cmdA.command,
             files: [],
+            output: [],
           },
         },
       },
@@ -88,6 +89,7 @@ test(
           a: {
             command: cmdA.command,
             files: [],
+            output: [],
           },
         },
       },
@@ -129,6 +131,7 @@ test(
           a: {
             command: cmdA.command,
             files: ['input'],
+            output: [],
           },
         },
       },

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -143,6 +143,7 @@ export class WireitTestRig extends FilesystemTestRig {
       // Unset GitHub Actions caching environment variables that are set when we
       // are running these tests in CI.
       WIREIT_CACHE: undefined,
+      WIREIT_FAILURES: undefined,
       ACTIONS_CACHE_URL: undefined,
       ACTIONS_RUNTIME_TOKEN: undefined,
       // In npm 6 (which ships with Node 14), "npm run" only includes the

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -323,10 +323,12 @@ test(
             command: cmdA.command,
             dependencies: ['b'],
             files: ['a.txt'],
+            output: [],
           },
           b: {
             command: cmdB.command,
             files: ['b.txt'],
+            output: [],
           },
         },
       },
@@ -392,6 +394,7 @@ test(
             command: cmdA.command,
             dependencies: ['../bar:b'],
             files: ['a.txt'],
+            output: [],
           },
         },
       },
@@ -404,6 +407,7 @@ test(
           b: {
             command: cmdB.command,
             files: ['b.txt'],
+            output: [],
           },
         },
       },

--- a/src/util/copy.ts
+++ b/src/util/copy.ts
@@ -10,7 +10,7 @@ import {optimizeMkdirs} from './optimize-mkdirs.js';
 import {constants} from 'fs';
 import {IS_WINDOWS} from '../util/windows.js';
 
-import type {RelativeEntry} from './glob.js';
+import type {AbsoluteEntry} from './glob.js';
 
 /**
  * Copy all of the given files and directories from one directory to another.
@@ -23,7 +23,7 @@ import type {RelativeEntry} from './glob.js';
  * automatically create "foo/", even if "foo/" wasn't listed.
  */
 export const copyEntries = async (
-  entries: RelativeEntry[],
+  entries: AbsoluteEntry[],
   sourceDir: string,
   destDir: string
 ): Promise<void> => {
@@ -34,7 +34,8 @@ export const copyEntries = async (
   const files = new Set<string>();
   const symlinks = new Set<string>();
   const directories = new Set<string>();
-  for (const {path: relativePath, dirent} of entries) {
+  for (const {path: absolutePath, dirent} of entries) {
+    const relativePath = pathlib.relative(sourceDir, absolutePath);
     if (dirent.isDirectory()) {
       directories.add(pathlib.join(destDir, relativePath));
     } else {

--- a/src/util/manifest.ts
+++ b/src/util/manifest.ts
@@ -31,7 +31,7 @@ export interface FileManifestEntry {
  * A JSON-serialized manifest of files.
  */
 export type FileManifestString = string & {
-  __OutputManifestStringBrand__: never;
+  __FileManifestStringBrand__: never;
 };
 
 export function computeManifestEntry(stats: Stats): FileManifestEntry {

--- a/src/util/manifest.ts
+++ b/src/util/manifest.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Stats} from 'fs';
+
+/**
+ * Metadata about a file which we use as a heuristic to decide whether two files
+ * are equal without needing to read its contents.
+ */
+export interface FileManifestEntry {
+  /** File type */
+  t:
+    | /** File */ 'f'
+    | /** Directory */ 'd'
+    | /** Symbolic link */ 'l'
+    | /** Block device */ 'b'
+    | /** Character device */ 'c'
+    | /** FIFO pipe */ 'p'
+    | /** Socket */ 's'
+    | /** Unknown */ '?';
+  /** Last content modification time. `undefined` for directories. */
+  m: number | undefined;
+  /** Size in bytes. `undefined` for directories. */
+  s: number | undefined;
+}
+
+/**
+ * A JSON-serialized manifest of files.
+ */
+export type FileManifestString = string & {
+  __OutputManifestStringBrand__: never;
+};
+
+export function computeManifestEntry(stats: Stats): FileManifestEntry {
+  return {
+    t: stats.isFile()
+      ? 'f'
+      : stats.isDirectory()
+      ? 'd'
+      : stats.isSymbolicLink()
+      ? 'l'
+      : stats.isBlockDevice()
+      ? 'b'
+      : stats.isCharacterDevice()
+      ? 'c'
+      : stats.isFIFO()
+      ? 'p'
+      : stats.isSocket()
+      ? 's'
+      : '?',
+    // Don't include timestamp or size for directories, because they can change
+    // when a child is added or removed. If we are tracking the child, then it
+    // will have its own entry. If we are not tracking the child, then we don't
+    // want it to affect the manifest.
+    m: stats.isDirectory() ? undefined : stats.mtimeMs,
+    s: stats.isDirectory() ? undefined : stats.size,
+  };
+}


### PR DESCRIPTION
### Background

Before this PR, if the `.wireit/<script>/fingerprint` file matches the current fingerprint for a script, then we assume that script is fresh, and skip it.

This works great, unless another process modifies the output files independently of Wireit, in which case the script will be skipped even though it actually needed to run.

### This PR

Now, after running a script, we now list all files matching the `output` globs, and save a record of their metadata (name, mtime, size) into a file named `.wireit/<script>/manifest`.

Then when preparing to run a script, after noticing that the current fingerprint matches the `.wireit/<script>/fingerprint` file, we re-compute the manifest (in the same way as we did above), and compare it to the `.wireit/<script>/manifest` file. If they match, consider the script fresh, and skip. If they don't match, consider the script stale, log an info message, and act the same way as we would if the fingerprint didn't match.

Fixes https://github.com/google/wireit/issues/292
Fixes https://github.com/google/wireit/issues/280
Fixes https://github.com/google/wireit/issues/262
Fixes https://github.com/google/wireit/issues/150

### Other changes

- Previously, if `output` was undefined, we could still treat a script as fresh, because we assumed the output wouldn't have changed if the input files didn't change. We no longer assume this, so now it's necessary to specify `output` to get freshness skipping (can be empty array).

- Glob results are now always returned as absolute paths. This made it simpler to share the cached output glob results between manifest generation and cleaning.

- Fixed a test rig bug where `WIREIT_FAILURES` would get propagated to the test cases.