### PR TITLE
Services: Add service-related analysis properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       "output": []
     },
     "test:basic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"basic\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^basic\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -126,7 +126,7 @@
       "output": []
     },
     "test:cache-github": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cache-github\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-github\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -134,7 +134,7 @@
       "output": []
     },
     "test:cache-local": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cache-local\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-local\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -142,7 +142,7 @@
       "output": []
     },
     "test:clean": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"clean\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^clean\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -150,7 +150,7 @@
       "output": []
     },
     "test:cli-options": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cli-options\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cli-options\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -158,7 +158,7 @@
       "output": []
     },
     "test:codeactions": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"codeactions\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^codeactions\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -166,7 +166,7 @@
       "output": []
     },
     "test:copy": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"copy\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^copy\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -174,7 +174,7 @@
       "output": []
     },
     "test:delete": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"delete\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^delete\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -182,7 +182,7 @@
       "output": []
     },
     "test:diagnostic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"diagnostic\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^diagnostic\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -190,7 +190,7 @@
       "output": []
     },
     "test:errors-analysis": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"errors-analysis\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-analysis\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -198,7 +198,7 @@
       "output": []
     },
     "test:errors-usage": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"errors-usage\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-usage\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -206,7 +206,7 @@
       "output": []
     },
     "test:failures": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"failures\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^failures\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -214,7 +214,7 @@
       "output": []
     },
     "test:freshness": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"freshness\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^freshness\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -222,7 +222,7 @@
       "output": []
     },
     "test:glob": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"glob\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^glob\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -230,7 +230,7 @@
       "output": []
     },
     "test:ide": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"ide\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^ide\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -238,7 +238,7 @@
       "output": []
     },
     "test:json-schema": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"json-schema\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^json-schema\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -248,7 +248,7 @@
       "output": []
     },
     "test:optimize-mkdirs": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"optimize-mkdirs\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^optimize-mkdirs\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -256,7 +256,7 @@
       "output": []
     },
     "test:parallelism": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"parallelism\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^parallelism\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -264,7 +264,7 @@
       "output": []
     },
     "test:service": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"service\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^service\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -272,7 +272,7 @@
       "output": []
     },
     "test:watch": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"watch\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^watch\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "format:check": "prettier . -c",
     "test": "wireit",
     "test:headless": "wireit",
+    "test:analysis": "wireit",
     "test:basic": "wireit",
     "test:cache-github": "wireit",
     "test:cache-local": "wireit",
@@ -71,6 +72,7 @@
     },
     "test:headless": {
       "dependencies": [
+        "test:analysis",
         "test:basic",
         "test:cache-github",
         "test:cache-local",
@@ -105,6 +107,14 @@
         "src/**/*.ts",
         "vscode-extension/src/**/*.ts"
       ],
+      "output": []
+    },
+    "test:analysis": {
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^analysis\\.test\\.js$\"",
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
       "output": []
     },
     "test:basic": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -493,7 +493,7 @@ export class Analyzer {
       scriptAstNode: scriptCommand,
       configAstNode: wireitConfig,
       declaringFile: packageJson.jsonFile,
-      effectiveServiceDependencies: [],
+      services: [],
     };
     Object.assign(placeholder, remainingConfig);
   }
