### PR TITLE
Services: Stdout/stderr and various error case handling

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,13 +94,14 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       return config;
     }
     const executor = new Executor(
+      config.value,
       logger,
       workerPool,
       cache,
       options.failureMode,
       abort
     );
-    const result = await executor.getExecution(config.value).execute();
+    const result = await executor.execute();
     if (!result.ok) {
       return result;
     }

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -107,7 +107,7 @@ export abstract class BaseExecutionWithCommand<
    * Resolves when any of the services this script depends on have terminated
    * (see {@link ServiceScriptExecution.terminated} for exact definiton).
    */
-  readonly anyServiceTerminated = Promise.race(
+  protected readonly _anyServiceTerminated = Promise.race(
     this._config.services.map(
       (service) => this._executor.getExecution(service).terminated
     )

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -271,6 +271,22 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         void this._state.child.completed.then(() => {
           this._onChildExited();
         });
+        this._state.child.stdout.on('data', (data: string | Buffer) => {
+          this._logger.log({
+            script: this._config,
+            type: 'output',
+            stream: 'stdout',
+            data,
+          });
+        });
+        this._state.child.stderr.on('data', (data: string | Buffer) => {
+          this._logger.log({
+            script: this._config,
+            type: 'output',
+            stream: 'stderr',
+            data,
+          });
+        });
         return this._state.started.promise;
       }
       case 'initial':

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -422,13 +422,23 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         });
         return;
       }
+      case 'started': {
+        const failure = {
+          script: this._config,
+          type: 'failure',
+          reason: 'service-exited-unexpectedly',
+        } as const;
+        this._terminated.resolve({ok: false, error: failure});
+        this._servicesNotNeeded.resolve();
+        this._logger.log(failure);
+        return;
+      }
       case 'initial':
       case 'executingDeps':
       case 'fingerprinting':
       case 'unstarted':
       case 'depsStarting':
       case 'starting':
-      case 'started':
       case 'stopped': {
         throw unexpectedState(this._state);
       }

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -436,7 +436,7 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
           )
         );
         void allConsumersDone.then(() => {
-          this._allConsumersDone();
+          this._onAllConsumersDone();
         });
         return;
       }
@@ -458,7 +458,7 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
     }
   }
 
-  private _allConsumersDone() {
+  private _onAllConsumersDone() {
     switch (this._state.id) {
       case 'started': {
         this._state.child.kill();

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -323,7 +323,7 @@ export class StandardScriptExecution extends BaseExecutionWithCommand<StandardSc
           return servicesStarted;
         }
 
-        void this.anyServiceTerminated.then((result) => {
+        void this._anyServiceTerminated.then((result) => {
           if (this._state === 'after-running') {
             // This is expected after we're done.
             return;

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -35,7 +35,7 @@ test.after.each(async (ctx) => {
 });
 
 test(
-  'simple consumer and service',
+  'simple consumer and service with stdout',
   timeout(async ({rig}) => {
     // consumer
     //    |
@@ -68,6 +68,12 @@ test(
     // The service starts because the consumer depends on it
     const serviceInv = await service.nextInvocation();
     await wireit.waitForLog(/Service started/);
+
+    // Confirm we show stdout/stderr from services
+    serviceInv.stdout('service stdout');
+    await wireit.waitForLog(/service stdout/);
+    serviceInv.stderr('service stderr');
+    await wireit.waitForLog(/service stderr/);
 
     // The consumer starts and finishes
     const consumerInv = await consumer.nextInvocation();

--- a/src/test/util/test-rig-command-child.ts
+++ b/src/test/util/test-rig-command-child.ts
@@ -59,3 +59,11 @@ if (!ipcPath) {
 }
 const socket = net.createConnection(ipcPath);
 new ChildIpcClient(socket);
+
+process.on('SIGINT', () => {
+  // Gracefully close the socket before we are terminated. This helps avoid
+  // occasional ECONNRESET errors on the other side.
+  socket.end(() => {
+    process.exit(1);
+  });
+});

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -276,13 +276,14 @@ export class Watcher {
       throw unexpectedState(this._state);
     }
     const executor = new Executor(
+      script,
       this._logger,
       this._workerPool,
       this._cache,
       this._failureMode,
       this._abort
     );
-    const result = await executor.getExecution(script).execute();
+    const result = await executor.execute();
     if (!result.ok) {
       for (const error of result.error) {
         this._logger.log(error);


### PR DESCRIPTION
More incremental progress on services:

- Show service stdout/stderr
- Make services wait for their own services to start
- Make standard scripts and services fail when a service exits unexpectedly (both while they are running and before)
- Wait for services to shut down before ending an execution, including a refactor to make this simpler

Also:

- Gracefully close IPC socket in our test processes on SIGINT. Fixes occasional ECONNRESET errors.
- Make our test stdout/stderr matcher only consume *up to the match*, instead of also consuming everything beyond.
- Minor renaming

Part of https://github.com/google/wireit/issues/33