### PR TITLE
Services: Allow scripts that consume services to cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Added `"service": true` setting, which is well suited for long-running
+  processes like servers. A service is started either when it is invoked directly,
+  or when another script that depends on it is ready to run. A service is stopped
+  when all scripts that depend on it have finished, or when Wireit is exited.
 
 ## [0.7.2] - 2022-09-25
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [GitHub Actions caching](#github-actions-caching)
 - [Cleaning output](#cleaning-output)
 - [Watch mode](#watch-mode)
+- [Services](#services)
 - [Failures and errors](#failures-and-errors)
 - [Package locks](#package-locks)
 - [Recipes](#recipes)
@@ -387,6 +388,46 @@ The benefit of Wireit's watch mode over built-in watch modes are:
 - It prevents problems that can occur when running many separate watch commands
   simultaneously, such as build steps being triggered before all preceding steps
   have finished.
+
+## Services
+
+By default, Wireit assumes that your scripts will eventually exit by themselves.
+This is well suited for build and test scripts, but not for long-running
+processes like servers. To tell Wireit that a process is long-running and not
+expected to exit by itself, set `"service": true`.
+
+```json
+{
+  "scripts": {
+    "serve": "wireit",
+    "build:server": "wireit",
+    "build:assets": "wireit"
+  },
+  "wireit": {
+    "serve": {
+      "command": "node my-server.js",
+      "service": true,
+      "files": ["server-config.json"],
+      "dependencies": ["build:server", "build:assets"]
+    }
+  }
+}
+```
+
+If a service is run _directly_ (e.g. `npm run serve`), then it will stay running
+until the user kills Wireit (e.g. `Ctrl-C`).
+
+If a service is a _dependency_ of one or more other scripts, then it will start
+up before any depending script runs, and will shut down after all depending
+scripts finish.
+
+In watch mode, a service will be restarted whenever one of its input files or
+dependencies change.
+
+Services cannot have `output` files, because there is no way for Wireit to know
+when a service has finished writing its output. If you have a service that
+produces output, you should define a non-service script that depends on it, and
+which exits when the service's output is complete.
 
 ## Failures and errors
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "format:check": "prettier . -c",
     "test": "wireit",
     "test:headless": "wireit",
+    "test:analysis": "wireit",
     "test:basic": "wireit",
     "test:cache-github": "wireit",
     "test:cache-local": "wireit",
@@ -71,6 +72,7 @@
     },
     "test:headless": {
       "dependencies": [
+        "test:analysis",
         "test:basic",
         "test:cache-github",
         "test:cache-local",
@@ -107,8 +109,16 @@
       ],
       "output": []
     },
+    "test:analysis": {
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^analysis\\.test\\.js$\"",
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
+      "output": []
+    },
     "test:basic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"basic\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^basic\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -116,7 +126,7 @@
       "output": []
     },
     "test:cache-github": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cache-github\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-github\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -124,7 +134,7 @@
       "output": []
     },
     "test:cache-local": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cache-local\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-local\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -132,7 +142,7 @@
       "output": []
     },
     "test:clean": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"clean\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^clean\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -140,7 +150,7 @@
       "output": []
     },
     "test:cli-options": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"cli-options\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cli-options\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -148,7 +158,7 @@
       "output": []
     },
     "test:codeactions": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"codeactions\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^codeactions\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -156,7 +166,7 @@
       "output": []
     },
     "test:copy": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"copy\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^copy\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -164,7 +174,7 @@
       "output": []
     },
     "test:delete": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"delete\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^delete\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -172,7 +182,7 @@
       "output": []
     },
     "test:diagnostic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"diagnostic\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^diagnostic\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -180,7 +190,7 @@
       "output": []
     },
     "test:errors-analysis": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"errors-analysis\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-analysis\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -188,7 +198,7 @@
       "output": []
     },
     "test:errors-usage": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"errors-usage\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-usage\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -196,7 +206,7 @@
       "output": []
     },
     "test:failures": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"failures\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^failures\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -204,7 +214,7 @@
       "output": []
     },
     "test:freshness": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"freshness\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^freshness\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -212,7 +222,7 @@
       "output": []
     },
     "test:glob": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"glob\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^glob\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -220,7 +230,7 @@
       "output": []
     },
     "test:ide": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"ide\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^ide\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -228,7 +238,7 @@
       "output": []
     },
     "test:json-schema": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"json-schema\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^json-schema\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -238,7 +248,7 @@
       "output": []
     },
     "test:optimize-mkdirs": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"optimize-mkdirs\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^optimize-mkdirs\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -246,7 +256,7 @@
       "output": []
     },
     "test:parallelism": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"parallelism\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^parallelism\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -254,7 +264,7 @@
       "output": []
     },
     "test:service": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"service\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^service\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],
@@ -262,7 +272,7 @@
       "output": []
     },
     "test:watch": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"watch\\.test\\.js$\"",
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^watch\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:json-schema": "wireit",
     "test:optimize-mkdirs": "wireit",
     "test:parallelism": "wireit",
+    "test:service": "wireit",
     "test:watch": "wireit"
   },
   "wireit": {
@@ -88,6 +89,7 @@
         "test:json-schema",
         "test:optimize-mkdirs",
         "test:parallelism",
+        "test:service",
         "test:watch"
       ]
     },
@@ -245,6 +247,14 @@
     },
     "test:parallelism": {
       "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"parallelism\\.test\\.js$\"",
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:service": {
+      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"service\\.test\\.js$\"",
       "dependencies": [
         "build"
       ],

--- a/schema.json
+++ b/schema.json
@@ -43,6 +43,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "service": {
+            "markdownDescription": "If true, treat this script as a long-running process.\nServices are automatically brought up and down as they are depended upon by other scripts. If invoked directly, services continue running until Wireit is killed with Ctrl-C.\nFor more info, see: https://github.com/google/wireit#services",
+            "type": "boolean"
           }
         },
         "type": "object"

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1082,19 +1082,44 @@ export class Analyzer {
       };
       return {ok: false, error: this._markAsInvalid(config, failure)};
     }
-    {
-      const validConfig: ScriptConfig = {
+
+    let validConfig: ScriptConfig;
+    if (config.service) {
+      // We should already have created an invalid script at this point, so we
+      // should never get here. We throw here to convince TypeScript that this
+      // is guaranteed.
+      if (config.command === undefined) {
+        throw new Error(
+          'Internal error: Supposedly valid service did not have command'
+        );
+      }
+      validConfig = {
         ...config,
-        extraArgs: undefined,
         state: 'valid',
+        extraArgs: undefined,
         dependencies: config.dependencies as Array<Dependency<ScriptConfig>>,
+        // Unfortunately TypeScript doesn't narrow the ...config spread, so we
+        // have to assign explicitly.
+        command: config.command,
       };
-      // We want to keep the original reference, but get type checking that
-      // the only difference between a ScriptConfig and a
-      // LocallyValidScriptConfig is that the state is 'valid' and the
-      // dependencies are also valid, which we confirmed above.
-      Object.assign(config, validConfig);
+    } else {
+      validConfig = {
+        ...config,
+        state: 'valid',
+        extraArgs: undefined,
+        dependencies: config.dependencies as Array<Dependency<ScriptConfig>>,
+        // Unfortunately TypeScript doesn't narrow the ...config spread, so we
+        // have to assign explicitly.
+        service: config.service,
+      };
     }
+
+    // We want to keep the original reference, but get type checking that
+    // the only difference between a ScriptConfig and a
+    // LocallyValidScriptConfig is that the state is 'valid' and the
+    // dependencies are also valid, which we confirmed above.
+    Object.assign(config, validConfig);
+
     return {ok: true, value: config as unknown as ScriptConfig};
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,13 +94,14 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       return config;
     }
     const executor = new Executor(
+      config.value,
       logger,
       workerPool,
       cache,
       options.failureMode,
       abort
     );
-    const result = await executor.getExecution(config.value).execute();
+    const result = await executor.execute();
     if (!result.ok) {
       return result;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,7 +99,8 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       workerPool,
       cache,
       options.failureMode,
-      abort
+      abort,
+      undefined
     );
     const result = await executor.execute();
     if (!result.ok) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       options.failureMode,
       abort
     );
