### PR TITLE
Services: Shut down services that were deleted between watch iterations

### DIFF
--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -254,8 +254,13 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         // fact that the promises remain unresolved will prevent GC of old
         // executions in watch mode. Those promises should probably be
         // Promise.race'd to prevent that.
-        child.stdout.removeAllListeners();
-        child.stderr.removeAllListeners();
+
+        // Note that for some reason, removing all listeners from stdout/stderr
+        // without specifying the "data" event will also remove the listeners
+        // directly on "child" inside the ScriptChildProceess for noticing when
+        // e.g. the process has exited.
+        child.stdout.removeAllListeners('data');
+        child.stderr.removeAllListeners('data');
         return child;
       }
       case 'stopping':


### PR DESCRIPTION
Handles the case where we're in watch mode, and a service was entirely deleted from the graph. Previously it would keep running, but now we notice it and shut it down before starting the next execution. The same goes for scripts that used to be "directly invoked" and are now no longer (since those might not need to run at all).

Part of https://github.com/google/wireit/issues/33