@@ -1086,12 +1086,12 @@ export class Analyzer {
         const validDependencyConfig = validDependencyConfigResult.value;
         if (validDependencyConfig.service) {
           // We directly depend on a service.
-          config.effectiveServiceDependencies.push(validDependencyConfig);
+          config.services.push(validDependencyConfig);
         } else if (validDependencyConfig.command === undefined) {
           // We depend on a no-command script, so in effect we depend on all of
           // the services it depends on.
-          for (const service of validDependencyConfig.effectiveServiceDependencies) {
-            config.effectiveServiceDependencies.push(service);
+          for (const service of validDependencyConfig.services) {
+            config.services.push(service);
           }
         }
       }
@@ -1129,7 +1129,7 @@ export class Analyzer {
         // have to assign explicitly.
         command: config.command,
         isDirectlyInvoked,
-        reverseEffectiveServiceDependencies: [],
+        serviceConsumers: [],
       };
     } else {
       validConfig = {
@@ -1147,13 +1147,10 @@ export class Analyzer {
     if (validConfig.command) {
       for (const dependency of validConfig.dependencies) {
         if (dependency.config.service) {
-          dependency.config.reverseEffectiveServiceDependencies.push(
-            validConfig
-          );
+          dependency.config.serviceConsumers.push(validConfig);
         } else if (dependency.config.command === undefined) {
-          for (const service of dependency.config
-            .effectiveServiceDependencies) {
-            service.reverseEffectiveServiceDependencies.push(validConfig);
+          for (const service of dependency.config.services) {
+            service.serviceConsumers.push(validConfig);
           }
         }
       }

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1129,6 +1129,7 @@ export class Analyzer {
         // have to assign explicitly.
         command: config.command,
         isDirectlyInvoked,
+        reverseEffectiveServiceDependencies: [],
       };
     } else {
       validConfig = {
@@ -1140,6 +1141,22 @@ export class Analyzer {
         // have to assign explicitly.
         service: config.service,
       };
+    }
+
+    // Propagate reverse service dependencies.
+    if (validConfig.command) {
+      for (const dependency of validConfig.dependencies) {
+        if (dependency.config.service) {
+          dependency.config.reverseEffectiveServiceDependencies.push(
+            validConfig
+          );
+        } else if (dependency.config.command === undefined) {
+          for (const service of dependency.config
+            .effectiveServiceDependencies) {
+            service.reverseEffectiveServiceDependencies.push(validConfig);
+          }
+        }
+      }
     }
 
     // We want to keep the original reference, but get type checking that

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,11 @@ export interface ServiceScriptConfig
   extends BaseScriptConfig,
     ScriptReferenceWithCommand {
   service: true;
+
+  /**
+   * Whether this service is being invoked directly (e.g. `npm run serve`).
+   */
+  isDirectlyInvoked: boolean;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,14 +87,9 @@ export interface ServiceScriptConfig
   isDirectlyInvoked: boolean;
 
   /**
-   * Which scripts depend on this service.
-   *
-   * "Effective" meaning these are not necessarily our direct dependents, since
-   * we include transitive service dependencies through no-command scripts.
+   * Scripts that depend on this service.
    */
-  reverseEffectiveServiceDependencies: Array<
-    ServiceScriptConfig | StandardScriptConfig
-  >;
+  serviceConsumers: Array<ServiceScriptConfig | StandardScriptConfig>;
 }
 
 /**
@@ -114,12 +109,8 @@ interface BaseScriptConfig extends ScriptReference {
 
   /**
    * The services that need to be started before we can run.
-   *
-   * "Effective" meaning these are not necessarily direct dependencies, since we
-   * include transitive service dependencies through no-command scripts as our
-   * own.
    */
-  effectiveServiceDependencies: Array<ServiceScriptConfig>;
+  services: Array<ServiceScriptConfig>;
 
   /**
    * Input file globs for this script.

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,16 @@ export interface ServiceScriptConfig
    * Whether this service is being invoked directly (e.g. `npm run serve`).
    */
   isDirectlyInvoked: boolean;
+
+  /**
+   * Which scripts depend on this service.
+   *
+   * "Effective" meaning these are not necessarily our direct dependents, since
+   * we include transitive service dependencies through no-command scripts.
+   */
+  reverseEffectiveServiceDependencies: Array<
+    ServiceScriptConfig | StandardScriptConfig
+  >;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,15 @@ interface BaseScriptConfig extends ScriptReference {
   dependencies: Array<Dependency<ScriptConfig>>;
 
   /**
+   * The services that need to be started before we can run.
+   *
+   * "Effective" meaning these are not necessarily direct dependencies, since we
+   * include transitive service dependencies through no-command scripts as our
+   * own.
+   */
+  effectiveServiceDependencies: Array<ServiceScriptConfig>;
+
+  /**
    * Input file globs for this script.
    *
    * If undefined, the input files are unknown (meaning the script cannot safely

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+import {WireitTestRig} from './util/test-rig.js';
+import {Analyzer} from '../analyzer.js';
+
+const test = suite<{rig: WireitTestRig}>();
+
+test.before.each(async (ctx) => {
+  try {
+    ctx.rig = new WireitTestRig();
+    await ctx.rig.setup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu before error', error);
+    process.exit(1);
+  }
+});
+
+test.after.each(async (ctx) => {
+  try {
+    await ctx.rig.cleanup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu after error', error);
+    process.exit(1);
+  }
+});
+
+test('analyzes services', async ({rig}) => {
+  //    a
+  //  / | \
+  // |  v  v
+  // |  c  d
+  // |    / |
+  // b <-+  |
+  //        v
+  //        e
+  await rig.write({
+    'package.json': {
+      scripts: {
+        a: 'wireit',
+        b: 'wireit',
+        c: 'wireit',
+        d: 'wireit',
+        e: 'wireit',
+      },
+      wireit: {
+        a: {
+          dependencies: ['b', 'c', 'd'],
+        },
+        b: {
+          command: 'true',
+          service: true,
+        },
+        c: {
+          command: 'true',
+          service: true,
+        },
+        d: {
+          command: 'true',
+          dependencies: ['b', 'e'],
+        },
+        e: {
+          command: 'true',
+          service: true,
+        },
+      },
+    },
+  });
+
+  const analyzer = new Analyzer();
+  const result = await analyzer.analyze({packageDir: rig.temp, name: 'a'}, []);
+  if (!result.config.ok) {
+    console.log(result.config.error);
+    throw new Error('Not ok');
+  }
+
+  // a
+  const a = result.config.value;
+  assert.equal(a.name, 'a');
+  if (a.command) {
+    throw new Error('Expected no-command');
+  }
+  assert.equal(a.dependencies.length, 3);
+
+  // b
+  const b = a.dependencies[0].config;
+  assert.equal(b.name, 'b');
+  if (!b.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(b.reverseEffectiveServiceDependencies.length, 1);
+  assert.equal(b.reverseEffectiveServiceDependencies[0].name, 'd');
+  assert.equal(b.isDirectlyInvoked, true);
+
+  // c
+  const c = a.dependencies[1].config;
+  assert.equal(c.name, 'c');
+  if (!c.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(c.isDirectlyInvoked, true);
+  assert.equal(c.reverseEffectiveServiceDependencies.length, 0);
+  assert.equal(c.effectiveServiceDependencies.length, 0);
+
+  // d
+  const d = a.dependencies[2].config;
+  assert.equal(d.name, 'd');
+  assert.equal(d.effectiveServiceDependencies.length, 2);
+  assert.equal(d.effectiveServiceDependencies[0].name, 'b');
+  assert.equal(d.effectiveServiceDependencies[1].name, 'e');
+
+  // e
+  const e = d.effectiveServiceDependencies[1];
+  assert.equal(e.name, 'e');
+  if (!e.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(e.isDirectlyInvoked, false);
+  assert.equal(e.reverseEffectiveServiceDependencies.length, 1);
+});
+
+test.run();

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -97,8 +97,8 @@ test('analyzes services', async ({rig}) => {
   if (!b.service) {
     throw new Error('Expected service');
   }
-  assert.equal(b.reverseEffectiveServiceDependencies.length, 1);
-  assert.equal(b.reverseEffectiveServiceDependencies[0].name, 'd');
+  assert.equal(b.serviceConsumers.length, 1);
+  assert.equal(b.serviceConsumers[0].name, 'd');
   assert.equal(b.isDirectlyInvoked, true);
 
   // c
@@ -108,24 +108,24 @@ test('analyzes services', async ({rig}) => {
     throw new Error('Expected service');
   }
   assert.equal(c.isDirectlyInvoked, true);
-  assert.equal(c.reverseEffectiveServiceDependencies.length, 0);
-  assert.equal(c.effectiveServiceDependencies.length, 0);
+  assert.equal(c.serviceConsumers.length, 0);
+  assert.equal(c.services.length, 0);
 
   // d
   const d = a.dependencies[2].config;
   assert.equal(d.name, 'd');
-  assert.equal(d.effectiveServiceDependencies.length, 2);
-  assert.equal(d.effectiveServiceDependencies[0].name, 'b');
-  assert.equal(d.effectiveServiceDependencies[1].name, 'e');
+  assert.equal(d.services.length, 2);
+  assert.equal(d.services[0].name, 'b');
+  assert.equal(d.services[1].name, 'e');
 
   // e
-  const e = d.effectiveServiceDependencies[1];
+  const e = d.services[1];
   assert.equal(e.name, 'e');
   if (!e.service) {
     throw new Error('Expected service');
   }
   assert.equal(e.isDirectlyInvoked, false);
-  assert.equal(e.reverseEffectiveServiceDependencies.length, 1);
+  assert.equal(e.serviceConsumers.length, 1);
 });
 
 test.run();


### PR DESCRIPTION
Adds 3 properties to analysis that are useful for services:

1. `isDirectlyInvoked` tells us whether a service is either the root script, or there's a path from the root script to the service that only passes through no-command scripts (which counts the same way). This is useful because being directly invoked means you should only exit when wireit exits; instead of when all scripts that depend on you have finished.

2. `services` lists the services that must be started before a script can start. This isn't quite as simple as "my dependencies which are services", again because of needing to traverse through no-command scripts.

3. `serviceConsumers` is the reverse of `services`. It's useful for services to know which scripts could *potentially* depend on a script, because once we start a service, we don't want to shut it down until we know that every depending script has either finished, or didn't need to run at all. Knowing how many to expect from the start makes this simpler.

Also adds a unit test that invokes the `Analyzer` directly. All of our other tests are integration, but in this case it's useful to be able to check the analysis result directly.

Also noticed our uvu test patterns were effectively suffix matches, instead of exact matches (I noticed because `analysis\.test\.js$` was accidentally matching both `analysis.test.js` and `errors-analysis.test.js`).

Part of https://github.com/google/wireit/issues/33