### PR TITLE
Services: Pass running services across watch iterations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,8 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       workerPool,
       cache,
       options.failureMode,
-      abort
+      abort,
+      undefined
     );
     const result = await executor.execute();
     if (!result.ok) {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -91,10 +91,24 @@ function unexpectedState(state: ServiceState) {
  *     ├─◄─ abort ─┤ FINGERPRINTING │                        │
  *     │           └───────┬────────┘                        │
  *     │                   │                                 │
- *     ▼             fingerprinted                           ▼
+ *     │             fingerprinted                           ▼
  *     │                   │                                 │
+ *     │        ╔══════════▼════════════╗                    │
+ *     ▼        ║ adoptee has different ╟─ yes ─╮            │
+ *     │        ║     fingerprint?      ║       │            │
+ *     │        ╚══════════╤════════════╝       │            │
+ *     │                   │                    ▼            │
+ *     │                   no                   │            │
+ *     │                   │                    │            │
+ *     │                   │          ┌─────────▼────────┐   │
+ *     ├─◄─ abort ─────────│─────◄────┤ STOPPING_ADOPTEE │   │
+ *     │                   │          └─────────┬────────┘   │
+ *     │                   │                    │            │
+ *     │                   ▼              adopteeStopped     │
+ *     │                   │                    │            │
+ *     │                   ├─────◄──────────────╯            │
  *     │                   │                                 │
- *     │        ╔══════════════════════╗                     │
+ *     ▼        ╔══════════▼═══════════╗                     │
  *     │        ║ is directly invoked? ╟── yes ──╮           │
  *     │        ╚══════════╤═══════════╝         │           │
  *     │                   │                     │           │

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -191,7 +191,8 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
     config: ServiceScriptConfig,
     executor: Executor,
     logger: Logger,
-    entireExecutionAborted: Promise<void>
+    entireExecutionAborted: Promise<void>,
+    _adoptee: ServiceScriptExecution | undefined
   ) {
     super(config, executor, logger);
     this._state = {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -213,27 +213,29 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
   }
 
   /**
-   * Return the fingerprint of this service. If the fingerprint is not yet
-   * computed, or if the service is stopped/failed/detached, returns undefined.
+   * Return the fingerprint of this service. Throws if the fingerprint is not
+   * yet available. Returns undefined if the service is stopped/failed/detached.
    */
   get fingerprint(): Fingerprint | undefined {
     switch (this._state.id) {
+      case 'stoppingAdoptee':
       case 'unstarted':
       case 'depsStarting':
       case 'starting':
       case 'started': {
         return this._state.fingerprint;
       }
-      case 'initial':
-      case 'executingDeps':
-      case 'fingerprinting':
-      case 'stoppingAdoptee':
       case 'stopping':
       case 'stopped':
       case 'failed':
       case 'failing':
       case 'detached': {
         return undefined;
+      }
+      case 'initial':
+      case 'executingDeps':
+      case 'fingerprinting': {
+        throw unexpectedState(this._state);
       }
       default: {
         throw unknownState(this._state);


### PR DESCRIPTION
Implements the basic logic for passing running services across watch mode iterations:

1. The top-level `execute` method now returns a map of the services that are still running at the end of the execution.

2. We pass that service map to the next iteration, and pass the previous version of each service into its new version.

3. As soon as a service knows its fingerprint, we check if it matches the previous version's fingerprint. If it does match, we "adopt" it instead of starting a new process. If it does not match, we shut it down, and then continue as normal (effectively restarting it).

Still a few cases to handle here, which are in TODOs, but will do in followup PRs.

Part of https://github.com/google/wireit/issues/33