### PR TITLE
Use unsquattable names for internal packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,6 +1231,14 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
+    "node_modules/@wireit/internal-vscode-extension": {
+      "resolved": "vscode-extension",
+      "link": true
+    },
+    "node_modules/@wireit/internal-website": {
+      "resolved": "website",
+      "link": true
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -7475,14 +7483,6 @@
         "node": ">=14.14.0"
       }
     },
-    "node_modules/wireit-extension": {
-      "resolved": "vscode-extension",
-      "link": true
-    },
-    "node_modules/wireit-website": {
-      "resolved": "website",
-      "link": true
-    },
     "node_modules/with": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
@@ -7694,13 +7694,13 @@
       }
     },
     "vscode-extension": {
-      "name": "wireit-extension",
+      "name": "@wireit/internal-vscode-extension",
       "engines": {
         "vscode": "^1.66.0"
       }
     },
     "website": {
-      "name": "wireit-website",
+      "name": "@wireit/internal-website",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -8612,6 +8612,42 @@
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
           "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+        }
+      }
+    },
+    "@wireit/internal-vscode-extension": {
+      "version": "file:vscode-extension"
+    },
+    "@wireit/internal-website": {
+      "version": "file:website",
+      "requires": {
+        "@11ty/eleventy": "^1.0.1",
+        "@11ty/eleventy-navigation": "^0.3.3",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
+        "@web/dev-server": "^0.1.31",
+        "markdown-it": "^13.0.1",
+        "markdown-it-anchor": "^8.6.3",
+        "prism-themes": "^1.9.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1"
+        },
+        "linkify-it": {
+          "version": "4.0.1",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "13.0.1",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~3.0.1",
+            "linkify-it": "^4.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
         }
       }
     },
@@ -13193,42 +13229,6 @@
         "fast-glob": "^3.2.11",
         "jsonc-parser": "^3.0.0",
         "proper-lockfile": "^4.1.2"
-      }
-    },
-    "wireit-extension": {
-      "version": "file:vscode-extension"
-    },
-    "wireit-website": {
-      "version": "file:website",
-      "requires": {
-        "@11ty/eleventy": "^1.0.1",
-        "@11ty/eleventy-navigation": "^0.3.3",
-        "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
-        "@web/dev-server": "^0.1.31",
-        "markdown-it": "^13.0.1",
-        "markdown-it-anchor": "^8.6.3",
-        "prism-themes": "^1.9.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "3.0.1"
-        },
-        "linkify-it": {
-          "version": "4.0.1",
-          "requires": {
-            "uc.micro": "^1.0.1"
-          }
-        },
-        "markdown-it": {
-          "version": "13.0.1",
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "~3.0.1",
-            "linkify-it": "^4.0.1",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          }
-        }
       }
     },
     "with": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wireit-extension",
+  "name": "@wireit/internal-vscode-extension",
   "#comment": [
     "This file is for dependency management and scripts, the file that",
     "is used for the actual vscode plugin is package-for-extension.json"

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wireit-website",
+  "name": "@wireit/internal-website",
   "description": "The website for wireit",
   "private": true,
   "version": "0.0.0",


### PR DESCRIPTION
Looks like somebody squatted `wireit-website` and put malware in it. It's since been removed, but let's update internal package names to clear the security warning, and prevent the same happening with the vscode extension package. Note  I have reserved the `@wireit` npm namespace.

https://github.com/google/wireit/security/dependabot/2