### PR TITLE
Services: Fix issue with caching in watch mode due to missing promise resolution

### DIFF
--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -746,6 +746,8 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
       case 'unstarted':
       case 'depsStarting': {
         this._state = {id: 'stopped'};
+        this._terminated.resolve({ok: true, value: undefined});
+        this._servicesNotNeeded.resolve();
         return;
       }
       case 'stopping':


### PR DESCRIPTION
I've started testing services for real on webcomponents.org, and I hit a bug where watch mode could get stuck because of some missing promise resolution.

Part of https://github.com/google/wireit/issues/33