### PR TITLE
Services: Config types, events, stub execution class, and started promise

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1082,19 +1082,44 @@ export class Analyzer {
       };
       return {ok: false, error: this._markAsInvalid(config, failure)};
     }
-    {
-      const validConfig: ScriptConfig = {
+
+    let validConfig: ScriptConfig;
+    if (config.service) {
+      // We should already have created an invalid script at this point, so we
+      // should never get here. We throw here to convince TypeScript that this
+      // is guaranteed.
+      if (config.command === undefined) {
+        throw new Error(
+          'Internal error: Supposedly valid service did not have command'
+        );
+      }
+      validConfig = {
         ...config,
-        extraArgs: undefined,
         state: 'valid',
+        extraArgs: undefined,
         dependencies: config.dependencies as Array<Dependency<ScriptConfig>>,
+        // Unfortunately TypeScript doesn't narrow the ...config spread, so we
+        // have to assign explicitly.
+        command: config.command,
       };
-      // We want to keep the original reference, but get type checking that
-      // the only difference between a ScriptConfig and a
-      // LocallyValidScriptConfig is that the state is 'valid' and the
-      // dependencies are also valid, which we confirmed above.
-      Object.assign(config, validConfig);
+    } else {
+      validConfig = {
+        ...config,
+        state: 'valid',
+        extraArgs: undefined,
+        dependencies: config.dependencies as Array<Dependency<ScriptConfig>>,
+        // Unfortunately TypeScript doesn't narrow the ...config spread, so we
+        // have to assign explicitly.
+        service: config.service,
+      };
     }
+
+    // We want to keep the original reference, but get type checking that
+    // the only difference between a ScriptConfig and a
+    // LocallyValidScriptConfig is that the state is 'valid' and the
+    // dependencies are also valid, which we confirmed above.
+    Object.assign(config, validConfig);
+
     return {ok: true, value: config as unknown as ScriptConfig};
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,10 @@ export interface Dependency<Config extends PotentiallyValidScriptConfig> {
   astNode: JsonAstNode<string>;
 }
 
-export type ScriptConfig = NoCommandScriptConfig | StandardScriptConfig;
+export type ScriptConfig =
+  | NoCommandScriptConfig
+  | StandardScriptConfig
+  | ServiceScriptConfig;
 
 /**
  * A script that doesn't run or produce anything. A pass-through for
@@ -58,6 +61,7 @@ export type ScriptConfig = NoCommandScriptConfig | StandardScriptConfig;
 export interface NoCommandScriptConfig extends BaseScriptConfig {
   command: undefined;
   extraArgs: undefined;
+  service: false;
 }
 
 /**
@@ -65,7 +69,18 @@ export interface NoCommandScriptConfig extends BaseScriptConfig {
  */
 export interface StandardScriptConfig
   extends BaseScriptConfig,
-    ScriptReferenceWithCommand {}
+    ScriptReferenceWithCommand {
+  service: false;
+}
+
+/**
+ * A service script.
+ */
+export interface ServiceScriptConfig
+  extends BaseScriptConfig,
+    ScriptReferenceWithCommand {
+  service: true;
+}
 
 /**
  * The name and location of a script, along with its full configuration.

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,21 @@ export interface ScriptReference extends PackageReference {
   name: string;
 }
 
+/**
+ * A script with a defined command.
+ */
+export interface ScriptReferenceWithCommand extends ScriptReference {
+  /**
+   * The shell command to execute.
+   */
+  command: JsonAstNode<string>;
+
+  /**
+   * Extra arguments to pass to the command.
+   */
+  extraArgs: string[] | undefined;
+}
+
 export interface Dependency<Config extends PotentiallyValidScriptConfig> {
   config: Config;
   astNode: JsonAstNode<string>;
@@ -48,17 +63,9 @@ export interface NoCommandScriptConfig extends BaseScriptConfig {
 /**
  * A script with a command that exits by itself.
  */
-export interface StandardScriptConfig extends BaseScriptConfig {
-  /**
-   * The shell command to execute.
-   */
-  command: JsonAstNode<string>;
-
-  /**
-   * Extra arguments to pass to the command.
-   */
-  extraArgs: string[] | undefined;
-}
+export interface StandardScriptConfig
+  extends BaseScriptConfig,
+    ScriptReferenceWithCommand {}
 
 /**
  * The name and location of a script, along with its full configuration.

--- a/src/event.ts
+++ b/src/event.ts
@@ -90,7 +90,8 @@ export type Failure =
   | UnknownErrorThrown
   | DependencyOnMissingPackageJson
   | DependencyOnMissingScript
-  | DependencyInvalid;
+  | DependencyInvalid
+  | ServiceExitedUnexpectedly;
 
 interface ErrorBase<T extends PackageReference> extends EventBase<T> {
   type: 'failure';
@@ -242,6 +243,13 @@ export interface DependencyOnMissingScript extends ErrorBase<ScriptReference> {
 }
 
 /**
+ * A service exited before it was supposed to.
+ */
+export interface ServiceExitedUnexpectedly extends ErrorBase<ScriptReference> {
+  reason: 'service-exited-unexpectedly';
+}
+
+/**
  * We reached the point of doing cyclic dependency checking, and one of our
  * transitive dependencies had not transitioned to being locally validated.
  * This should generally only happen if we ignored the diagnostics after
@@ -308,6 +316,8 @@ type Info =
   | OutputModified
   | WatchRunStart
   | WatchRunEnd
+  | ServiceStarted
+  | ServiceStopped
   | GenericInfo;
 
 interface InfoBase<T extends ScriptReference> extends EventBase<T> {
@@ -350,6 +360,20 @@ export interface WatchRunStart extends InfoBase<ScriptReference> {
  */
 export interface WatchRunEnd extends InfoBase<ScriptReference> {
   detail: 'watch-run-end';
+}
+
+/**
+ * A service started running.
+ */
+export interface ServiceStarted extends InfoBase<ScriptReference> {
+  detail: 'service-started';
+}
+
+/**
+ * A service stopped running.
+ */
+export interface ServiceStopped extends InfoBase<ScriptReference> {
+  detail: 'service-stopped';
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -9,6 +9,7 @@ import {Diagnostic} from './error.js';
 import type {
   ScriptConfig,
   ScriptReference,
+  ScriptReferenceWithCommand,
   PackageReference,
 } from './config.js';
 
@@ -20,7 +21,7 @@ import type {
  */
 export type Event = Success | Failure | Output | Info;
 
-interface EventBase<T extends PackageReference> {
+interface EventBase<T extends PackageReference = ScriptReference> {
   script: T;
   diagnostic?: Diagnostic;
   diagnostics?: Diagnostic[];
@@ -32,35 +33,36 @@ interface EventBase<T extends PackageReference> {
 
 type Success = ExitZero | NoCommand | Fresh | Cached;
 
-interface SuccessBase<T extends PackageReference> extends EventBase<T> {
+interface SuccessBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'success';
 }
 
 /**
  * A script finished with exit code 0.
  */
-export interface ExitZero extends SuccessBase<ScriptConfig> {
+export interface ExitZero extends SuccessBase {
   reason: 'exit-zero';
 }
 
 /**
  * A script completed because it had no command and its dependencies completed.
  */
-export interface NoCommand extends SuccessBase<ScriptConfig> {
+export interface NoCommand extends SuccessBase {
   reason: 'no-command';
 }
 
 /**
  * A script was already fresh so it didn't need to execute.
  */
-export interface Fresh extends SuccessBase<ScriptConfig> {
+export interface Fresh extends SuccessBase {
   reason: 'fresh';
 }
 
 /**
  * Script output was restored from cache.
  */
-export interface Cached extends SuccessBase<ScriptConfig> {
+export interface Cached extends SuccessBase {
   reason: 'cached';
 }
 
@@ -93,14 +95,15 @@ export type Failure =
   | DependencyInvalid
   | ServiceExitedUnexpectedly;
 
-interface ErrorBase<T extends PackageReference> extends EventBase<T> {
+interface ErrorBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'failure';
 }
 
 /**
  * A script finished with an exit status that was not 0.
  */
-export interface ExitNonZero extends ErrorBase<ScriptConfig> {
+export interface ExitNonZero extends ErrorBase {
   reason: 'exit-non-zero';
   status: number;
 }
@@ -108,7 +111,7 @@ export interface ExitNonZero extends ErrorBase<ScriptConfig> {
 /**
  * A script exited because of a signal it received.
  */
-export interface ExitSignal extends ErrorBase<ScriptConfig> {
+export interface ExitSignal extends ErrorBase {
   reason: 'signal';
   signal: NodeJS.Signals;
 }
@@ -116,7 +119,7 @@ export interface ExitSignal extends ErrorBase<ScriptConfig> {
 /**
  * An error occured trying to spawn a script's command.
  */
-export interface SpawnError extends ErrorBase<ScriptReference> {
+export interface SpawnError extends ErrorBase {
   reason: 'spawn-error';
   message: string;
 }
@@ -125,14 +128,14 @@ export interface SpawnError extends ErrorBase<ScriptReference> {
  * We decided not to start a script after all, due to e.g. another script
  * failure.
  */
-export interface StartCancelled extends ErrorBase<ScriptReference> {
+export interface StartCancelled extends ErrorBase {
   reason: 'start-cancelled';
 }
 
 /**
  * A script was intentionally and successfully killed by Wireit.
  */
-export interface Killed extends ErrorBase<ScriptReference> {
+export interface Killed extends ErrorBase {
   reason: 'killed';
 }
 
@@ -163,15 +166,14 @@ export interface PackageJsonParseError extends ErrorBase<PackageReference> {
 /**
  * The package.json doesn't have a "scripts" object at all.
  */
-export interface NoScriptsSectionInPackageJson
-  extends ErrorBase<ScriptReference> {
+export interface NoScriptsSectionInPackageJson extends ErrorBase {
   reason: 'no-scripts-in-package-json';
 }
 
 /**
  * The specified script does not exist in a package.json.
  */
-export interface ScriptNotFound extends ErrorBase<ScriptReference> {
+export interface ScriptNotFound extends ErrorBase {
   reason: 'script-not-found';
   diagnostic: Diagnostic;
 }
@@ -180,8 +182,7 @@ export interface ScriptNotFound extends ErrorBase<ScriptReference> {
  * The specified script has a wireit config, but it isn't declared in the
  * scripts section at all.
  */
-export interface WireitScriptNotInScriptsSection
-  extends ErrorBase<ScriptReference> {
+export interface WireitScriptNotInScriptsSection extends ErrorBase {
   reason: 'wireit-config-but-no-script';
   diagnostic: Diagnostic;
 }
@@ -189,7 +190,7 @@ export interface WireitScriptNotInScriptsSection
 /**
  * The specified script's command is not "wireit".
  */
-export interface ScriptNotWireit extends ErrorBase<ScriptReference> {
+export interface ScriptNotWireit extends ErrorBase {
   reason: 'script-not-wireit';
   diagnostic: Diagnostic;
 }
@@ -202,7 +203,7 @@ export interface InvalidConfigSyntax extends ErrorBase<PackageReference> {
   diagnostic: Diagnostic;
 }
 
-export interface InvalidUsage extends ErrorBase<ScriptReference> {
+export interface InvalidUsage extends ErrorBase {
   reason: 'invalid-usage';
   message: string;
 }
@@ -210,7 +211,7 @@ export interface InvalidUsage extends ErrorBase<ScriptReference> {
 /**
  * A script lists the same dependency multiple times.
  */
-export interface DuplicateDependency extends ErrorBase<ScriptReference> {
+export interface DuplicateDependency extends ErrorBase {
   reason: 'duplicate-dependency';
   /**
    * The dependency that is duplicated.
@@ -222,8 +223,7 @@ export interface DuplicateDependency extends ErrorBase<ScriptReference> {
 /**
  * A script depends on another in a package that isn't there.
  */
-export interface DependencyOnMissingPackageJson
-  extends ErrorBase<ScriptReference> {
+export interface DependencyOnMissingPackageJson extends ErrorBase {
   reason: 'dependency-on-missing-package-json';
   diagnostic: Diagnostic;
   /**
@@ -236,7 +236,7 @@ export interface DependencyOnMissingPackageJson
 /**
  * A script's dependency doesn't exist.
  */
-export interface DependencyOnMissingScript extends ErrorBase<ScriptReference> {
+export interface DependencyOnMissingScript extends ErrorBase {
   reason: 'dependency-on-missing-script';
   diagnostic: Diagnostic;
   supercedes: ScriptNotFound;
@@ -245,7 +245,7 @@ export interface DependencyOnMissingScript extends ErrorBase<ScriptReference> {
 /**
  * A service exited before it was supposed to.
  */
-export interface ServiceExitedUnexpectedly extends ErrorBase<ScriptReference> {
+export interface ServiceExitedUnexpectedly extends ErrorBase {
   reason: 'service-exited-unexpectedly';
 }
 
@@ -259,7 +259,7 @@ export interface ServiceExitedUnexpectedly extends ErrorBase<ScriptReference> {
  * continue to cycle detection even when some diagnostics were generated during
  * local analysis.
  */
-export interface DependencyInvalid extends ErrorBase<ScriptReference> {
+export interface DependencyInvalid extends ErrorBase {
   reason: 'dependency-invalid';
   dependency: UnvalidatedConfig;
 }
@@ -267,7 +267,7 @@ export interface DependencyInvalid extends ErrorBase<ScriptReference> {
 /**
  * The dependency graph has a cycle in it.
  */
-export interface Cycle extends ErrorBase<ScriptReference> {
+export interface Cycle extends ErrorBase {
   reason: 'cycle';
 
   diagnostic: Diagnostic;
@@ -276,7 +276,7 @@ export interface Cycle extends ErrorBase<ScriptReference> {
 /**
  * For when we catch an error not handled by any of the other types.
  */
-export interface UnknownErrorThrown extends ErrorBase<ScriptReference> {
+export interface UnknownErrorThrown extends ErrorBase {
   reason: 'unknown-error-thrown';
   error: unknown;
 }
@@ -320,14 +320,15 @@ type Info =
   | ServiceStopped
   | GenericInfo;
 
-interface InfoBase<T extends ScriptReference> extends EventBase<T> {
+interface InfoBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'info';
 }
 
 /**
  * A script's command started running.
  */
-export interface ScriptRunning extends InfoBase<ScriptConfig> {
+export interface ScriptRunning extends InfoBase<ScriptReferenceWithCommand> {
   detail: 'running';
 }
 
@@ -335,7 +336,7 @@ export interface ScriptRunning extends InfoBase<ScriptConfig> {
  * A script can't run right now because a system-wide lock is being held by
  * another process.
  */
-export interface ScriptLocked extends InfoBase<ScriptConfig> {
+export interface ScriptLocked extends InfoBase {
   detail: 'locked';
 }
 
@@ -344,42 +345,42 @@ export interface ScriptLocked extends InfoBase<ScriptConfig> {
  * stale, because one or more output files from the previous run have been
  * added, removed, or changed.
  */
-export interface OutputModified extends InfoBase<ScriptConfig> {
+export interface OutputModified extends InfoBase {
   detail: 'output-modified';
 }
 
 /**
  * A watch mode iteration started.
  */
-export interface WatchRunStart extends InfoBase<ScriptReference> {
+export interface WatchRunStart extends InfoBase {
   detail: 'watch-run-start';
 }
 
 /**
  * A watch mode iteration ended.
  */
-export interface WatchRunEnd extends InfoBase<ScriptReference> {
+export interface WatchRunEnd extends InfoBase {
   detail: 'watch-run-end';
 }
 
 /**
  * A service started running.
  */
-export interface ServiceStarted extends InfoBase<ScriptReference> {
+export interface ServiceStarted extends InfoBase {
   detail: 'service-started';
 }
 
 /**
  * A service stopped running.
  */
-export interface ServiceStopped extends InfoBase<ScriptReference> {
+export interface ServiceStopped extends InfoBase {
   detail: 'service-stopped';
 }
 
 /**
  * A generic info event.
  */
-export interface GenericInfo extends InfoBase<ScriptReference> {
+export interface GenericInfo extends InfoBase {
   detail: 'generic';
   message: string;
 }

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseExecution} from './base.js';
+import {Fingerprint} from '../fingerprint.js';
+
+import type {ExecutionResult} from './base.js';
+import type {Executor} from '../executor.js';
+import type {ServiceScriptConfig} from '../config.js';
+import type {Logger} from '../logging/logger.js';
+
+/**
+ * Execution for a {@link ServiceScriptConfig}.
+ */
+export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
+  static execute(
+    script: ServiceScriptConfig,
+    executor: Executor,
+    logger: Logger
+  ): Promise<ExecutionResult> {
+    return new ServiceScriptExecution(script, executor, logger)._execute();
+  }
+
+  private async _execute(): Promise<ExecutionResult> {
+    const dependencyFingerprints = await this.executeDependencies();
+    if (!dependencyFingerprints.ok) {
+      return dependencyFingerprints;
+    }
+    const fingerprint = await Fingerprint.compute(
+      this.script,
+      dependencyFingerprints.value
+    );
+    return {ok: true, value: fingerprint};
+  }
+
+  // TODO(aomarks) Implement service starting/stopping.
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,6 +6,7 @@
 
 import {NoCommandScriptExecution} from './execution/no-command.js';
 import {StandardScriptExecution} from './execution/standard.js';
+import {ServiceScriptExecution} from './execution/service.js';
 import {ScriptConfig, scriptReferenceToString} from './config.js';
 import {WorkerPool} from './util/worker-pool.js';
 import {Deferred} from './util/deferred.js';
@@ -133,6 +134,9 @@ export class Executor {
   ): Promise<ExecutionResult> {
     if (script.command === undefined) {
       return NoCommandScriptExecution.execute(script, this, this._logger);
+    }
+    if (script.service) {
+      return ServiceScriptExecution.execute(script, this, this._logger);
     }
     return StandardScriptExecution.execute(
       script,

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -198,6 +198,11 @@ export class DefaultLogger implements Logger {
                 event.dependency
               )} which could not be validated. Please file a bug at https://github.com/google/wireit/issues/new, mention this message, that you encountered it in wireit version ${getWireitVersion()}, and give information about your package.json files.`
             );
+            break;
+          }
+          case 'service-exited-unexpectedly': {
+            console.error(`❌${prefix} Service exited unexpectedly`);
+            break;
           }
         }
         break;
@@ -273,6 +278,14 @@ export class DefaultLogger implements Logger {
           }
           case 'generic': {
             console.log(`ℹ️${prefix} ${event.message}`);
+            break;
+          }
+          case 'service-started': {
+            console.log(`⬆️${prefix} Service started`);
+            break;
+          }
+          case 'service-stopped': {
+            console.log(`⬇️${prefix} Service stopped`);
             break;
           }
         }

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -13,7 +13,7 @@ import {
 import {Deferred} from './util/deferred.js';
 
 import type {Result} from './error.js';
-import type {ScriptConfig} from './config.js';
+import type {ScriptReferenceWithCommand} from './config.js';
 import type {ChildProcessWithoutNullStreams} from 'child_process';
 import type {ExitNonZero, ExitSignal, SpawnError, Killed} from './event.js';
 
@@ -46,17 +46,10 @@ export type ScriptChildProcessState =
   | 'stopped';
 
 /**
- * A script config but the command is required.
- */
-type ScriptConfigWithRequiredCommand = ScriptConfig & {
-  command: Exclude<ScriptConfig['command'], undefined>;
-};
-
-/**
  * A child process spawned during execution of a script.
  */
 export class ScriptChildProcess {
-  private readonly _script: ScriptConfigWithRequiredCommand;
+  private readonly _script: ScriptReferenceWithCommand;
   private readonly _child: ChildProcessWithoutNullStreams;
   private readonly _started = new Deferred<Result<void, SpawnError>>();
   private readonly _completed = new Deferred<
@@ -88,13 +81,21 @@ export class ScriptChildProcess {
     return this._child.stderr;
   }
 
-  constructor(script: ScriptConfigWithRequiredCommand) {
-    this._script = script;
+  constructor(script: ScriptReferenceWithCommand) {
+    // Copy only the fields we actually require from the script config, because
+    // the full script config contains references to the full config, which we
+    // want to allow to be garbage-collected across watch iterations.
+    this._script = {
+      packageDir: script.packageDir,
+      name: script.name,
+      command: script.command,
+      extraArgs: script.extraArgs,
+    };
 
     // TODO(aomarks) Update npm_ environment variables to reflect the new
     // package.
-    this._child = spawn(script.command.value, script.extraArgs, {
-      cwd: script.packageDir,
+    this._child = spawn(this._script.command.value, this._script.extraArgs, {
+      cwd: this._script.packageDir,
       // Conveniently, "shell:true" has the same shell-selection behavior as
       // "npm run", where on macOS and Linux it is "sh", and on Windows it is
       // %COMSPEC% || "cmd.exe".


### PR DESCRIPTION
1. Added a `started` promise property to `ScriptChildProcess`. We'll be re-using this class for services, and we'll need to know when a child process has spawned. We didn't need that exposed before, because all that mattered was the exit code.

2. Added events and logging specific to services.

3. Refactored the config types so that classes can hold copies of just a subset of the fields of a config, instead of the full object. In watch mode, service child processes will get handed-off _across iterations_, and potentially _across different build graphs_, so I wanted to make sure we don't have a memory leak relating to keeping around references to old build graphs (configs hold references to their dependencies, so potentially that keeps the full build graph live).

4. Added a `ServiceScriptConfig` which is guaranteed to have `service:false`, and a stub `ServiceScriptExecution` which currently can produce a fingerprint, but doesn't yet actually start/stop the service command.

More incremental work towards [services](https://github.com/google/wireit/issues/33).
