### PR TITLE
Services: Handle more starting/stopping scenarios

### DIFF
--- a/src/test/util/test-rig-command-interface.ts
+++ b/src/test/util/test-rig-command-interface.ts
@@ -14,7 +14,8 @@ export type RigToChildMessage =
   | StdoutMessage
   | StderrMessage
   | ExitMessage
-  | EnvironmentRequestMessage;
+  | EnvironmentRequestMessage
+  | InterceptSigintMessage;
 
 /**
  * Tell the command to emit the given string to its stdout stream.
@@ -41,6 +42,14 @@ export interface ExitMessage {
 }
 
 /**
+ * The the command to wait until a SIGINT signal is received, and then send a
+ * messsage back instead of exiting.
+ */
+export interface InterceptSigintMessage {
+  type: 'interceptSigint';
+}
+
+/**
  * Ask the command for information about its environment (argv, cwd, env).
  */
 export interface EnvironmentRequestMessage {
@@ -50,7 +59,9 @@ export interface EnvironmentRequestMessage {
 /**
  * A message sent from a spawned command to the test rig.
  */
-export type ChildToRigMessage = EnvironmentResponseMessage;
+export type ChildToRigMessage =
+  | EnvironmentResponseMessage
+  | SigintReceivedMessage;
 
 /**
  * Report to the rig what cwd, argv, and environment variables were set when
@@ -61,6 +72,13 @@ export interface EnvironmentResponseMessage {
   cwd: string;
   argv: string[];
   env: {[key: string]: string | undefined};
+}
+
+/**
+ * Report the rig that a SIGINT signal has been received.
+ */
+export interface SigintReceivedMessage {
+  type: 'sigintReceived';
 }
 
 /**


### PR DESCRIPTION
- Directly invoked scripts now start up immediately, and shut down when wireit receives `SIGINT`.

- All services now shut down whenever an error occurs anywhere in the graph, regardless of the `FAILURE_MODE` (`"continue" | "no-new" | "kill"`).

- Services start up in bottom-up order, and stop in top-down order. We stop in top-down order so that if exiting gracefully requires interacting with another service you depend on, that will be reliable.

- Updated the test rig so that we can get a notification of when a child process receives `SIGINT`, instead of always exiting. This lets us control how long it takes for a child to exit after it has been killed, so that we can better validate  the order that services stop.

Part of https://github.com/google/wireit/issues/33