### PR TITLE
Add single task debounce to watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where a redundant extra run could be triggered in watch mode when
+  multiple scripts were watching the same file(s).
+
 ### Changed
 
 - stdout color output is now forced when Wireit is run with a text terminal

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -163,6 +163,9 @@ export class Watcher {
   }
 
   #startDebounce(): void {
+    if (this.#debounceTimeoutId !== undefined) {
+      throw new Error('Expected #debounceTimeoutId to be undefined');
+    }
     this.#debounceTimeoutId = setTimeout(() => {
       this.#onDebounced();
     }, DEBOUNCE_MS);


### PR DESCRIPTION
File change events are now debounced using a `setTimeout` with 0ms. In the future we could maybe make this a user-controlled parameter, but the immediate purpose is to solve a bug I noticed while setting up the webcomponents.org dev configuration.

The bug was that if multiple scripts have the same input files, then because in watch mode we register a filesystem watcher for *each of those scripts* *, when a common file changed, we'd start a run from the first event, and then immediately queue up a second run from the second event. Now we wait a task before running, so the two events get batched.

For a build with good caching configuration, this would usually cause a no-op second build -- but that's quite annoying because of the console spam. For a build without caching, this would cause a fully redundant build.

**(We could potentially register fewer watchers by noticing when input files are the same across scripts, but note that different globs can match the same file, so it's often not possible to do this, and the bug would still exist.)*