-    const result = await executor.execute(config.value);
+    const result = await executor.getExecution(config.value).execute();
     if (!result.ok) {
       return result;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,11 @@ interface BaseScriptConfig extends ScriptReference {
   clean: boolean | 'if-file-deleted';
 
   /**
+   * Whether the script should run in service mode.
+   */
+  service: boolean;
+
+  /**
    * The command string in the scripts section. i.e.:
    *
    * ```json

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,16 @@ export interface ServiceScriptConfig
   extends BaseScriptConfig,
     ScriptReferenceWithCommand {
   service: true;
+
+  /**
+   * Whether this service is being invoked directly (e.g. `npm run serve`).
+   */
+  isDirectlyInvoked: boolean;
+
+  /**
+   * Scripts that depend on this service.
+   */
+  serviceConsumers: Array<ServiceScriptConfig | StandardScriptConfig>;
 }
 
 /**
@@ -96,6 +106,11 @@ interface BaseScriptConfig extends ScriptReference {
    * during execution.
    */
   dependencies: Array<Dependency<ScriptConfig>>;
+
+  /**
+   * The services that need to be started before we can run.
+   */
+  services: Array<ServiceScriptConfig>;
 
   /**
    * Input file globs for this script.

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,26 +29,10 @@ export interface ScriptReference extends PackageReference {
   name: string;
 }
 
-export interface Dependency<Config extends PotentiallyValidScriptConfig> {
-  config: Config;
-  astNode: JsonAstNode<string>;
-}
-
-export type ScriptConfig = NoCommandScriptConfig | StandardScriptConfig;
-
 /**
- * A script that doesn't run or produce anything. A pass-through for
- * dependencies and/or files.
+ * A script with a defined command.
  */
-export interface NoCommandScriptConfig extends BaseScriptConfig {
-  command: undefined;
-  extraArgs: undefined;
-}
-
-/**
- * A script with a command that exits by itself.
- */
-export interface StandardScriptConfig extends BaseScriptConfig {
+export interface ScriptReferenceWithCommand extends ScriptReference {
   /**
    * The shell command to execute.
    */
@@ -58,6 +42,44 @@ export interface StandardScriptConfig extends BaseScriptConfig {
    * Extra arguments to pass to the command.
    */
   extraArgs: string[] | undefined;
+}
+
+export interface Dependency<Config extends PotentiallyValidScriptConfig> {
+  config: Config;
+  astNode: JsonAstNode<string>;
+}
+
+export type ScriptConfig =
+  | NoCommandScriptConfig
+  | StandardScriptConfig
+  | ServiceScriptConfig;
+
+/**
+ * A script that doesn't run or produce anything. A pass-through for
+ * dependencies and/or files.
+ */
+export interface NoCommandScriptConfig extends BaseScriptConfig {
+  command: undefined;
+  extraArgs: undefined;
+  service: false;
+}
+
+/**
+ * A script with a command that exits by itself.
+ */
+export interface StandardScriptConfig
+  extends BaseScriptConfig,
+    ScriptReferenceWithCommand {
+  service: false;
+}
+
+/**
+ * A service script.
+ */
+export interface ServiceScriptConfig
+  extends BaseScriptConfig,
+    ScriptReferenceWithCommand {
+  service: true;
 }
 
 /**

--- a/src/event.ts
+++ b/src/event.ts
@@ -9,6 +9,7 @@ import {Diagnostic} from './error.js';
 import type {
   ScriptConfig,
   ScriptReference,
+  ScriptReferenceWithCommand,
   PackageReference,
 } from './config.js';
 
@@ -20,7 +21,7 @@ import type {
  */
 export type Event = Success | Failure | Output | Info;
 
-interface EventBase<T extends PackageReference> {
+interface EventBase<T extends PackageReference = ScriptReference> {
   script: T;
   diagnostic?: Diagnostic;
   diagnostics?: Diagnostic[];
@@ -32,35 +33,36 @@ interface EventBase<T extends PackageReference> {
 
 type Success = ExitZero | NoCommand | Fresh | Cached;
 
-interface SuccessBase<T extends PackageReference> extends EventBase<T> {
+interface SuccessBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'success';
 }
 
 /**
  * A script finished with exit code 0.
  */
-export interface ExitZero extends SuccessBase<ScriptConfig> {
+export interface ExitZero extends SuccessBase {
   reason: 'exit-zero';
 }
 
 /**
  * A script completed because it had no command and its dependencies completed.
  */
-export interface NoCommand extends SuccessBase<ScriptConfig> {
+export interface NoCommand extends SuccessBase {
   reason: 'no-command';
 }
 
 /**
  * A script was already fresh so it didn't need to execute.
  */
-export interface Fresh extends SuccessBase<ScriptConfig> {
+export interface Fresh extends SuccessBase {
   reason: 'fresh';
 }
 
 /**
  * Script output was restored from cache.
  */
-export interface Cached extends SuccessBase<ScriptConfig> {
+export interface Cached extends SuccessBase {
   reason: 'cached';
 }
 
@@ -90,16 +92,18 @@ export type Failure =
   | UnknownErrorThrown
   | DependencyOnMissingPackageJson
   | DependencyOnMissingScript
-  | DependencyInvalid;
+  | DependencyInvalid
+  | ServiceExitedUnexpectedly;
 
-interface ErrorBase<T extends PackageReference> extends EventBase<T> {
+interface ErrorBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'failure';
 }
 
 /**
  * A script finished with an exit status that was not 0.
  */
-export interface ExitNonZero extends ErrorBase<ScriptConfig> {
+export interface ExitNonZero extends ErrorBase {
   reason: 'exit-non-zero';
   status: number;
 }
@@ -107,7 +111,7 @@ export interface ExitNonZero extends ErrorBase<ScriptConfig> {
 /**
  * A script exited because of a signal it received.
  */
-export interface ExitSignal extends ErrorBase<ScriptConfig> {
+export interface ExitSignal extends ErrorBase {
   reason: 'signal';
   signal: NodeJS.Signals;
 }
@@ -115,7 +119,7 @@ export interface ExitSignal extends ErrorBase<ScriptConfig> {
 /**
  * An error occured trying to spawn a script's command.
  */
-export interface SpawnError extends ErrorBase<ScriptReference> {
+export interface SpawnError extends ErrorBase {
   reason: 'spawn-error';
   message: string;
 }
@@ -124,14 +128,14 @@ export interface SpawnError extends ErrorBase<ScriptReference> {
  * We decided not to start a script after all, due to e.g. another script
  * failure.
  */
-export interface StartCancelled extends ErrorBase<ScriptReference> {
+export interface StartCancelled extends ErrorBase {
   reason: 'start-cancelled';
 }
 
 /**
  * A script was intentionally and successfully killed by Wireit.
  */
-export interface Killed extends ErrorBase<ScriptReference> {
+export interface Killed extends ErrorBase {
   reason: 'killed';
 }
 
@@ -162,15 +166,14 @@ export interface PackageJsonParseError extends ErrorBase<PackageReference> {
 /**
  * The package.json doesn't have a "scripts" object at all.
  */
-export interface NoScriptsSectionInPackageJson
-  extends ErrorBase<ScriptReference> {
+export interface NoScriptsSectionInPackageJson extends ErrorBase {
   reason: 'no-scripts-in-package-json';
 }
 
 /**
  * The specified script does not exist in a package.json.
  */
-export interface ScriptNotFound extends ErrorBase<ScriptReference> {
+export interface ScriptNotFound extends ErrorBase {
   reason: 'script-not-found';
   diagnostic: Diagnostic;
 }
@@ -179,8 +182,7 @@ export interface ScriptNotFound extends ErrorBase<ScriptReference> {
  * The specified script has a wireit config, but it isn't declared in the
  * scripts section at all.
  */
-export interface WireitScriptNotInScriptsSection
-  extends ErrorBase<ScriptReference> {
+export interface WireitScriptNotInScriptsSection extends ErrorBase {
   reason: 'wireit-config-but-no-script';
   diagnostic: Diagnostic;
 }
@@ -188,7 +190,7 @@ export interface WireitScriptNotInScriptsSection
 /**
  * The specified script's command is not "wireit".
  */
-export interface ScriptNotWireit extends ErrorBase<ScriptReference> {
+export interface ScriptNotWireit extends ErrorBase {
   reason: 'script-not-wireit';
   diagnostic: Diagnostic;
 }
@@ -201,7 +203,7 @@ export interface InvalidConfigSyntax extends ErrorBase<PackageReference> {
   diagnostic: Diagnostic;
 }
 
-export interface InvalidUsage extends ErrorBase<ScriptReference> {
+export interface InvalidUsage extends ErrorBase {
   reason: 'invalid-usage';
   message: string;
 }
@@ -209,7 +211,7 @@ export interface InvalidUsage extends ErrorBase<ScriptReference> {
 /**
  * A script lists the same dependency multiple times.
  */
-export interface DuplicateDependency extends ErrorBase<ScriptReference> {
+export interface DuplicateDependency extends ErrorBase {
   reason: 'duplicate-dependency';
   /**
    * The dependency that is duplicated.
@@ -221,8 +223,7 @@ export interface DuplicateDependency extends ErrorBase<ScriptReference> {
 /**
  * A script depends on another in a package that isn't there.
  */
-export interface DependencyOnMissingPackageJson
-  extends ErrorBase<ScriptReference> {
+export interface DependencyOnMissingPackageJson extends ErrorBase {
   reason: 'dependency-on-missing-package-json';
   diagnostic: Diagnostic;
   /**
@@ -235,10 +236,17 @@ export interface DependencyOnMissingPackageJson
 /**
  * A script's dependency doesn't exist.
  */
-export interface DependencyOnMissingScript extends ErrorBase<ScriptReference> {
+export interface DependencyOnMissingScript extends ErrorBase {
   reason: 'dependency-on-missing-script';
   diagnostic: Diagnostic;
   supercedes: ScriptNotFound;
+}
+
+/**
+ * A service exited before it was supposed to.
+ */
+export interface ServiceExitedUnexpectedly extends ErrorBase {
+  reason: 'service-exited-unexpectedly';
 }
 
 /**
@@ -251,7 +259,7 @@ export interface DependencyOnMissingScript extends ErrorBase<ScriptReference> {
  * continue to cycle detection even when some diagnostics were generated during
  * local analysis.
  */
-export interface DependencyInvalid extends ErrorBase<ScriptReference> {
+export interface DependencyInvalid extends ErrorBase {
   reason: 'dependency-invalid';
   dependency: UnvalidatedConfig;
 }
@@ -259,7 +267,7 @@ export interface DependencyInvalid extends ErrorBase<ScriptReference> {
 /**
  * The dependency graph has a cycle in it.
  */
-export interface Cycle extends ErrorBase<ScriptReference> {
+export interface Cycle extends ErrorBase {
   reason: 'cycle';
 
   diagnostic: Diagnostic;
@@ -268,7 +276,7 @@ export interface Cycle extends ErrorBase<ScriptReference> {
 /**
  * For when we catch an error not handled by any of the other types.
  */
-export interface UnknownErrorThrown extends ErrorBase<ScriptReference> {
+export interface UnknownErrorThrown extends ErrorBase {
   reason: 'unknown-error-thrown';
   error: unknown;
 }
@@ -308,16 +316,19 @@ type Info =
   | OutputModified
   | WatchRunStart
   | WatchRunEnd
+  | ServiceStarted
+  | ServiceStopped
   | GenericInfo;
 
-interface InfoBase<T extends ScriptReference> extends EventBase<T> {
+interface InfoBase<T extends PackageReference = ScriptReference>
+  extends EventBase<T> {
   type: 'info';
 }
 
 /**
  * A script's command started running.
  */
-export interface ScriptRunning extends InfoBase<ScriptConfig> {
+export interface ScriptRunning extends InfoBase<ScriptReferenceWithCommand> {
   detail: 'running';
 }
 
@@ -325,7 +336,7 @@ export interface ScriptRunning extends InfoBase<ScriptConfig> {
  * A script can't run right now because a system-wide lock is being held by
  * another process.
  */
-export interface ScriptLocked extends InfoBase<ScriptConfig> {
+export interface ScriptLocked extends InfoBase {
   detail: 'locked';
 }
 
@@ -334,28 +345,42 @@ export interface ScriptLocked extends InfoBase<ScriptConfig> {
  * stale, because one or more output files from the previous run have been
  * added, removed, or changed.
  */
-export interface OutputModified extends InfoBase<ScriptConfig> {
+export interface OutputModified extends InfoBase {
   detail: 'output-modified';
 }
 
 /**
  * A watch mode iteration started.
  */
-export interface WatchRunStart extends InfoBase<ScriptReference> {
+export interface WatchRunStart extends InfoBase {
   detail: 'watch-run-start';
 }
 
 /**
  * A watch mode iteration ended.
  */
-export interface WatchRunEnd extends InfoBase<ScriptReference> {
+export interface WatchRunEnd extends InfoBase {
   detail: 'watch-run-end';
+}
+
+/**
+ * A service started running.
+ */
+export interface ServiceStarted extends InfoBase {
+  detail: 'service-started';
+}
+
+/**
+ * A service stopped running.
+ */
+export interface ServiceStopped extends InfoBase {
+  detail: 'service-stopped';
 }
 
 /**
  * A generic info event.
  */
-export interface GenericInfo extends InfoBase<ScriptReference> {
+export interface GenericInfo extends InfoBase {
   detail: 'generic';
   message: string;
 }

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -107,7 +107,7 @@ export abstract class BaseExecutionWithCommand<
    * Resolves when any of the services this script depends on have terminated
    * (see {@link ServiceScriptExecution.terminated} for exact definiton).
    */
-  readonly anyServiceTerminated = Promise.race(
+  protected readonly _anyServiceTerminated = Promise.race(
     this._config.services.map(
       (service) => this._executor.getExecution(service).terminated
     )

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -6,6 +6,7 @@
 
 import {shuffle} from '../util/shuffle.js';
 import {Fingerprint} from '../fingerprint.js';
+import {Deferred} from '../util/deferred.js';
 
 import type {Result} from '../error.js';
 import type {Executor} from '../executor.js';
@@ -83,4 +84,22 @@ export abstract class BaseExecution<T extends ScriptConfig> {
     }
     return {ok: true, value: results};
   }
+}
+
+/**
+ * A single execution of a specific script which has a command.
+ */
+export abstract class BaseExecutionWithCommand<
+  T extends ScriptConfig & {
+    command: Exclude<ScriptConfig['command'], undefined>;
+  }
+> extends BaseExecution<T> {
+  protected readonly _servicesNotNeeded = new Deferred<void>();
+
+  /**
+   * Resolves when this script no longer needs any of its service dependencies
+   * to be running. This could happen because it finished, failed, or never
+   * needed to run at all.
+   */
+  readonly servicesNotNeeded = this._servicesNotNeeded.promise;
 }

--- a/src/execution/base.ts
+++ b/src/execution/base.ts
@@ -29,30 +29,41 @@ export type FailureMode = 'no-new' | 'continue' | 'kill';
  * A single execution of a specific script.
  */
 export abstract class BaseExecution<T extends ScriptConfig> {
-  protected readonly script: T;
-  protected readonly executor: Executor;
-  protected readonly logger: Logger;
+  protected readonly _config: T;
+  protected readonly _executor: Executor;
+  protected readonly _logger: Logger;
+  private _fingerprint?: Promise<ExecutionResult>;
 
-  protected constructor(script: T, executor: Executor, logger: Logger) {
-    this.script = script;
-    this.executor = executor;
-    this.logger = logger;
+  constructor(config: T, executor: Executor, logger: Logger) {
+    this._config = config;
+    this._executor = executor;
+    this._logger = logger;
   }
+
+  /**
+   * Execute this script and return its fingerprint. Cached, so safe to call
+   * multiple times.
+   */
+  execute(): Promise<ExecutionResult> {
+    return (this._fingerprint ??= this._execute());
+  }
+
+  protected abstract _execute(): Promise<ExecutionResult>;
 
   /**
    * Execute all of this script's dependencies.
    */
-  protected async executeDependencies(): Promise<
+  protected async _executeDependencies(): Promise<
     Result<Array<[ScriptReference, Fingerprint]>, Failure[]>
   > {
     // Randomize the order we execute dependencies to make it less likely for a
     // user to inadvertently depend on any specific order, which could indicate
     // a missing edge in the dependency graph.
-    shuffle(this.script.dependencies);
+    shuffle(this._config.dependencies);
 
     const dependencyResults = await Promise.all(
-      this.script.dependencies.map((dependency) => {
-        return this.executor.execute(dependency.config);
+      this._config.dependencies.map((dependency) => {
+        return this._executor.getExecution(dependency.config).execute();
       })
     );
     const results: Array<[ScriptReference, Fingerprint]> = [];
@@ -64,7 +75,7 @@ export abstract class BaseExecution<T extends ScriptConfig> {
           errors.add(error);
         }
       } else {
-        results.push([this.script.dependencies[i].config, result.value]);
+        results.push([this._config.dependencies[i].config, result.value]);
       }
     }
     if (errors.size > 0) {

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -8,33 +8,23 @@ import {BaseExecution} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
-import type {Executor} from '../executor.js';
 import type {NoCommandScriptConfig} from '../config.js';
-import type {Logger} from '../logging/logger.js';
 
 /**
  * Execution for a {@link NoCommandScriptConfig}.
  */
 export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfig> {
-  static execute(
-    script: NoCommandScriptConfig,
-    executor: Executor,
-    logger: Logger
-  ): Promise<ExecutionResult> {
-    return new NoCommandScriptExecution(script, executor, logger)._execute();
-  }
-
-  private async _execute(): Promise<ExecutionResult> {
-    const dependencyFingerprints = await this.executeDependencies();
+  protected override async _execute(): Promise<ExecutionResult> {
+    const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.script,
+      this._config,
       dependencyFingerprints.value
     );
-    this.logger.log({
-      script: this.script,
+    this._logger.log({
+      script: this._config,
       type: 'success',
       reason: 'no-command',
     });

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -254,8 +254,13 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         // fact that the promises remain unresolved will prevent GC of old
         // executions in watch mode. Those promises should probably be
         // Promise.race'd to prevent that.
-        child.stdout.removeAllListeners();
-        child.stderr.removeAllListeners();
+
+        // Note that for some reason, removing all listeners from stdout/stderr
+        // without specifying the "data" event will also remove the listeners
+        // directly on "child" inside the ScriptChildProceess for noticing when
+        // e.g. the process has exited.
+        child.stdout.removeAllListeners('data');
+        child.stderr.removeAllListeners('data');
         return child;
       }
       case 'stopping':

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -6,16 +6,31 @@
 
 import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
+import {Deferred} from '../util/deferred.js';
 
 import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
 import type {Executor} from '../executor.js';
 import type {Logger} from '../logging/logger.js';
+import type {Failure} from '../event.js';
+import type {Result} from '../error.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
+  private readonly _terminated = new Deferred<Result<void, Failure>>();
+
+  /**
+   * Resolves as "ok" when this script decides it is no longer needed, and
+   * either has begun shutting down, or never needed to start in the first
+   * place.
+   *
+   * Resolves with an error if this service exited unexpectedly, or if any of
+   * its own service dependencies exited unexpectedly.
+   */
+  readonly terminated = this._terminated.promise;
+
   constructor(
     config: ServiceScriptConfig,
     executor: Executor,
@@ -42,5 +57,11 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
     return {ok: true, value: fingerprint};
   }
 
-  // TODO(aomarks) Implement service starting/stopping.
+  /**
+   * Start this service if it isn't already started.
+   */
+  start(): Promise<Result<void, Failure[]>> {
+    // TODO(aomarks) Implement service starting/stopping.
+    throw new Error('Not implemented');
+  }
 }

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -4,16 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {BaseExecution} from './base.js';
+import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
 import type {ServiceScriptConfig} from '../config.js';
+import type {Executor} from '../executor.js';
+import type {Logger} from '../logging/logger.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
-export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
+export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
+  constructor(
+    config: ServiceScriptConfig,
+    executor: Executor,
+    logger: Logger,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _abort: Promise<void>
+  ) {
+    super(config, executor, logger);
+  }
+
   /**
    * Note `execute` is a bit of a misnomer here, because we don't actually
    * execute the command at this stage in the case of services.

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -17,6 +17,69 @@ import type {Result} from '../error.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
+ *
+ * Note that this class represents a service _bound to one particular execution_
+ * of the script graph. In non-watch mode (`npm run ...`), there will be one
+ * instance of this class per service. In watch mode (`npm run --watch ...`),
+ * there will be one instance of this class per service _per watch iteration_,
+ * and the underlying child process will be transfered between instances of this
+ * class whenever possible to avoid restarts.
+ *
+ * ```
+ *                    ┌─────────┐
+ *     ╭─◄─ abort ────┤ INITIAL │
+ *     │              └────┬────┘
+ *     │                   │
+ *     ▼                execute
+ *     │                   │
+ *     │           ┌───────▼────────┐
+ *     ├─◄─ abort ─┤ FINGERPRINTING ├──── depExecErr ────►───╮
+ *     │           └───────┬────────┘                        │
+ *     │                   │                                 │
+ *     ▼             fingerprinted                           │
+ *     │                   │                                 │
+ *     │             ┌─────▼─────┐                           │
+ *     ├─◄─ abort ───┤ UNSTARTED │                           │
+ *     │             └─────┬─────┘                           ▼
+ *     │                   │                                 │
+ *     │                 start                               │
+ *     │                   │  ╭─╮                            │
+ *     │                   │  │ start                        │
+ *     │              ┌────▼──▼─┴┐                           │
+ *     │    ╭◄─ abort ┤ STARTING ├─── startErr or ────►──────┤
+ *     │    │         └────┬────┬┘    depServiceStartErr     │
+ *     ▼    │              │    │                            │
+ *     │    │              │    ▼                            │
+ *     │    │              │    ╰─── depServiceExit ──►──╮   │
+ *     │    │           started                          │   │
+ *     │    ▼              │ ╭─╮                         ▼   │
+ *     │    │              │ │ start                     │   │
+ *     │    │         ┌────▼─▼─┴┐                        │   │
+ *     │    ├◄─ abort ┤ STARTED ├── exit ─────────────►──│───┤
+ *     │    │         └────┬─┬─┬┘                        │   │
+ *     │    │              │ │ ╰─── detach ──╮           │   │
+ *     │    │              │ ▼               │           │   │
+ *     │    │              │ ╰───── depServiceExit ───►──┤   │
+ *     │    │              │                 │           │   │
+ *     │    │        allConsumersDone        │           │   │
+ *     │    ▼    (unless directly invoked)   │           │   │
+ *     │    │              │                 ▼           ▼   ▼
+ *     ▼    │              │  ╭─╮            │           │   │
+ *     │    │              │  │ start        │           │   │
+ *     │    │         ┌────▼──▼─┴┐           │           │   │
+ *     │    ╰─────────► STOPPING ◄─────────────◄─────────╯   │
+ *     │              └┬─▲─┬─────┘           │               │
+ *     │           abort │ │                 │               │
+ *     │               ╰─╯ │                 │               │
+ *     │                  exit               │               │
+ *     │                   │ ╭─╮             │               │ ╭─╮
+ *     │                   │ │ start         │               │ │ start
+ *     │              ┌────▼─▼─┴┐       ┌────▼─────┐     ┌───▼─▼─┴┐
+ *     ╰──────────────► STOPPED │       │ DETACHED │     │ FAILED │
+ *                    └┬─▲──────┘       └┬─▲───────┘     └┬─▲─────┘
+ *                 abort │           *all* │          abort │
+ *                     ╰─╯               ╰─╯              ╰─╯
+ * ```
  */
 export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScriptConfig> {
   private readonly _terminated = new Deferred<Result<void, Failure>>();

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -8,29 +8,23 @@ import {BaseExecution} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 
 import type {ExecutionResult} from './base.js';
-import type {Executor} from '../executor.js';
 import type {ServiceScriptConfig} from '../config.js';
-import type {Logger} from '../logging/logger.js';
 
 /**
  * Execution for a {@link ServiceScriptConfig}.
  */
 export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
-  static execute(
-    script: ServiceScriptConfig,
-    executor: Executor,
-    logger: Logger
-  ): Promise<ExecutionResult> {
-    return new ServiceScriptExecution(script, executor, logger)._execute();
-  }
-
-  private async _execute(): Promise<ExecutionResult> {
-    const dependencyFingerprints = await this.executeDependencies();
+  /**
+   * Note `execute` is a bit of a misnomer here, because we don't actually
+   * execute the command at this stage in the case of services.
+   */
+  protected override async _execute(): Promise<ExecutionResult> {
+    const dependencyFingerprints = await this._executeDependencies();
     if (!dependencyFingerprints.ok) {
       return dependencyFingerprints;
     }
     const fingerprint = await Fingerprint.compute(
-      this.script,
+      this._config,
       dependencyFingerprints.value
     );
     return {ok: true, value: fingerprint};

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {BaseExecution} from './base.js';
+import {Fingerprint} from '../fingerprint.js';
+
+import type {ExecutionResult} from './base.js';
+import type {Executor} from '../executor.js';
+import type {ServiceScriptConfig} from '../config.js';
+import type {Logger} from '../logging/logger.js';
+
+/**
+ * Execution for a {@link ServiceScriptConfig}.
+ */
+export class ServiceScriptExecution extends BaseExecution<ServiceScriptConfig> {
+  static execute(
+    script: ServiceScriptConfig,
+    executor: Executor,
+    logger: Logger
+  ): Promise<ExecutionResult> {
+    return new ServiceScriptExecution(script, executor, logger)._execute();
+  }
+
+  private async _execute(): Promise<ExecutionResult> {
+    const dependencyFingerprints = await this.executeDependencies();
+    if (!dependencyFingerprints.ok) {
+      return dependencyFingerprints;
+    }
+    const fingerprint = await Fingerprint.compute(
+      this.script,
+      dependencyFingerprints.value
+    );
+    return {ok: true, value: fingerprint};
+  }
+
+  // TODO(aomarks) Implement service starting/stopping.
+}

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -13,7 +13,7 @@ import {glob, GlobOutsideCwdError} from '../util/glob.js';
 import {deleteEntries} from '../util/delete.js';
 import lockfile from 'proper-lockfile';
 import {ScriptChildProcess} from '../script-child-process.js';
-import {BaseExecution} from './base.js';
+import {BaseExecutionWithCommand} from './base.js';
 import {Fingerprint} from '../fingerprint.js';
 import {computeManifestEntry} from '../util/manifest.js';
 
@@ -36,7 +36,7 @@ type StandardScriptExecutionState =
 /**
  * Execution for a {@link StandardScriptConfig}.
  */
-export class StandardScriptExecution extends BaseExecution<StandardScriptConfig> {
+export class StandardScriptExecution extends BaseExecutionWithCommand<StandardScriptConfig> {
   private _state: StandardScriptExecutionState = 'before-running';
   private readonly _cache?: Cache;
   private readonly _workerPool: WorkerPool;
@@ -60,57 +60,61 @@ export class StandardScriptExecution extends BaseExecution<StandardScriptConfig>
   }
 
   protected async _execute(): Promise<ExecutionResult> {
-    this._ensureState('before-running');
+    try {
+      this._ensureState('before-running');
 
-    const dependencyFingerprints = await this._executeDependencies();
-    if (!dependencyFingerprints.ok) {
-      dependencyFingerprints.error.push(this._startCancelledEvent);
-      return dependencyFingerprints;
-    }
-
-    // Significant time could have elapsed since we last checked because our
-    // dependencies had to finish.
-    if (this._shouldNotStart) {
-      return {ok: false, error: [this._startCancelledEvent]};
-    }
-
-    return this._acquireSystemLockIfNeeded(async () => {
-      // Note we must wait for dependencies to finish before generating the
-      // cache key, because a dependency could create or modify an input file to
-      // this script, which would affect the key.
-      const fingerprint = await Fingerprint.compute(
-        this._config,
-        dependencyFingerprints.value
-      );
-      if (await this._fingerprintIsFresh(fingerprint)) {
-        const manifestFresh = await this._outputManifestIsFresh();
-        if (!manifestFresh.ok) {
-          return {ok: false, error: [manifestFresh.error]};
-        }
-        if (manifestFresh.value) {
-          return this._handleFresh(fingerprint);
-        }
+      const dependencyFingerprints = await this._executeDependencies();
+      if (!dependencyFingerprints.ok) {
+        dependencyFingerprints.error.push(this._startCancelledEvent);
+        return dependencyFingerprints;
       }
 
-      // Computing the fingerprint can take some time, and the next operation is
-      // destructive. Another good opportunity to check if we should still
-      // start.
+      // Significant time could have elapsed since we last checked because our
+      // dependencies had to finish.
       if (this._shouldNotStart) {
         return {ok: false, error: [this._startCancelledEvent]};
       }
 
-      const cacheHit = fingerprint.data.fullyTracked
-        ? await this._cache?.get(this._config, fingerprint)
-        : undefined;
-      if (this._shouldNotStart) {
-        return {ok: false, error: [this._startCancelledEvent]};
-      }
-      if (cacheHit !== undefined) {
-        return this._handleCacheHit(cacheHit, fingerprint);
-      }
+      return this._acquireSystemLockIfNeeded(async () => {
+        // Note we must wait for dependencies to finish before generating the
+        // cache key, because a dependency could create or modify an input file to
+        // this script, which would affect the key.
+        const fingerprint = await Fingerprint.compute(
+          this._config,
+          dependencyFingerprints.value
+        );
+        if (await this._fingerprintIsFresh(fingerprint)) {
+          const manifestFresh = await this._outputManifestIsFresh();
+          if (!manifestFresh.ok) {
+            return {ok: false, error: [manifestFresh.error]};
+          }
+          if (manifestFresh.value) {
+            return this._handleFresh(fingerprint);
+          }
+        }
 
-      return this._handleNeedsRun(fingerprint);
-    });
+        // Computing the fingerprint can take some time, and the next operation is
+        // destructive. Another good opportunity to check if we should still
+        // start.
+        if (this._shouldNotStart) {
+          return {ok: false, error: [this._startCancelledEvent]};
+        }
+
+        const cacheHit = fingerprint.data.fullyTracked
+          ? await this._cache?.get(this._config, fingerprint)
+          : undefined;
+        if (this._shouldNotStart) {
+          return {ok: false, error: [this._startCancelledEvent]};
+        }
+        if (cacheHit !== undefined) {
+          return this._handleCacheHit(cacheHit, fingerprint);
+        }
+
+        return this._handleNeedsRun(fingerprint);
+      });
+    } finally {
+      this._servicesNotNeeded.resolve();
+    }
   }
 
   /**
@@ -239,6 +243,10 @@ export class StandardScriptExecution extends BaseExecution<StandardScriptConfig>
     cacheHit: CacheHit,
     fingerprint: Fingerprint
   ): Promise<ExecutionResult> {
+    // Optimization: early signal that services are not needed while we're still
+    // restoring from cache.
+    this._servicesNotNeeded.resolve();
+
     // Delete the fingerprint and other files. It's important we do this before
     // restoring from cache, because we don't want to think that the previous
     // fingerprint is still valid when it no longer is.
@@ -372,6 +380,10 @@ export class StandardScriptExecution extends BaseExecution<StandardScriptConfig>
     if (!childResult.ok) {
       return {ok: false, error: [childResult.error]};
     }
+
+    // Optimization: early signal that services are no longer needed while we're
+    // still writing the fingerprint file etc.
+    this._servicesNotNeeded.resolve();
 
     const writeFingerprintPromise = this._writeFingerprintFile(fingerprint);
     const outputFilesAfterRunning = await this._globOutputFilesAfterRunning();

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -323,7 +323,7 @@ export class StandardScriptExecution extends BaseExecutionWithCommand<StandardSc
           return servicesStarted;
         }
 
-        void this.anyServiceTerminated.then((result) => {
+        void this._anyServiceTerminated.then((result) => {
           if (this._state === 'after-running') {
             // This is expected after we're done.
             return;

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -75,7 +75,7 @@ export class StandardScriptExecution extends BaseExecutionWithCommand<StandardSc
         return {ok: false, error: [this._startCancelledEvent]};
       }
 
-      return this._acquireSystemLockIfNeeded(async () => {
+      return await this._acquireSystemLockIfNeeded(async () => {
         // Note we must wait for dependencies to finish before generating the
         // cache key, because a dependency could create or modify an input file to
         // this script, which would affect the key.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,6 +6,7 @@
 
 import {NoCommandScriptExecution} from './execution/no-command.js';
 import {StandardScriptExecution} from './execution/standard.js';
+import {ServiceScriptExecution} from './execution/service.js';
 import {ScriptConfig, scriptReferenceToString} from './config.js';
 import {WorkerPool} from './util/worker-pool.js';
 import {Deferred} from './util/deferred.js';
@@ -133,6 +134,9 @@ export class Executor {
   ): Promise<ExecutionResult> {
     if (script.command === undefined) {
       return NoCommandScriptExecution.execute(script, this, this._logger);
+    }
+    if (script.service) {
+      return ServiceScriptExecution.execute(script, this, this._logger);
     }
     return StandardScriptExecution.execute(
       script,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -35,6 +35,8 @@ type ConfigToExecution<T extends ScriptConfig> = T extends NoCommandScriptConfig
   ? ServiceScriptExecution
   : never;
 
+export type ServiceMap = Map<ScriptReferenceString, ServiceScriptExecution>;
+
 /**
  * What to do when a script failure occurs:
  *
@@ -51,7 +53,9 @@ export type FailureMode = 'no-new' | 'continue' | 'kill';
 export class Executor {
   private readonly _rootConfig: ScriptConfig;
   private readonly _executions = new Map<ScriptReferenceString, Execution>();
-  private readonly _allServices: Array<ServiceScriptExecution> = [];
+  private readonly _directlyInvokedServices: ServiceMap = new Map();
+  private readonly _indirectlyInvokedServices: ServiceScriptExecution[] = [];
+  private readonly _previousIterationServices: ServiceMap | undefined;
   private readonly _logger: Logger;
   private readonly _workerPool: WorkerPool;
   private readonly _cache?: Cache;
@@ -71,12 +75,14 @@ export class Executor {
     workerPool: WorkerPool,
     cache: Cache | undefined,
     failureMode: FailureMode,
-    abort: Deferred<void>
+    abort: Deferred<void>,
+    previousIterationServices: ServiceMap | undefined
   ) {
     this._rootConfig = rootConfig;
     this._logger = logger;
     this._workerPool = workerPool;
     this._cache = cache;
+    this._previousIterationServices = previousIterationServices;
 
     // If this entire execution is aborted because e.g. the user sent a SIGINT
     // to the Wireit process, then dont start new scripts, and kill running
@@ -118,14 +124,30 @@ export class Executor {
   /**
    * Execute the root script.
    */
-  async execute(): Promise<Result<unknown, Failure[]>> {
-    const result = await this.getExecution(this._rootConfig).execute();
-    // Wait for services to shut down.
-    // TODO(aomarks) In watch mode, directly-invoked scripts (and the services
-    // they depend on) should not block here, since they should continue
-    // running.
-    await Promise.all(this._allServices.map((service) => service.terminated));
-    return result;
+  async execute(): Promise<Result<ServiceMap, Failure[]>> {
+    // TOOD(aomarks) If we have any running services from a previous watch
+    // iteration, we should at this point shut down any of the ones that have
+    // since been deleted from the build graph entirely, or which have become
+    // non-directly-invoked.
+    const errors: Failure[] = [];
+    const rootExecutionResult = await this.getExecution(
+      this._rootConfig
+    ).execute();
+    if (!rootExecutionResult.ok) {
+      errors.push(...rootExecutionResult.error);
+    }
+    const indirectlyInvokedServiceResults = await Promise.all(
+      this._indirectlyInvokedServices.map((service) => service.terminated)
+    );
+    for (const result of indirectlyInvokedServiceResults) {
+      if (!result.ok) {
+        errors.push(result.error);
+      }
+    }
+    if (errors.length > 0) {
+      return {ok: false, error: errors};
+    }
+    return {ok: true, value: this._directlyInvokedServices};
   }
 
   /**
@@ -168,9 +190,14 @@ export class Executor {
           config,
           this,
           this._logger,
-          this._stopServices.promise
+          this._stopServices.promise,
+          this._previousIterationServices?.get(key)
         );
-        this._allServices.push(execution);
+        if (config.isDirectlyInvoked) {
+          this._directlyInvokedServices.set(key, execution);
+        } else {
+          this._indirectlyInvokedServices.push(execution);
+        }
       } else {
         execution = new StandardScriptExecution(
           config,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -7,14 +7,31 @@
 import {NoCommandScriptExecution} from './execution/no-command.js';
 import {StandardScriptExecution} from './execution/standard.js';
 import {ServiceScriptExecution} from './execution/service.js';
-import {ScriptConfig, scriptReferenceToString} from './config.js';
+import {ScriptReferenceString, scriptReferenceToString} from './config.js';
 import {WorkerPool} from './util/worker-pool.js';
 import {Deferred} from './util/deferred.js';
-import {convertExceptionToFailure} from './error.js';
 
-import type {ExecutionResult} from './execution/base.js';
 import type {Logger} from './logging/logger.js';
 import type {Cache} from './caching/cache.js';
+import type {
+  ScriptConfig,
+  NoCommandScriptConfig,
+  ServiceScriptConfig,
+  StandardScriptConfig,
+} from './config.js';
+
+type Execution =
+  | NoCommandScriptExecution
+  | StandardScriptExecution
+  | ServiceScriptExecution;
+
+type ConfigToExecution<T extends ScriptConfig> = T extends NoCommandScriptConfig
+  ? NoCommandScriptExecution
+  : T extends StandardScriptConfig
+  ? StandardScriptExecution
+  : T extends ServiceScriptConfig
+  ? ServiceScriptExecution
+  : never;
 
 /**
  * What to do when a script failure occurs:
@@ -30,7 +47,7 @@ export type FailureMode = 'no-new' | 'continue' | 'kill';
  * Executes a script that has been analyzed and validated by the Analyzer.
  */
 export class Executor {
-  private readonly _executions = new Map<string, Promise<ExecutionResult>>();
+  private readonly _executions = new Map<ScriptReferenceString, Execution>();
   private readonly _logger: Logger;
   private readonly _workerPool: WorkerPool;
   private readonly _cache?: Cache;
@@ -112,38 +129,32 @@ export class Executor {
     return this._killRunningScripts.promise;
   }
 
-  async execute(script: ScriptConfig): Promise<ExecutionResult> {
-    const executionKey = scriptReferenceToString(script);
-    let promise = this._executions.get(executionKey);
-    if (promise === undefined) {
-      promise = this._executeAccordingToKind(script)
-        .catch((error) => convertExceptionToFailure(error, script))
-        .then((result) => {
-          if (!result.ok) {
-            this.notifyFailure();
-          }
-          return result;
-        });
-      this._executions.set(executionKey, promise);
+  /**
+   * Get the execution instance for a script config, creating one if it doesn't
+   * already exist.
+   */
+  getExecution<T extends ScriptConfig>(config: T): ConfigToExecution<T> {
+    const key = scriptReferenceToString(config);
+    let execution = this._executions.get(key);
+    if (execution === undefined) {
+      if (config.command === undefined) {
+        execution = new NoCommandScriptExecution(config, this, this._logger);
+      } else if (config.service) {
+        execution = new ServiceScriptExecution(config, this, this._logger);
+      } else {
+        execution = new StandardScriptExecution(
+          config,
+          this,
+          this._workerPool,
+          this._cache,
+          this._logger
+        );
+      }
+      this._executions.set(key, execution);
     }
-    return promise;
-  }
-
-  private _executeAccordingToKind(
-    script: ScriptConfig
-  ): Promise<ExecutionResult> {
-    if (script.command === undefined) {
-      return NoCommandScriptExecution.execute(script, this, this._logger);
-    }
-    if (script.service) {
-      return ServiceScriptExecution.execute(script, this, this._logger);
-    }
-    return StandardScriptExecution.execute(
-      script,
-      this,
-      this._workerPool,
-      this._cache,
-      this._logger
-    );
+    // Cast needed because our Map type doesn't know about the config ->
+    // execution type guarantees. We could make a smarter Map type, but not
+    // really worth it here.
+    return execution as ConfigToExecution<T>;
   }
 }

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -198,6 +198,11 @@ export class DefaultLogger implements Logger {
                 event.dependency
               )} which could not be validated. Please file a bug at https://github.com/google/wireit/issues/new, mention this message, that you encountered it in wireit version ${getWireitVersion()}, and give information about your package.json files.`
             );
+            break;
+          }
+          case 'service-exited-unexpectedly': {
+            console.error(`❌${prefix} Service exited unexpectedly`);
+            break;
           }
         }
         break;
@@ -273,6 +278,14 @@ export class DefaultLogger implements Logger {
           }
           case 'generic': {
             console.log(`ℹ️${prefix} ${event.message}`);
+            break;
+          }
+          case 'service-started': {
+            console.log(`⬆️${prefix} Service started`);
+            break;
+          }
+          case 'service-stopped': {
+            console.log(`⬇️${prefix} Service stopped`);
             break;
           }
         }

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -10,9 +10,10 @@ import {
   augmentProcessEnvSafelyIfOnWindows,
   IS_WINDOWS,
 } from './util/windows.js';
+import {Deferred} from './util/deferred.js';
 
 import type {Result} from './error.js';
-import type {ScriptConfig} from './config.js';
+import type {ScriptReferenceWithCommand} from './config.js';
 import type {ChildProcessWithoutNullStreams} from 'child_process';
 import type {ExitNonZero, ExitSignal, SpawnError, Killed} from './event.js';
 
@@ -45,26 +46,26 @@ export type ScriptChildProcessState =
   | 'stopped';
 
 /**
- * A script config but the command is required.
- */
-type ScriptConfigWithRequiredCommand = ScriptConfig & {
-  command: Exclude<ScriptConfig['command'], undefined>;
-};
-
-/**
  * A child process spawned during execution of a script.
  */
 export class ScriptChildProcess {
-  private readonly _script: ScriptConfigWithRequiredCommand;
+  private readonly _script: ScriptReferenceWithCommand;
   private readonly _child: ChildProcessWithoutNullStreams;
+  private readonly _started = new Deferred<Result<void, SpawnError>>();
+  private readonly _completed = new Deferred<
+    Result<void, SpawnError | ExitSignal | ExitNonZero | Killed>
+  >();
   private _state: ScriptChildProcessState = 'starting';
+
+  /**
+   * Resolves when this process starts
+   */
+  readonly started = this._started.promise;
 
   /**
    * Resolves when this child process ends.
    */
-  readonly completed: Promise<
-    Result<void, SpawnError | ExitSignal | ExitNonZero | Killed>
-  >;
+  readonly completed = this._completed.promise;
 
   get stdout() {
     return this._child.stdout;
@@ -74,13 +75,21 @@ export class ScriptChildProcess {
     return this._child.stderr;
   }
 
-  constructor(script: ScriptConfigWithRequiredCommand) {
-    this._script = script;
+  constructor(script: ScriptReferenceWithCommand) {
+    // Copy only the fields we actually require from the script config, because
+    // the full script config contains references to the full config, which we
+    // want to allow to be garbage-collected across watch iterations.
+    this._script = {
+      packageDir: script.packageDir,
+      name: script.name,
+      command: script.command,
+      extraArgs: script.extraArgs,
+    };
 
     // TODO(aomarks) Update npm_ environment variables to reflect the new
     // package.
-    this._child = spawn(script.command.value, script.extraArgs, {
-      cwd: script.packageDir,
+    this._child = spawn(this._script.command.value, this._script.extraArgs, {
+      cwd: this._script.packageDir,
       // Conveniently, "shell:true" has the same shell-selection behavior as
       // "npm run", where on macOS and Linux it is "sh", and on Windows it is
       // %COMSPEC% || "cmd.exe".
@@ -113,94 +122,96 @@ export class ScriptChildProcess {
       detached: !IS_WINDOWS,
     });
 
-    this.completed = new Promise((resolve, reject) => {
-      this._child.on('spawn', () => {
-        switch (this._state) {
-          case 'starting': {
-            this._state = 'started';
-            break;
-          }
-          case 'killing': {
-            // We received a kill request while we were still starting. Kill now
-            // that we're started.
-            this._actuallyKill();
-            break;
-          }
-          case 'started':
-          case 'stopped': {
-            reject(
-              new Error(
-                `Internal error: Expected ScriptChildProcessState ` +
-                  `to be "started" or "killing" but was "${this._state}"`
-              )
-            );
-            break;
-          }
-          default: {
-            const never: never = this._state;
-            reject(
-              new Error(
-                `Internal error: unexpected ScriptChildProcessState: ${String(
-                  never
-                )}`
-              )
-            );
-          }
+    this._child.on('spawn', () => {
+      switch (this._state) {
+        case 'starting': {
+          this._started.resolve({ok: true, value: undefined});
+          this._state = 'started';
+          break;
         }
-      });
+        case 'killing': {
+          this._started.resolve({ok: true, value: undefined});
+          // We received a kill request while we were still starting. Kill now
+          // that we're started.
+          this._actuallyKill();
+          break;
+        }
+        case 'started':
+        case 'stopped': {
+          const exception = new Error(
+            `Internal error: Expected ScriptChildProcessState ` +
+              `to be "started" or "killing" but was "${this._state}"`
+          );
+          this._started.reject(exception);
+          this._completed.reject(exception);
+          break;
+        }
+        default: {
+          const never: never = this._state;
+          const exception = new Error(
+            `Internal error: unexpected ScriptChildProcessState: ${String(
+              never
+            )}`
+          );
+          this._started.reject(exception);
+          this._completed.reject(exception);
+        }
+      }
+    });
 
-      this._child.on('error', (error) => {
-        resolve({
+    this._child.on('error', (error) => {
+      const result = {
+        ok: false,
+        error: {
+          script,
+          type: 'failure',
+          reason: 'spawn-error',
+          message: error.message,
+        },
+      } as const;
+      this._started.resolve(result);
+      this._completed.resolve(result);
+      this._state = 'stopped';
+    });
+
+    this._child.on('close', (status, signal) => {
+      if (this._state === 'killing') {
+        this._completed.resolve({
           ok: false,
           error: {
             script,
             type: 'failure',
-            reason: 'spawn-error',
-            message: error.message,
+            reason: 'killed',
           },
         });
-        this._state = 'stopped';
-      });
-
-      this._child.on('close', (status, signal) => {
-        if (this._state === 'killing') {
-          resolve({
-            ok: false,
-            error: {
-              script,
-              type: 'failure',
-              reason: 'killed',
-            },
-          });
-        } else if (signal !== null) {
-          resolve({
-            ok: false,
-            error: {
-              script,
-              type: 'failure',
-              reason: 'signal',
-              signal,
-            },
-          });
-        } else if (status !== 0) {
-          resolve({
-            ok: false,
-            error: {
-              script,
-              type: 'failure',
-              reason: 'exit-non-zero',
-              // status should only ever be null if signal was not null, but
-              // this isn't reflected in the TypeScript types. Just in case, and
-              // to make TypeScript happy, fall back to -1 (which is a
-              // conventional exit status used for "exited with signal").
-              status: status ?? -1,
-            },
-          });
-        } else {
-          resolve({ok: true, value: undefined});
-        }
-        this._state = 'stopped';
-      });
+      } else if (signal !== null) {
+        this._completed.resolve({
+          ok: false,
+          error: {
+            script,
+            type: 'failure',
+            reason: 'signal',
+            signal,
+          },
+        });
+      } else if (status !== 0) {
+        this._completed.resolve({
+          ok: false,
+          error: {
+            script,
+            type: 'failure',
+            reason: 'exit-non-zero',
+            // status should only ever be null if signal was not null, but
+            // this isn't reflected in the TypeScript types. Just in case, and
+            // to make TypeScript happy, fall back to -1 (which is a
+            // conventional exit status used for "exited with signal").
+            status: status ?? -1,
+          },
+        });
+      } else {
+        this._completed.resolve({ok: true, value: undefined});
+      }
+      this._state = 'stopped';
     });
   }
 

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+import {WireitTestRig} from './util/test-rig.js';
+import {Analyzer} from '../analyzer.js';
+
+const test = suite<{rig: WireitTestRig}>();
+
+test.before.each(async (ctx) => {
+  try {
+    ctx.rig = new WireitTestRig();
+    await ctx.rig.setup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu before error', error);
+    process.exit(1);
+  }
+});
+
+test.after.each(async (ctx) => {
+  try {
+    await ctx.rig.cleanup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu after error', error);
+    process.exit(1);
+  }
+});
+
+test('analyzes services', async ({rig}) => {
+  //    a
+  //  / | \
+  // |  v  v
+  // |  c  d
+  // |    / |
+  // b <-+  |
+  //        v
+  //        e
+  await rig.write({
+    'package.json': {
+      scripts: {
+        a: 'wireit',
+        b: 'wireit',
+        c: 'wireit',
+        d: 'wireit',
+        e: 'wireit',
+      },
+      wireit: {
+        a: {
+          dependencies: ['b', 'c', 'd'],
+        },
+        b: {
+          command: 'true',
+          service: true,
+        },
+        c: {
+          command: 'true',
+          service: true,
+        },
+        d: {
+          command: 'true',
+          dependencies: ['b', 'e'],
+        },
+        e: {
+          command: 'true',
+          service: true,
+        },
+      },
+    },
+  });
+
+  const analyzer = new Analyzer();
+  const result = await analyzer.analyze({packageDir: rig.temp, name: 'a'}, []);
+  if (!result.config.ok) {
+    console.log(result.config.error);
+    throw new Error('Not ok');
+  }
+
+  // a
+  const a = result.config.value;
+  assert.equal(a.name, 'a');
+  if (a.command) {
+    throw new Error('Expected no-command');
+  }
+  assert.equal(a.dependencies.length, 3);
+
+  // b
+  const b = a.dependencies[0].config;
+  assert.equal(b.name, 'b');
+  if (!b.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(b.serviceConsumers.length, 1);
+  assert.equal(b.serviceConsumers[0].name, 'd');
+  assert.equal(b.isDirectlyInvoked, true);
+
+  // c
+  const c = a.dependencies[1].config;
+  assert.equal(c.name, 'c');
+  if (!c.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(c.isDirectlyInvoked, true);
+  assert.equal(c.serviceConsumers.length, 0);
+  assert.equal(c.services.length, 0);
+
+  // d
+  const d = a.dependencies[2].config;
+  assert.equal(d.name, 'd');
+  assert.equal(d.services.length, 2);
+  assert.equal(d.services[0].name, 'b');
+  assert.equal(d.services[1].name, 'e');
+
+  // e
+  const e = d.services[1];
+  assert.equal(e.name, 'e');
+  if (!e.service) {
+    throw new Error('Expected service');
+  }
+  assert.equal(e.isDirectlyInvoked, false);
+  assert.equal(e.serviceConsumers.length, 1);
+});
+
+test.run();

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -20,9 +20,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = pathlib.dirname(__filename);
 const repoRoot = pathlib.resolve(__dirname, '..', '..');
 
-const SELF_SIGNED_CERT = selfsigned.generate([
-  {name: 'commonName', value: 'localhost'},
-]);
+const SELF_SIGNED_CERT = selfsigned.generate(
+  [{name: 'commonName', value: 'localhost'}],
+  // More recent versions of TLS require a larger minimum key size than the
+  // default of this library (1024). Let's also upgrade from sha1 to sha256
+  // while we're at it.
+  {keySize: 2048, algorithm: 'sha256'}
+);
 const SELF_SIGNED_CERT_PATH = pathlib.resolve(
   repoRoot,
   'temp',

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {suite} from 'uvu';
+import {WireitTestRig} from './util/test-rig.js';
+
+const test = suite<{rig: WireitTestRig}>();
+
+test.before.each(async (ctx) => {
+  try {
+    ctx.rig = new WireitTestRig();
+    await ctx.rig.setup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu before error', error);
+    process.exit(1);
+  }
+});
+
+test.after.each(async (ctx) => {
+  try {
+    await ctx.rig.cleanup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu after error', error);
+    process.exit(1);
+  }
+});
+
+test.run();

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -5,6 +5,8 @@
  */
 
 import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+import {timeout} from './util/uvu-timeout.js';
 import {WireitTestRig} from './util/test-rig.js';
 
 const test = suite<{rig: WireitTestRig}>();
@@ -31,5 +33,57 @@ test.after.each(async (ctx) => {
     process.exit(1);
   }
 });
+
+test(
+  'simple consumer and service',
+  timeout(async ({rig}) => {
+    // consumer
+    //    |
+    //    v
+    // service
+
+    const consumer = await rig.newCommand();
+    const service = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          consumer: 'wireit',
+          service: 'wireit',
+        },
+        wireit: {
+          consumer: {
+            command: consumer.command,
+            dependencies: ['service'],
+          },
+          service: {
+            command: service.command,
+            service: true,
+          },
+        },
+      },
+    });
+
+    const wireit = rig.exec('npm run consumer');
+
+    // The service starts because the consumer depends on it
+    const serviceInv = await service.nextInvocation();
+    await wireit.waitForLog(/Service started/);
+
+    // The consumer starts and finishes
+    const consumerInv = await consumer.nextInvocation();
+    // Wait a moment to ensure the service stays running
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.ok(serviceInv.isRunning);
+    consumerInv.exit(0);
+
+    // The service stops because the consumer is done
+    await serviceInv.closed;
+    await wireit.waitForLog(/Service stopped/);
+
+    await wireit.exit;
+    assert.equal(service.numInvocations, 1);
+    assert.equal(consumer.numInvocations, 1);
+  })
+);
 
 test.run();

--- a/src/test/util/filesystem-test-rig.ts
+++ b/src/test/util/filesystem-test-rig.ts
@@ -21,7 +21,7 @@ export class FilesystemTestRig {
   readonly temp = pathlib.resolve(repoRoot, 'temp', String(Math.random()));
   private _state: 'uninitialized' | 'running' | 'done' = 'uninitialized';
 
-  protected assertState(expected: 'uninitialized' | 'running' | 'done') {
+  protected _assertState(expected: 'uninitialized' | 'running' | 'done') {
     if (this._state !== expected) {
       throw new Error(
         `Expected state to be ${expected} but was ${this._state}`
@@ -33,7 +33,7 @@ export class FilesystemTestRig {
    * Initialize the temporary filesystem.
    */
   async setup() {
-    this.assertState('uninitialized');
+    this._assertState('uninitialized');
     this._state = 'running';
     await this.mkdir('.');
   }
@@ -42,7 +42,7 @@ export class FilesystemTestRig {
    * Delete the temporary filesystem.
    */
   async cleanup(): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await this.delete('.');
     this._state = 'done';
   }
@@ -66,7 +66,7 @@ export class FilesystemTestRig {
     fileOrFiles: string | {[filename: string]: unknown},
     data?: string
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     if (typeof fileOrFiles === 'string') {
       const absolute = pathlib.resolve(this.temp, fileOrFiles);
       await fs.mkdir(pathlib.dirname(absolute), {recursive: true});
@@ -92,7 +92,7 @@ export class FilesystemTestRig {
     fileOrFiles: string | {[filename: string]: unknown},
     data?: string
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     if (typeof fileOrFiles === 'string') {
       const actual = pathlib.resolve(this.temp, fileOrFiles);
       const temp = actual + '.tmp';
@@ -125,7 +125,7 @@ export class FilesystemTestRig {
    * Read a file from the temporary filesystem.
    */
   async read(filename: string): Promise<string> {
-    this.assertState('running');
+    this._assertState('running');
     return fs.readFile(this.resolve(filename), 'utf8');
   }
 
@@ -133,7 +133,7 @@ export class FilesystemTestRig {
    * Check whether a file exists in the temporary filesystem.
    */
   async exists(filename: string): Promise<boolean> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       await fs.access(this.resolve(filename));
       return true;
@@ -149,7 +149,7 @@ export class FilesystemTestRig {
    * Get filesystem metadata for the given path in the temporary filesystem.
    */
   async lstat(path: string): Promise<Stats> {
-    this.assertState('running');
+    this._assertState('running');
     return fs.lstat(this.resolve(path));
   }
 
@@ -158,7 +158,7 @@ export class FilesystemTestRig {
    * Return false if it is another kind of file, or if it doesn't exit.
    */
   async isDirectory(path: string): Promise<boolean> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       const stats = await this.lstat(path);
       return stats.isDirectory();
@@ -176,7 +176,7 @@ export class FilesystemTestRig {
    * or undefined if it doesn't exist.
    */
   async readlink(path: string): Promise<string | undefined> {
-    this.assertState('running');
+    this._assertState('running');
     try {
       return await fs.readlink(this.resolve(path));
     } catch (error) {
@@ -193,7 +193,7 @@ export class FilesystemTestRig {
    * directories.
    */
   async mkdir(dirname: string): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await fs.mkdir(this.resolve(dirname), {recursive: true});
   }
 
@@ -201,7 +201,7 @@ export class FilesystemTestRig {
    * Delete a file or directory in the temporary filesystem.
    */
   async delete(filename: string): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     await fs.rm(this.resolve(filename), {force: true, recursive: true});
   }
 
@@ -213,7 +213,7 @@ export class FilesystemTestRig {
     filename: string,
     windowsType: 'file' | 'dir' | 'junction'
   ): Promise<void> {
-    this.assertState('running');
+    this._assertState('running');
     const absolute = this.resolve(filename);
     try {
       await fs.unlink(absolute);

--- a/src/test/util/test-rig-command-child.ts
+++ b/src/test/util/test-rig-command-child.ts
@@ -59,3 +59,11 @@ if (!ipcPath) {
 }
 const socket = net.createConnection(ipcPath);
 new ChildIpcClient(socket);
+
+process.on('SIGINT', () => {
+  // Gracefully close the socket before we are terminated. This helps avoid
+  // occasional ECONNRESET errors on the other side.
+  socket.end(() => {
+    process.exit(1);
+  });
+});

--- a/src/test/util/test-rig-command-interface.ts
+++ b/src/test/util/test-rig-command-interface.ts
@@ -14,7 +14,8 @@ export type RigToChildMessage =
   | StdoutMessage
   | StderrMessage
   | ExitMessage
-  | EnvironmentRequestMessage;
+  | EnvironmentRequestMessage
+  | InterceptSigintMessage;
 
 /**
  * Tell the command to emit the given string to its stdout stream.
@@ -41,6 +42,14 @@ export interface ExitMessage {
 }
 
 /**
+ * The the command to wait until a SIGINT signal is received, and then send a
+ * messsage back instead of exiting.
+ */
+export interface InterceptSigintMessage {
+  type: 'interceptSigint';
+}
+
+/**
  * Ask the command for information about its environment (argv, cwd, env).
  */
 export interface EnvironmentRequestMessage {
@@ -50,7 +59,9 @@ export interface EnvironmentRequestMessage {
 /**
  * A message sent from a spawned command to the test rig.
  */
-export type ChildToRigMessage = EnvironmentResponseMessage;
+export type ChildToRigMessage =
+  | EnvironmentResponseMessage
+  | SigintReceivedMessage;
 
 /**
  * Report to the rig what cwd, argv, and environment variables were set when
@@ -61,6 +72,13 @@ export interface EnvironmentResponseMessage {
   cwd: string;
   argv: string[];
   env: {[key: string]: string | undefined};
+}
+
+/**
+ * Report the rig that a SIGINT signal has been received.
+ */
+export interface SigintReceivedMessage {
+  type: 'sigintReceived';
 }
 
 /**

--- a/src/test/util/test-rig-command.ts
+++ b/src/test/util/test-rig-command.ts
@@ -195,6 +195,13 @@ export class WireitTestRigCommandInvocation extends IpcClient<
   }
 
   /**
+   * Return whether this invocation is still running.
+   */
+  get isRunning(): boolean {
+    return this._state === 'connected';
+  }
+
+  /**
    * Tell this invocation to exit with the given code.
    */
   exit(code: number): void {

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -38,7 +38,7 @@ export class WireitTestRig extends FilesystemTestRig {
    * Initialize the temporary filesystem, and set up the wireit binary to be
    * runnable as though it had been installed there through npm.
    */
-  async setup() {
+  override async setup() {
     await super.setup();
     const absWireitBinaryPath = pathlib.resolve(repoRoot, 'bin', 'wireit.js');
     const absWireitTempInstallPath = pathlib.resolve(
@@ -78,7 +78,7 @@ export class WireitTestRig extends FilesystemTestRig {
     binaryPath: string;
     installPath: string;
   }) {
-    this.assertState('running');
+    this._assertState('running');
 
     binaryPath = this._resolve(binaryPath);
     installPath = this._resolve(installPath);
@@ -110,7 +110,7 @@ export class WireitTestRig extends FilesystemTestRig {
   /**
    * Delete the temporary filesystem and perform other cleanup.
    */
-  async cleanup(): Promise<void> {
+  override async cleanup(): Promise<void> {
     await Promise.all(this._commands.map((command) => command.close()));
     for (const child of this._activeChildProcesses) {
       child.kill();
@@ -130,7 +130,7 @@ export class WireitTestRig extends FilesystemTestRig {
     command: string,
     opts?: {cwd?: string; env?: Record<string, string | undefined>}
   ): ExecResult {
-    this.assertState('running');
+    this._assertState('running');
     const cwd = this._resolve(opts?.cwd ?? '.');
     const result = new ExecResult(command, cwd, {
       // We hard code the parallelism here because by default we infer a value
@@ -180,7 +180,7 @@ export class WireitTestRig extends FilesystemTestRig {
    * Create a new test command.
    */
   async newCommand(): Promise<WireitTestRigCommand> {
-    this.assertState('running');
+    this._assertState('running');
     // On Windows, Node IPC is implemented with named pipes, which must be
     // prefixed by "\\?\pipe\". On Linux/macOS it's a unix domain socket, which
     // can be any filepath. See https://nodejs.org/api/net.html#ipc-support for

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -320,33 +320,57 @@ class ExecResult {
     }
   }
 
-  private readonly _logMatchers: Array<{re: RegExp; deferred: Deferred<void>}> =
-    [];
+  private readonly _logMatchers = new Set<{
+    re: RegExp;
+    deferred: Deferred<void>;
+  }>();
 
   /**
    * Waits for the given content to be logged to either stdout or stderr.
    *
-   * When it does, it consumes all the stdout and stderr that's been emitted
-   * so far and returns it.
+   * When it does, it consumes all stdout or stderr that's been emitted up to
+   * that match so far.
    */
-  async waitForLog(matcher: RegExp): Promise<{stdout: string; stderr: string}> {
+  waitForLog(matcher: RegExp): Promise<void> {
     const deferred = new Deferred<void>();
-    this._logMatchers.push({re: matcher, deferred});
+    this._logMatchers.add({re: matcher, deferred});
     // In case we've already received the log we're watching for
     this._checkMatchersAgainstLogs();
-    await deferred.promise;
-    const stdout = this._stdout;
-    const stderr = this._stderr;
-    this._stdout = '';
-    this._stderr = '';
-    return {stdout, stderr};
+    return deferred.promise;
   }
 
   private _checkMatchersAgainstLogs() {
+    let stdoutLastIndex = -1;
+    let stderrLastIndex = -1;
     for (const matcher of this._logMatchers) {
-      if (matcher.re.test(this._stdout) || matcher.re.test(this._stderr)) {
-        matcher.deferred.resolve();
+      const {re, deferred} = matcher;
+      // Use exec instead of match because otherwise if the user used the /g/
+      // flag, we'll get an array and can't access the index.
+      const stdoutMatch = re.exec(this._stdout);
+      if (stdoutMatch !== null) {
+        deferred.resolve();
+        this._logMatchers.delete(matcher);
+        stdoutLastIndex = Math.max(
+          stdoutLastIndex,
+          stdoutMatch.index + stdoutMatch[0].length
+        );
+      } else {
+        const stderrMatch = re.exec(this._stderr);
+        if (stderrMatch !== null) {
+          deferred.resolve();
+          this._logMatchers.delete(matcher);
+          stderrLastIndex = Math.max(
+            stderrLastIndex,
+            stderrMatch.index + stderrMatch[0].length
+          );
+        }
       }
+    }
+    if (stdoutLastIndex > 0) {
+      this._stdout = this._stdout.slice(stdoutLastIndex);
+    }
+    if (stderrLastIndex > 0) {
+      this._stderr = this._stderr.slice(stderrLastIndex);
     }
   }
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -48,11 +48,11 @@ type WatcherState =
   | 'aborted';
 
 function unknownState(state: never) {
-  throw new Error(`Unknown watcher state ${String(state)}`);
+  return new Error(`Unknown watcher state ${String(state)}`);
 }
 
 function unexpectedState(state: WatcherState) {
-  throw new Error(`Unexpected watcher state ${state}`);
+  return new Error(`Unexpected watcher state ${state}`);
 }
 
 /**

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -282,7 +282,7 @@ export class Watcher {
       this._failureMode,
       this._abort
     );
-    const result = await executor.execute(script);
+    const result = await executor.getExecution(script).execute();
     if (!result.ok) {
       for (const error of result.error) {
         this._logger.log(error);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -276,13 +276,14 @@ export class Watcher {
       throw unexpectedState(this._state);
     }
     const executor = new Executor(
+      script,
       this._logger,
       this._workerPool,
       this._cache,
       this._failureMode,
       this._abort
     );
-    const result = await executor.getExecution(script).execute();
+    const result = await executor.execute();
     if (!result.ok) {
       for (const error of result.error) {
         this._logger.log(error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "useUnknownInCatchVariables": true,
+    "noImplicitOverride": true,
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo",
     "composite": true


### PR DESCRIPTION
Allows scripts that consume services to cache. This just requires slightly relaxing how we define when a service is "trackable". A standard script needs both its inputs and outputs known in order to be cached, but services never have output, so we need to account for that when we set the trackable bit.