### PR TITLE
Services: Continue to show output of stale services during watch mode shutdown

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -137,18 +137,14 @@ export class Executor {
           currentPersistentServices.add(scriptReferenceToString(script));
         }
       }
-      const stopPromises = [];
+      const abortPromises = [];
       for (const [key, service] of this._previousIterationServices) {
         if (!currentPersistentServices.has(key)) {
-          const child = service.detach();
-          if (child !== undefined) {
-            child.kill();
-            stopPromises.push(child.completed);
-          }
+          abortPromises.push(service.abort());
           this._previousIterationServices.delete(key);
         }
       }
-      await Promise.all(stopPromises);
+      await Promise.all(abortPromises);
     }
 
     const errors: Failure[] = [];


### PR DESCRIPTION
Previously, if we were shutting down a service in watch mode because either its fingerprint changed, or it was removed from the script graph, then during the time the service was shutting down, we wouldn't display its stdout/stderr.

That was because we "detached" it before killing it, but detaching also includes removing the stdout/stderr listeners from the previous execution. It makes more sense to instead go through the existing `abort` process, and only `detach` when we are actually adopting a child into a new execution.

Part of https://github.com/google/wireit/issues/33