### PR TITLE
Remove test-rig tempfix for Windows

### DIFF
--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -270,15 +270,7 @@ class ExecResult {
         code,
         signal,
         stdout: this._stdout,
-        // TODO(aomarks) Temporary fix for
-        // https://github.com/npm/cli/issues/4980#issuecomment-1145334203.
-        // Remove when resolved.
-        stderr: IS_WINDOWS
-          ? this._stderr.replace(
-              /npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.\n/,
-              ''
-            )
-          : this._stderr,
+        stderr: this._stderr,
       });
     });
 


### PR DESCRIPTION
Remove the temp fix introduced in #290.
The latest versions of npm shipping in the Github actions runners no longer cause the original issue.