### PR TITLE
Remove Alpha warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
 - ♻️ Cache output locally and remotely on GitHub Actions for free
 - 🛠️ Works with single packages, npm workspaces, and other monorepos
 
-## Alpha
-
-> ### 🚧 Wireit is alpha software — in active but early development. You are welcome to try it out, but note there a number of [missing features and issues](https://github.com/google/wireit/issues) that you may run into! 🚧
-
 ## Contents
 
 - [Features](#features)


### PR DESCRIPTION
I don't think we need it anymore. There are features to add, but the features we have are quite stable and proved out now.