### PR TITLE
Services: Support for very basic consumer/service test case

### DIFF
--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -75,7 +75,7 @@ export class StandardScriptExecution extends BaseExecutionWithCommand<StandardSc
         return {ok: false, error: [this._startCancelledEvent]};
       }
 
-      return this._acquireSystemLockIfNeeded(async () => {
+      return await this._acquireSystemLockIfNeeded(async () => {
         // Note we must wait for dependencies to finish before generating the
         // cache key, because a dependency could create or modify an input file to
         // this script, which would affect the key.

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -73,7 +73,7 @@ test(
     const consumerInv = await consumer.nextInvocation();
     // Wait a moment to ensure the service stays running
     await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.ok(serviceInv.running);
+    assert.ok(serviceInv.isRunning);
     consumerInv.exit(0);
 
     // The service stops because the consumer is done

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -5,6 +5,8 @@
  */
 
 import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+import {timeout} from './util/uvu-timeout.js';
 import {WireitTestRig} from './util/test-rig.js';
 
 const test = suite<{rig: WireitTestRig}>();
@@ -31,5 +33,57 @@ test.after.each(async (ctx) => {
     process.exit(1);
   }
 });
+
+test(
+  'simple consumer and service',
+  timeout(async ({rig}) => {
+    // consumer
+    //    |
+    //    v
+    // service
+
+    const consumer = await rig.newCommand();
+    const service = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          consumer: 'wireit',
+          service: 'wireit',
+        },
+        wireit: {
+          consumer: {
+            command: consumer.command,
+            dependencies: ['service'],
+          },
+          service: {
+            command: service.command,
+            service: true,
+          },
+        },
+      },
+    });
+
+    const wireit = rig.exec('npm run consumer');
+
+    // The service starts because the consumer depends on it
+    const serviceInv = await service.nextInvocation();
+    await wireit.waitForLog(/Service started/);
+
+    // The consumer starts and finishes
+    const consumerInv = await consumer.nextInvocation();
+    // Wait a moment to ensure the service stays running
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.ok(serviceInv.running);
+    consumerInv.exit(0);
+
+    // The service stops because the consumer is done
+    await serviceInv.closed;
+    await wireit.waitForLog(/Service stopped/);
+
+    await wireit.exit;
+    assert.equal(service.numInvocations, 1);
+    assert.equal(consumer.numInvocations, 1);
+  })
+);
 
 test.run();

--- a/src/test/util/test-rig-command.ts
+++ b/src/test/util/test-rig-command.ts
@@ -195,6 +195,13 @@ export class WireitTestRigCommandInvocation extends IpcClient<
   }
 
   /**
+   * Return whether this invocation is still running.
+   */
+  get running(): boolean {
+    return this._state === 'connected';
+  }
+
+  /**
    * Tell this invocation to exit with the given code.
    */
   exit(code: number): void {

--- a/src/test/util/test-rig-command.ts
+++ b/src/test/util/test-rig-command.ts
@@ -197,7 +197,7 @@ export class WireitTestRigCommandInvocation extends IpcClient<
   /**
    * Return whether this invocation is still running.
    */
-  get running(): boolean {
+  get isRunning(): boolean {
     return this._state === 'connected';
   }
 


### PR DESCRIPTION
Just a start on the service state machine, with a test. Handling for the most basic simple case: one standard consumer that depends on one service. Obviously many cases not yet handled/tested here, but will build out more complexity incrementally.

Also fixes a bug with a missing `await`, and adds a small test utility method.

Part of https://github.com/google/wireit/issues/33