### PR TITLE
Force stdout color output when Wireit is run with a text terminal attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- stdout color output is now forced when Wireit is run with a text terminal
+  attached.
+
 - Default number of scripts run in parallel is now 2x logical CPU cores instead
   of 4x.
 

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -91,6 +91,10 @@ export class ScriptChildProcess {
       //   https://github.com/npm/run-script/blob/a5b03bdfc3a499bf7587d7414d5ea712888bfe93/lib/make-spawn-args.js#L11
       shell: true,
       env: augmentProcessEnvSafelyIfOnWindows({
+        FORCE_COLOR:
+          process.stdout.isTTY && process.env.FORCE_COLOR === undefined
+            ? 'true'
+            : process.env.FORCE_COLOR,
         PATH: this.#pathEnvironmentVariable,
       }),
       // Set "detached" on Linux and macOS so that we create a new process


### PR DESCRIPTION
### Background
As discussed in #56, some tools produce different output when they detect that they're not run with a text terminal attached (TTY), most commonly causing colours to be removed from the output.

Since using `nx` [doesn't seem to change terminal output](https://nx.dev/more-concepts/turbo-and-nx#10.-transparency) I decided to look into how they deal with it, and as far as I can tell it seems they're just [setting the `FORCE_COLOR` environment variable to `true`](https://github.com/nrwl/nx/blob/master/packages/nx/src/tasks-runner/forked-process-task-runner.ts#L131).

While just setting `FORCE_COLOR` doesn't trick processes into thinking they are attached to a TTY, it does enable coloured output for processes which check for it (for example Next.js's build command). To simulate a real TTY and still be able to capture stdout we would have to use something like [node-pty](https://github.com/microsoft/node-pty), which would be a big change, and quite frankly might not be worth the overhead.

### This PR
This PR sets `FORCE_COLOR` to `true` if it's not already set, and also just to be sure checks if stdout is attached to a TTY using Node's built in `process.stdout.isTTY`.

Fixes #56 