### PR TITLE
Services: Track when services are not needed

### DIFF
--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -84,3 +84,12 @@ export abstract class BaseExecution<T extends ScriptConfig> {
     return {ok: true, value: results};
   }
 }
+
+/**
+ * A single execution of a specific script which has a command.
+ */
+export abstract class BaseExecutionWithCommand<
+  T extends ScriptConfig & {
+    command: Exclude<ScriptConfig['command'], undefined>;
+  }
+> extends BaseExecution<T> {}

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -6,6 +6,7 @@
 
 import {shuffle} from '../util/shuffle.js';
 import {Fingerprint} from '../fingerprint.js';
+import {Deferred} from '../util/deferred.js';
 
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
@@ -92,4 +93,13 @@ export abstract class BaseExecutionWithCommand<
   T extends ScriptConfig & {
     command: Exclude<ScriptConfig['command'], undefined>;
   }
-> extends BaseExecution<T> {}
+> extends BaseExecution<T> {
+  protected readonly _servicesNotNeeded = new Deferred<void>();
+
+  /**
+   * Resolves when this script no longer needs any of its service dependencies
+   * to be running. This could happen because it finished, failed, or never
+   * needed to run at all.
+   */
+  readonly servicesNotNeeded = this._servicesNotNeeded.promise;
+}

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -9,11 +9,23 @@ import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
+import type {Executor} from '../executor.js';
+import type {Logger} from '../logging/logger.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
+  constructor(
+    config: ServiceScriptConfig,
+    executor: Executor,
+    logger: Logger,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _abort: Promise<void>
+  ) {
+    super(config, executor, logger);
+  }
+
   /**
    * Note `execute` is a bit of a misnomer here, because we don't actually
    * execute the command at this stage in the case of services.

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BaseExecution} from './base.js';
+import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
@@ -13,7 +13,7 @@ import type {ServiceScriptConfig} from '../config.js';
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
-export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
+export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
   /**
    * Note `execute` is a bit of a misnomer here, because we don't actually
    * execute the command at this stage in the case of services.

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -13,7 +13,7 @@ import {glob, GlobOutsideCwdError} from '../util/glob.js';
 import {deleteEntries} from '../util/delete.js';
 import lockfile from 'proper-lockfile';
 import {ScriptChildProcess} from '../script-child-process.js';
-import {BaseExecution} from './base.js';
+import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 import {computeManifestEntry} from '../util/manifest.js';
 
@@ -36,7 +36,7 @@ type StandardScriptExecutionState =
 /**
  * Execution for a {@link StandardScriptConfig}.
  */
-export class StandardScriptExecution extends BaseExecution<StandardScriptConfig> {
+export class StandardScriptExecution extends BaseExecutionWithCommand<StandardScriptConfig> {
   private _state: StandardScriptExecutionState = 'before-running';
   private readonly _cache?: Cache;
   private readonly _workerPool: WorkerPool;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -48,11 +48,11 @@ type WatcherState =
   | 'aborted';
 
 function unknownState(state: never) {
-  throw new Error(`Unknown watcher state ${String(state)}`);
+  return new Error(`Unknown watcher state ${String(state)}`);
 }
 
 function unexpectedState(state: WatcherState) {
-  throw new Error(`Unexpected watcher state ${state}`);
+  return new Error(`Unexpected watcher state ${state}`);
 }
 
 /**


### PR DESCRIPTION
Adds a `servicesNotNeeded` promise, which gets resolved when a script either knows it will never run, or when it has finished running, and hence no longer needs the services it depends on to be running. This is how services will keep track of how many dependents still need them to be running -- once there are none left, they can shut down (unless they are directly invoked).

This is done via a new `BaseExecutionWithCommand` base class, which is only relevant to scripts with commands (because no-command scripts don't directly consume services).

Also:

- Pass `abort` promise down to services. Directly-invoked services will need this to know when to shut down on SIGINT.

- Removed a redundant `throw` I noticed.

Part of https://github.com/google/wireit/issues/33