### PR TITLE
Services: Integrate into standard scripts

### DIFF
--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -104,6 +104,16 @@ export abstract class BaseExecutionWithCommand<
   readonly servicesNotNeeded = this._servicesNotNeeded.promise;
 
   /**
+   * Resolves when any of the services this script depends on have terminated
+   * (see {@link ServiceScriptExecution.terminated} for exact definiton).
+   */
+  readonly anyServiceTerminated = Promise.race(
+    this._config.services.map(
+      (service) => this._executor.getExecution(service).terminated
+    )
+  );
+
+  /**
    * Ensure that all of the services this script depends on are running.
    */
   protected async _startServices(): Promise<Result<void, Failure[]>> {

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -102,4 +102,27 @@ export abstract class BaseExecutionWithCommand<
    * needed to run at all.
    */
   readonly servicesNotNeeded = this._servicesNotNeeded.promise;
+
+  /**
+   * Ensure that all of the services this script depends on are running.
+   */
+  protected async _startServices(): Promise<Result<void, Failure[]>> {
+    if (this._config.services.length > 0) {
+      const results = await Promise.all(
+        this._config.services.map((service) =>
+          this._executor.getExecution(service).start()
+        )
+      );
+      const errors: Failure[] = [];
+      for (const result of results) {
+        if (!result.ok) {
+          errors.push(...result.error);
+        }
+      }
+      if (errors.length > 0) {
+        return {ok: false, error: errors};
+      }
+    }
+    return {ok: true, value: undefined};
+  }
 }

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -11,6 +11,8 @@ import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
 import type {Executor} from '../executor.js';
 import type {Logger} from '../logging/logger.js';
+import type {Failure} from '../event.js';
+import type {Result} from '../error.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
@@ -42,5 +44,11 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
     return {ok: true, value: fingerprint};
   }
 
-  // TODO(aomarks) Implement service starting/stopping.
+  /**
+   * Start this service if it isn't already started.
+   */
+  start(): Promise<Result<void, Failure[]>> {
+    // TODO(aomarks) Implement service starting/stopping.
+    throw new Error('Not implemented');
+  }
 }

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -6,6 +6,7 @@
 
 import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
+import {Deferred} from '../util/deferred.js';
 
 import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
@@ -18,6 +19,18 @@ import type {Result} from '../error.js';
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
+  private readonly _terminated = new Deferred<Result<void, Failure>>();
+
+  /**
+   * Resolves as "ok" when this script decides it is no longer needed, and
+   * either has begun shutting down, or never needed to start in the first
+   * place.
+   *
+   * Resolves with an error if this service exited unexpectedly, or if any of
+   * its own service dependencies exited unexpectedly.
+   */
+  readonly terminated = this._terminated.promise;
+
   constructor(
     config: ServiceScriptConfig,
     executor: Executor,


### PR DESCRIPTION
Integrates services into standard scripts (though note services don't yet actually _do_ anything, that's coming up next). Summary:

1. Before a standard script runs, all of its services must have started. If any service failed to start, we fail.

2. While a standard script is still running, if any of its services unexpectedly shuts down, then we're in an invalid state and fail too.

Part of https://github.com/google/wireit/issues/33