### PR TITLE
Services: Make services of services also be persistent

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -946,7 +946,7 @@ export class Analyzer {
   private _checkForCyclesAndSortDependencies(
     config: LocallyValidScriptConfig | ScriptConfig | InvalidScriptConfig,
     trail: Set<ScriptReferenceString>,
-    isDirectlyInvoked: boolean
+    isPersistent: boolean
   ): Result<ScriptConfig, InvalidScriptConfig> {
     if (config.state === 'valid') {
       // Already validated.
@@ -1069,10 +1069,10 @@ export class Analyzer {
             dependency.config,
             trail,
             // Walk through no-command scripts when determining if something is
-            // being directly invoked (e.g. if the top-level script has no command
-            // and simply delegates to one or more other scripts, then those
-            // dependencies are effectively being directly invoked).
-            isDirectlyInvoked && config.command === undefined
+            // persistent (e.g. if the top-level script has no command and
+            // simply delegates to one or more other scripts, then those
+            // dependencies are effectively persistent).
+            isPersistent && config.command === undefined
           );
         if (!validDependencyConfigResult.ok) {
           return {
@@ -1128,7 +1128,7 @@ export class Analyzer {
         // Unfortunately TypeScript doesn't narrow the ...config spread, so we
         // have to assign explicitly.
         command: config.command,
-        isDirectlyInvoked,
+        isPersistent,
         serviceConsumers: [],
       };
     } else {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -1068,11 +1068,9 @@ export class Analyzer {
           this._checkForCyclesAndSortDependencies(
             dependency.config,
             trail,
-            // Walk through no-command scripts when determining if something is
-            // persistent (e.g. if the top-level script has no command and
-            // simply delegates to one or more other scripts, then those
-            // dependencies are effectively persistent).
-            isPersistent && config.command === undefined
+            // Walk through no-command scripts and services when determining if
+            // something is persistent.
+            isPersistent && (config.command === undefined || config.service)
           );
         if (!validDependencyConfigResult.ok) {
           return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,34 @@ export interface ServiceScriptConfig
   service: true;
 
   /**
-   * Whether this service is being invoked directly (e.g. `npm run serve`).
+   * Whether this service persists beyond the initial execution phase.
+   *
+   * When true, this service will keep running until the user exits wireit, or
+   * until its fingerprint changes in watch mode, requiring a restart.
+   *
+   * When false, this service will start only if it is needed by a standard
+   * script, and will stop when that dependent is done. We call these scripts
+   * "ephemeral".
+   *
+   * So, this is true when there is a path from the entrypoint script to the
+   * service, which does not pass through a standard script.
+   *
+   * Example:
+   *
+   *                      start
+   *                   (no-command)
+   *                    /        \
+   *                   ▼          ▼
+   *             serve:api      serve:static
+   *  (persistent service)      (persistent service)
+   *          |                          |
+   *          ▼                          ▼
+   *      serve:db                   build:assets
+   *  (persistent service)            (standard)
+   *                                     |
+   *                                     ▼
+   *                             serve:playwright
+   *                            (ephemeral service)
    */
   isPersistent: boolean;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ export interface ServiceScriptConfig
   /**
    * Whether this service is being invoked directly (e.g. `npm run serve`).
    */
-  isDirectlyInvoked: boolean;
+  isPersistent: boolean;
 
   /**
    * Scripts that depend on this service.

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -525,6 +525,12 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         });
         return this._state.started.promise;
       }
+      case 'starting': {
+        return this._state.started.promise;
+      }
+      case 'started': {
+        return Promise.resolve({ok: true, value: undefined});
+      }
       case 'failing':
       case 'failed': {
         return Promise.resolve({ok: false, error: [this._state.failure]});
@@ -534,8 +540,6 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
       case 'fingerprinting':
       case 'stoppingAdoptee':
       case 'depsStarting':
-      case 'starting':
-      case 'started':
       case 'stopping':
       case 'stopped':
       case 'detached': {

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -125,9 +125,9 @@ function unexpectedState(state: ServiceState) {
  *     │                   │                    │            │
  *     │                   ├─────◄──────────────╯            │
  *     │                   │                                 │
- *     ▼        ╔══════════▼═══════════╗                     │
- *     │        ║ is directly invoked? ╟── yes ──╮           │
- *     │        ╚══════════╤═══════════╝         │           │
+ *     ▼           ╔═══════▼════════╗                        │
+ *     │           ║ is persistent? ╟───── yes ──╮           │
+ *     │           ╚═══════╤════════╝            │           │
  *     │                   │                     │           │
  *     │                   no                    │           │
  *     │                   │                     │           │
@@ -298,7 +298,7 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
               this._executor.getExecution(consumer).servicesNotNeeded
           )
         );
-        const abort = this._config.isDirectlyInvoked
+        const abort = this._config.isPersistent
           ? Promise.all([this._state.entireExecutionAborted, allConsumersDone])
           : allConsumersDone;
         void abort.then(() => {
@@ -439,7 +439,7 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
           fingerprint,
           adoptee,
         };
-        if (this._config.isDirectlyInvoked) {
+        if (this._config.isPersistent) {
           void this.start();
         }
         return;
@@ -478,7 +478,7 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
           fingerprint: this._state.fingerprint,
           adoptee: undefined,
         };
-        if (this._config.isDirectlyInvoked) {
+        if (this._config.isPersistent) {
           void this.start();
         }
         return;

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -99,7 +99,7 @@ test('analyzes services', async ({rig}) => {
   }
   assert.equal(b.serviceConsumers.length, 1);
   assert.equal(b.serviceConsumers[0].name, 'd');
-  assert.equal(b.isDirectlyInvoked, true);
+  assert.equal(b.isPersistent, true);
 
   // c
   const c = a.dependencies[1].config;
@@ -107,7 +107,7 @@ test('analyzes services', async ({rig}) => {
   if (!c.service) {
     throw new Error('Expected service');
   }
-  assert.equal(c.isDirectlyInvoked, true);
+  assert.equal(c.isPersistent, true);
   assert.equal(c.serviceConsumers.length, 0);
   assert.equal(c.services.length, 0);
 
@@ -124,7 +124,7 @@ test('analyzes services', async ({rig}) => {
   if (!e.service) {
     throw new Error('Expected service');
   }
-  assert.equal(e.isDirectlyInvoked, false);
+  assert.equal(e.isPersistent, false);
   assert.equal(e.serviceConsumers.length, 1);
 });
 

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -606,28 +606,38 @@ test(
 );
 
 test(
-  'persistent service is preserved across watch iterations',
+  'persistent services are preserved across watch iterations',
   timeout(async ({rig}) => {
     //     entrypoint
     //     /        \
     //    v          v
-    // service    standard
+    // service1    standard
+    //    |
+    //    v
+    // service2
 
-    const service = await rig.newCommand();
+    const service1 = await rig.newCommand();
+    const service2 = await rig.newCommand();
     const standard = await rig.newCommand();
     await rig.writeAtomic({
       'package.json': {
         scripts: {
           entrypoint: 'wireit',
-          service: 'wireit',
+          service1: 'wireit',
+          service2: 'wireit',
           standard: 'wireit',
         },
         wireit: {
           entrypoint: {
-            dependencies: ['service', 'standard'],
+            dependencies: ['service1', 'standard'],
           },
-          service: {
-            command: service.command,
+          service1: {
+            command: service1.command,
+            dependencies: ['service2'],
+            service: true,
+          },
+          service2: {
+            command: service2.command,
             service: true,
           },
           standard: {
@@ -643,10 +653,12 @@ test(
 
     // Iteration 1
     {
-      await service.nextInvocation();
+      await service2.nextInvocation();
+      await service1.nextInvocation();
       const standardInv = await standard.nextInvocation();
       standardInv.exit(0);
       await standardInv.closed;
+      await wireit.waitForLog(/Watching for file changes/);
     }
 
     await rig.write('input', '1');
@@ -656,11 +668,13 @@ test(
       const standardInv = await standard.nextInvocation();
       standardInv.exit(0);
       await standardInv.closed;
+      await wireit.waitForLog(/Watching for file changes/);
     }
 
     wireit.kill();
     await wireit.exit;
-    assert.equal(service.numInvocations, 1);
+    assert.equal(service1.numInvocations, 1);
+    assert.equal(service2.numInvocations, 1);
     assert.equal(standard.numInvocations, 2);
   })
 );

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -378,7 +378,7 @@ test(
 );
 
 test(
-  'directly invoked service and dependency starts and runs until SIGINT',
+  'persistent service and dependency starts and runs until SIGINT',
   // service1
   //    |
   //    v
@@ -449,11 +449,11 @@ test(
 );
 
 for (const failureMode of ['continue', 'no-new', 'kill']) {
-  // Even directly invoked services which don't have an error in their branch
-  // should stop when an error occurs elsewhere, regardless of the error mode.
+  // Even persistent services which don't have an error in their branch should
+  // stop when an error occurs elsewhere, regardless of the error mode.
   // Otherwise wireit won't always exit on failures.
   test(
-    `directly invoked service and dependency stop on error ` +
+    `persistent service and dependency stop on error ` +
       `with failure mode ${failureMode}`,
     //      entrypoint
     //        /   \
@@ -546,7 +546,7 @@ for (const failureMode of ['continue', 'no-new', 'kill']) {
 }
 
 test(
-  'indirectly invoked service shuts down between watch iterations',
+  'ephemeral service shuts down between watch iterations',
   timeout(async ({rig}) => {
     // consumer
     //    |
@@ -606,7 +606,7 @@ test(
 );
 
 test(
-  'directly invoked service is preserved across watch iterations',
+  'persistent service is preserved across watch iterations',
   timeout(async ({rig}) => {
     //     entrypoint
     //     /        \


### PR DESCRIPTION
Previously, only a directly invoked service persisted across watch iterations. But actually, if one of those services itself depends on a service, then that service should persist too. 

So this PR renames "isDirectlyInvoked" to "isPersistent", and expands its definition to include services of services. We call non-persistent services "ephemeral".

Also allows `start` to be called multiple times (an obvious case to handle, just hadn't hit it in the tests so far).

Example:

```
                       start
                   (no-command)
                    /        \
                   ▼          ▼
             serve:api      serve:static
  (persistent service)      (persistent service)
          |                          |
          ▼                          ▼
      serve:db                   build:assets
  (persistent service)            (standard)
                                     |
                                     ▼
                             serve:playwright
                            (ephemeral service)
```

Part of https://github.com/google/wireit/issues/33