### PR TITLE
Services: Refactoring to surface more Execution API to other scripts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       options.failureMode,
       abort
     );
-    const result = await executor.execute(config.value);
+    const result = await executor.getExecution(config.value).execute();
     if (!result.ok) {
       return result;
     }

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -34,7 +34,7 @@ export abstract class BaseExecution<T extends ScriptConfig> {
   protected readonly _logger: Logger;
   private _fingerprint?: Promise<ExecutionResult>;
 
-  protected constructor(config: T, executor: Executor, logger: Logger) {
+  constructor(config: T, executor: Executor, logger: Logger) {
     this._config = config;
     this._executor = executor;
     this._logger = logger;

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -29,12 +29,12 @@ export type FailureMode = 'no-new' | 'continue' | 'kill';
  * A single execution of a specific script.
  */
 export abstract class BaseExecution<T extends ScriptConfig> {
-  protected readonly script: T;
+  protected readonly config: T;
   protected readonly executor: Executor;
   protected readonly logger: Logger;
 
-  protected constructor(script: T, executor: Executor, logger: Logger) {
-    this.script = script;
+  protected constructor(config: T, executor: Executor, logger: Logger) {
+    this.config = config;
     this.executor = executor;
     this.logger = logger;
   }
@@ -48,10 +48,10 @@ export abstract class BaseExecution<T extends ScriptConfig> {
     // Randomize the order we execute dependencies to make it less likely for a
     // user to inadvertently depend on any specific order, which could indicate
     // a missing edge in the dependency graph.
-    shuffle(this.script.dependencies);
+    shuffle(this.config.dependencies);
 
     const dependencyResults = await Promise.all(
-      this.script.dependencies.map((dependency) => {
+      this.config.dependencies.map((dependency) => {
         return this.executor.execute(dependency.config);
       })
     );
@@ -64,7 +64,7 @@ export abstract class BaseExecution<T extends ScriptConfig> {
           errors.add(error);
         }
       } else {
-        results.push([this.script.dependencies[i].config, result.value]);
+        results.push([this.config.dependencies[i].config, result.value]);
       }
     }
     if (errors.size > 0) {

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -32,12 +32,23 @@ export abstract class BaseExecution<T extends ScriptConfig> {
   protected readonly _config: T;
   protected readonly _executor: Executor;
   protected readonly _logger: Logger;
+  private _fingerprint?: Promise<ExecutionResult>;
 
   protected constructor(config: T, executor: Executor, logger: Logger) {
     this._config = config;
     this._executor = executor;
     this._logger = logger;
   }
+
+  /**
+   * Execute this script and return its fingerprint. Cached, so safe to call
+   * multiple times.
+   */
+  execute(): Promise<ExecutionResult> {
+    return (this._fingerprint ??= this._execute());
+  }
+
+  protected abstract _execute(): Promise<ExecutionResult>;
 
   /**
    * Execute all of this script's dependencies.

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -63,7 +63,7 @@ export abstract class BaseExecution<T extends ScriptConfig> {
 
     const dependencyResults = await Promise.all(
       this._config.dependencies.map((dependency) => {
-        return this._executor.execute(dependency.config);
+        return this._executor.getExecution(dependency.config).execute();
       })
     );
     const results: Array<[ScriptReference, Fingerprint]> = [];

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -29,30 +29,30 @@ export type FailureMode = 'no-new' | 'continue' | 'kill';
  * A single execution of a specific script.
  */
 export abstract class BaseExecution<T extends ScriptConfig> {
-  protected readonly config: T;
-  protected readonly executor: Executor;
-  protected readonly logger: Logger;
+  protected readonly _config: T;
+  protected readonly _executor: Executor;
+  protected readonly _logger: Logger;
 
   protected constructor(config: T, executor: Executor, logger: Logger) {
-    this.config = config;
-    this.executor = executor;
-    this.logger = logger;
+    this._config = config;
+    this._executor = executor;
+    this._logger = logger;
   }
 
   /**
    * Execute all of this script's dependencies.
    */
-  protected async executeDependencies(): Promise<
+  protected async _executeDependencies(): Promise<
     Result<Array<[ScriptReference, Fingerprint]>, Failure[]>
   > {
     // Randomize the order we execute dependencies to make it less likely for a
     // user to inadvertently depend on any specific order, which could indicate
     // a missing edge in the dependency graph.
-    shuffle(this.config.dependencies);
+    shuffle(this._config.dependencies);
 
     const dependencyResults = await Promise.all(
-      this.config.dependencies.map((dependency) => {
-        return this.executor.execute(dependency.config);
+      this._config.dependencies.map((dependency) => {
+        return this._executor.execute(dependency.config);
       })
     );
     const results: Array<[ScriptReference, Fingerprint]> = [];
@@ -64,7 +64,7 @@ export abstract class BaseExecution<T extends ScriptConfig> {
           errors.add(error);
         }
       } else {
-        results.push([this.config.dependencies[i].config, result.value]);
+        results.push([this._config.dependencies[i].config, result.value]);
       }
     }
     if (errors.size > 0) {

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -24,7 +24,7 @@ export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfi
     return new NoCommandScriptExecution(config, executor, logger)._execute();
   }
 
-  private async _execute(): Promise<ExecutionResult> {
+  protected override async _execute(): Promise<ExecutionResult> {
     const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -25,16 +25,16 @@ export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfi
   }
 
   private async _execute(): Promise<ExecutionResult> {
-    const dependencyFingerprints = await this.executeDependencies();
+    const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.config,
+      this._config,
       dependencyFingerprints.value
     );
-    this.logger.log({
-      script: this.config,
+    this._logger.log({
+      script: this._config,
       type: 'success',
       reason: 'no-command',
     });

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -17,11 +17,11 @@ import type {Logger} from '../logging/logger.js';
  */
 export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfig> {
   static execute(
-    script: NoCommandScriptConfig,
+    config: NoCommandScriptConfig,
     executor: Executor,
     logger: Logger
   ): Promise<ExecutionResult> {
-    return new NoCommandScriptExecution(script, executor, logger)._execute();
+    return new NoCommandScriptExecution(config, executor, logger)._execute();
   }
 
   private async _execute(): Promise<ExecutionResult> {
@@ -30,11 +30,11 @@ export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfi
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.script,
+      this.config,
       dependencyFingerprints.value
     );
     this.logger.log({
-      script: this.script,
+      script: this.config,
       type: 'success',
       reason: 'no-command',
     });

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -8,22 +8,12 @@ import {BaseExecution} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
-import type {Executor} from '../executor.js';
 import type {NoCommandScriptConfig} from '../config.js';
-import type {Logger} from '../logging/logger.js';
 
 /**
  * Execution for a {@link NoCommandScriptConfig}.
  */
 export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfig> {
-  static execute(
-    config: NoCommandScriptConfig,
-    executor: Executor,
-    logger: Logger
-  ): Promise<ExecutionResult> {
-    return new NoCommandScriptExecution(config, executor, logger)._execute();
-  }
-
   protected override async _execute(): Promise<ExecutionResult> {
     const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -8,23 +8,27 @@ import {BaseExecution} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
-import type {Executor} from '../executor.js';
 import type {ServiceScriptConfig} from '../config.js';
 import type {Logger} from '../logging/logger.js';
+import type {Executor} from '../executor.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
   static execute(
-    config: ServiceScriptConfig,
+    script: ServiceScriptConfig,
     executor: Executor,
     logger: Logger
   ): Promise<ExecutionResult> {
-    return new ServiceScriptExecution(config, executor, logger)._execute();
+    return new ServiceScriptExecution(script, executor, logger)._execute();
   }
 
-  private async _execute(): Promise<ExecutionResult> {
+  /**
+   * Note `execute` is a bit of a misnomer here, because we don't actually
+   * execute the command at this stage in the case of services.
+   */
+  protected override async _execute(): Promise<ExecutionResult> {
     const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -17,11 +17,11 @@ import type {Logger} from '../logging/logger.js';
  */
 export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
   static execute(
-    script: ServiceScriptConfig,
+    config: ServiceScriptConfig,
     executor: Executor,
     logger: Logger
   ): Promise<ExecutionResult> {
-    return new ServiceScriptExecution(script, executor, logger)._execute();
+    return new ServiceScriptExecution(config, executor, logger)._execute();
   }
 
   private async _execute(): Promise<ExecutionResult> {
@@ -30,7 +30,7 @@ export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.script,
+      this.config,
       dependencyFingerprints.value
     );
     return {ok: true, value: fingerprint};

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -9,21 +9,11 @@ import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
-import type {Logger} from '../logging/logger.js';
-import type {Executor} from '../executor.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
-  static execute(
-    script: ServiceScriptConfig,
-    executor: Executor,
-    logger: Logger
-  ): Promise<ExecutionResult> {
-    return new ServiceScriptExecution(script, executor, logger)._execute();
-  }
-
   /**
    * Note `execute` is a bit of a misnomer here, because we don't actually
    * execute the command at this stage in the case of services.

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -25,12 +25,12 @@ export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
   }
 
   private async _execute(): Promise<ExecutionResult> {
-    const dependencyFingerprints = await this.executeDependencies();
+    const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.config,
+      this._config,
       dependencyFingerprints.value
     );
     return {ok: true, value: fingerprint};

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -37,27 +37,11 @@ type StandardScriptExecutionState =
  * Execution for a {@link StandardScriptConfig}.
  */
 export class StandardScriptExecution extends BaseExecution<StandardScriptConfig> {
-  static execute(
-    config: StandardScriptConfig,
-    executor: Executor,
-    workerPool: WorkerPool,
-    cache: Cache | undefined,
-    logger: Logger
-  ): Promise<ExecutionResult> {
-    return new StandardScriptExecution(
-      config,
-      executor,
-      workerPool,
-      cache,
-      logger
-    )._execute();
-  }
-
   private _state: StandardScriptExecutionState = 'before-running';
   private readonly _cache?: Cache;
   private readonly _workerPool: WorkerPool;
 
-  private constructor(
+  constructor(
     config: StandardScriptConfig,
     executor: Executor,
     workerPool: WorkerPool,

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -75,7 +75,7 @@ export class StandardScriptExecution extends BaseExecution<StandardScriptConfig>
     }
   }
 
-  private async _execute(): Promise<ExecutionResult> {
+  protected async _execute(): Promise<ExecutionResult> {
     this._ensureState('before-running');
 
     const dependencyFingerprints = await this._executeDependencies();

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -11,7 +11,6 @@ import {ScriptReferenceString, scriptReferenceToString} from './config.js';
 import {WorkerPool} from './util/worker-pool.js';
 import {Deferred} from './util/deferred.js';
 
-import type {ExecutionResult} from './execution/base.js';
 import type {Logger} from './logging/logger.js';
 import type {Cache} from './caching/cache.js';
 import type {
@@ -157,10 +156,5 @@ export class Executor {
     // execution type guarantees. We could make a smarter Map type, but not
     // really worth it here.
     return execution as ConfigToExecution<T>;
-  }
-
-  async execute(config: ScriptConfig): Promise<ExecutionResult> {
-    const execution = this.getExecution(config);
-    return execution.execute();
   }
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -133,17 +133,17 @@ export class Executor {
     script: ScriptConfig
   ): Promise<ExecutionResult> {
     if (script.command === undefined) {
-      return NoCommandScriptExecution.execute(script, this, this._logger);
+      return new NoCommandScriptExecution(script, this, this._logger).execute();
     }
     if (script.service) {
-      return ServiceScriptExecution.execute(script, this, this._logger);
+      return new ServiceScriptExecution(script, this, this._logger).execute();
     }
-    return StandardScriptExecution.execute(
+    return new StandardScriptExecution(
       script,
       this,
       this._workerPool,
       this._cache,
       this._logger
-    );
+    ).execute();
   }
 }

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -20,9 +20,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = pathlib.dirname(__filename);
 const repoRoot = pathlib.resolve(__dirname, '..', '..');
 
-const SELF_SIGNED_CERT = selfsigned.generate([
-  {name: 'commonName', value: 'localhost'},
-]);
+const SELF_SIGNED_CERT = selfsigned.generate(
+  [{name: 'commonName', value: 'localhost'}],
+  // More recent versions of TLS require a larger minimum key size than the
+  // default of this library (1024). Let's also upgrade from sha1 to sha256
+  // while we're at it.
+  {keySize: 2048, algorithm: 'sha256'}
+);
 const SELF_SIGNED_CERT_PATH = pathlib.resolve(
   repoRoot,
   'temp',

--- a/src/test/util/filesystem-test-rig.ts
+++ b/src/test/util/filesystem-test-rig.ts
@@ -21,7 +21,7 @@ export class FilesystemTestRig {
   readonly temp = pathlib.resolve(repoRoot, 'temp', String(Math.random()));
   private _state: 'uninitialized' | 'running' | 'done' = 'uninitialized';
 
-  protected assertState(expected: 'uninitialized' | 'running' | 'done') {
+  protected _assertState(expected: 'uninitialized' | 'running' | 'done') {
     if (this._state !== expected) {
       throw new Error(
         `Expected state to be ${expected} but was ${this._state}`
@@ -33,7 +33,7 @@ export class FilesystemTestRig {
    * Initialize the temporary filesystem.
    */
   async setup() {
-    this.assertState('uninitialized');
+    this._assertState('uninitialized');
     this._state = 'running';
     await this.mkdir('.');
   }
@@ -42,7 +42,7 @@ export class FilesystemTestRig {
    * Delete the temporary filesystem.
    */
   async cleanup(): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await this.delete('.');
     this._state = 'done';
   }
@@ -66,7 +66,7 @@ export class FilesystemTestRig {
     fileOrFiles: string | {[filename: string]: unknown},
     data?: string
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     if (typeof fileOrFiles === 'string') {
       const absolute = pathlib.resolve(this.temp, fileOrFiles);
       await fs.mkdir(pathlib.dirname(absolute), {recursive: true});
@@ -92,7 +92,7 @@ export class FilesystemTestRig {
     fileOrFiles: string | {[filename: string]: unknown},
     data?: string
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     if (typeof fileOrFiles === 'string') {
       const actual = pathlib.resolve(this.temp, fileOrFiles);
       const temp = actual + '.tmp';
@@ -125,7 +125,7 @@ export class FilesystemTestRig {
    * Read a file from the temporary filesystem.
    */
   async read(filename: string): Promise<string> {
-    this.assertState('running');
+    this._assertState('running');
     return fs.readFile(this.resolve(filename), 'utf8');
   }
 
@@ -133,7 +133,7 @@ export class FilesystemTestRig {
    * Check whether a file exists in the temporary filesystem.
    */
   async exists(filename: string): Promise<boolean> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       await fs.access(this.resolve(filename));
       return true;
@@ -149,7 +149,7 @@ export class FilesystemTestRig {
    * Get filesystem metadata for the given path in the temporary filesystem.
    */
   async lstat(path: string): Promise<Stats> {
-    this.assertState('running');
+    this._assertState('running');
     return fs.lstat(this.resolve(path));
   }
 
@@ -158,7 +158,7 @@ export class FilesystemTestRig {
    * Return false if it is another kind of file, or if it doesn't exit.
    */
   async isDirectory(path: string): Promise<boolean> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       const stats = await this.lstat(path);
       return stats.isDirectory();
@@ -176,7 +176,7 @@ export class FilesystemTestRig {
    * or undefined if it doesn't exist.
    */
   async readlink(path: string): Promise<string | undefined> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       return await fs.readlink(this.resolve(path));
     } catch (error) {
@@ -193,7 +193,7 @@ export class FilesystemTestRig {
    * directories.
    */
   async mkdir(dirname: string): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await fs.mkdir(this.resolve(dirname), {recursive: true});
   }
 
@@ -201,7 +201,7 @@ export class FilesystemTestRig {
    * Delete a file or directory in the temporary filesystem.
    */
   async delete(filename: string): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await fs.rm(this.resolve(filename), {force: true, recursive: true});
   }
 
@@ -213,7 +213,7 @@ export class FilesystemTestRig {
     filename: string,
     windowsType: 'file' | 'dir' | 'junction'
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     const absolute = this.resolve(filename);
     try {
       await fs.unlink(absolute);

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -78,7 +78,7 @@ export class WireitTestRig extends FilesystemTestRig {
     binaryPath: string;
     installPath: string;
   }) {
-    this.assertState('running');
+    this._assertState('running');
 
     binaryPath = this._resolve(binaryPath);
     installPath = this._resolve(installPath);
@@ -130,7 +130,7 @@ export class WireitTestRig extends FilesystemTestRig {
     command: string,
     opts?: {cwd?: string; env?: Record<string, string | undefined>}
   ): ExecResult {
-    this.assertState('running');
+    this._assertState('running');
     const cwd = this._resolve(opts?.cwd ?? '.');
     const result = new ExecResult(command, cwd, {
       // We hard code the parallelism here because by default we infer a value
@@ -180,7 +180,7 @@ export class WireitTestRig extends FilesystemTestRig {
    * Create a new test command.
    */
   async newCommand(): Promise<WireitTestRigCommand> {
-    this.assertState('running');
+    this._assertState('running');
     // On Windows, Node IPC is implemented with named pipes, which must be
     // prefixed by "\\?\pipe\". On Linux/macOS it's a unix domain socket, which
     // can be any filepath. See https://nodejs.org/api/net.html#ipc-support for

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -38,7 +38,7 @@ export class WireitTestRig extends FilesystemTestRig {
    * Initialize the temporary filesystem, and set up the wireit binary to be
    * runnable as though it had been installed there through npm.
    */
-  async setup() {
+  override async setup() {
     await super.setup();
     const absWireitBinaryPath = pathlib.resolve(repoRoot, 'bin', 'wireit.js');
     const absWireitTempInstallPath = pathlib.resolve(
@@ -110,7 +110,7 @@ export class WireitTestRig extends FilesystemTestRig {
   /**
    * Delete the temporary filesystem and perform other cleanup.
    */
-  async cleanup(): Promise<void> {
+  override async cleanup(): Promise<void> {
     await Promise.all(this._commands.map((command) => command.close()));
     for (const child of this._activeChildProcesses) {
       child.kill();

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -282,7 +282,7 @@ export class Watcher {
       this._failureMode,
       this._abort
     );
-    const result = await executor.execute(script);
+    const result = await executor.getExecution(script).execute();
     if (!result.ok) {
       for (const error of result.error) {
         this._logger.log(error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true,
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo",
     "composite": true


### PR DESCRIPTION
A refactoring which allows scripts to directly access full `Execution` instances, instead of just fingerprints as before.

This is useful for the lazy startup/shutdown feature of services, because other scripts need to not only get the service's fingerprint, but also to have a `start` method they can call once they eventually decide whether they need to run or not.

Also:

- Upgraded the self-signed TLS certificate we use in tests, because after upgrading my Linux distro and/or my Node version, these tests were failing locally due to the key being too weak.

- Renamed `script` to `config` in a few places to remove ambiguity.

- Use `_foo` style for `protected` methods.

- Enabled `noImplicitOverride` tsc flag

Part of https://github.com/google/wireit/issues/33