### PR TITLE
Handle 503 errors from GitHub the same as 429 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- 503 "Service Unavailable" HTTP errors returned by the GitHub Actions caching
+  service are no longer fatal. Instead, caching will be skipped for the
+  remainder of the Wireit run, similar to how 429 "Too Many Requests" errors are
+  handled.
 
 ## [0.7.0] - 2022-06-17
 

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -216,95 +216,97 @@ test(
   })
 );
 
-test(
-  'recovers from rate limit',
-  timeout(async ({rig, server}) => {
-    await rig.write({
-      'package.json': {
-        scripts: {
-          a: 'wireit',
-          b: 'wireit',
-        },
-        wireit: {
-          a: {
-            command: 'true',
-            files: ['input'],
-            output: [],
-            dependencies: ['b'],
+for (const code of [429, 503]) {
+  test(
+    `recovers from ${code} error`,
+    timeout(async ({rig, server}) => {
+      await rig.write({
+        'package.json': {
+          scripts: {
+            a: 'wireit',
+            b: 'wireit',
           },
-          b: {
-            command: 'true',
-            files: ['input'],
-            output: [],
+          wireit: {
+            a: {
+              command: 'true',
+              files: ['input'],
+              output: [],
+              dependencies: ['b'],
+            },
+            b: {
+              command: 'true',
+              files: ['input'],
+              output: [],
+            },
           },
         },
-      },
-    });
+      });
 
-    // Check API
-    server.rateLimitNextRequest('check');
-    server.resetMetrics();
-    await rig.write('input', '0');
-    assert.equal((await rig.exec('npm run a').exit).code, 0);
-    assert.equal(server.metrics, {
-      // Note that because we turn off GitHub Actions Caching after the first
-      // rate limit error, "b" fails and then "a" skips, so this count is 1
-      // instead of 2.
-      check: 1,
-      reserve: 0,
-      upload: 0,
-      commit: 0,
-      download: 0,
-    });
+      // Check API
+      server.forceErrorOnNextRequest('check', code);
+      server.resetMetrics();
+      await rig.write('input', '0');
+      assert.equal((await rig.exec('npm run a').exit).code, 0);
+      assert.equal(server.metrics, {
+        // Note that because we turn off GitHub Actions Caching after the first
+        // rate limit error, "b" fails and then "a" skips, so this count is 1
+        // instead of 2.
+        check: 1,
+        reserve: 0,
+        upload: 0,
+        commit: 0,
+        download: 0,
+      });
 
-    // Reserve API
-    server.rateLimitNextRequest('reserve');
-    server.resetMetrics();
-    await rig.write('input', '1');
-    assert.equal((await rig.exec('npm run a').exit).code, 0);
-    assert.equal(server.metrics, {
-      check: 1,
-      reserve: 1,
-      upload: 0,
-      commit: 0,
-      download: 0,
-    });
+      // Reserve API
+      server.forceErrorOnNextRequest('reserve', code);
+      server.resetMetrics();
+      await rig.write('input', '1');
+      assert.equal((await rig.exec('npm run a').exit).code, 0);
+      assert.equal(server.metrics, {
+        check: 1,
+        reserve: 1,
+        upload: 0,
+        commit: 0,
+        download: 0,
+      });
 
-    // Upload API
-    server.rateLimitNextRequest('upload');
-    server.resetMetrics();
-    await rig.write('input', '2');
-    assert.equal((await rig.exec('npm run a').exit).code, 0);
-    assert.equal(server.metrics, {
-      check: 1,
-      reserve: 1,
-      upload: 1,
-      commit: 0,
-      download: 0,
-    });
+      // Upload API
+      server.forceErrorOnNextRequest('upload', code);
+      server.resetMetrics();
+      await rig.write('input', '2');
+      assert.equal((await rig.exec('npm run a').exit).code, 0);
+      assert.equal(server.metrics, {
+        check: 1,
+        reserve: 1,
+        upload: 1,
+        commit: 0,
+        download: 0,
+      });
 
-    // Commit API
-    server.rateLimitNextRequest('commit');
-    server.resetMetrics();
-    await rig.write('input', '3');
-    assert.equal((await rig.exec('npm run a').exit).code, 0);
-    assert.equal(server.metrics, {
-      check: 1,
-      reserve: 1,
-      upload: 1,
-      commit: 1,
-      download: 0,
-    });
+      // Commit API
+      server.forceErrorOnNextRequest('commit', code);
+      server.resetMetrics();
+      await rig.write('input', '3');
+      assert.equal((await rig.exec('npm run a').exit).code, 0);
+      assert.equal(server.metrics, {
+        check: 1,
+        reserve: 1,
+        upload: 1,
+        commit: 1,
+        download: 0,
+      });
 
-    // Download API
-    //
-    // TODO(aomarks) The GitHub Actions caching library doesn't surface HTTP
-    // errors during download. Instead it seems to create invalid tarballs. This
-    // might not really be a problem in reality, because tarballs come from a
-    // different CDN server, so probably have a separate rate limit from the
-    // rest of the caching APIs.
-  })
-);
+      // Download API
+      //
+      // TODO(aomarks) The GitHub Actions caching library doesn't surface HTTP
+      // errors during download. Instead it seems to create invalid tarballs. This
+      // might not really be a problem in reality, because tarballs come from a
+      // different CDN server, so probably have a separate rate limit from the
+      // rest of the caching APIs.
+    })
+  );
+}
 
 test(
   'uploads large tarball in multiple chunks',


### PR DESCRIPTION
Sometimes we get 503 "Service Unavailable" errors from the GitHub Caching service that are out of our control. Previously, this would be fatal. Now, it is non-fatal, and instead just causes us to stop using the caching service for the remainder of that Wireit process. This is the same way we already handled 429 "Too Many Requests" errors.

Note in the future we could add some retries, but since caching is optional, this is a good enough behavior in the meantime.

Fixes https://github.com/google/wireit/issues/313