### PR TITLE
Recover from ECONNRESET and similar GitHub caching connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed memory leak in watch mode.
 
+- Added graceful recovery from `ECONNRESET` and other connection errors when
+  using GitHub Actions caching.
+
 ## [0.7.2] - 2022-09-25
 
 ### Fixed

--- a/src/test/cache-github.test.ts
+++ b/src/test/cache-github.test.ts
@@ -220,7 +220,7 @@ test(
   })
 );
 
-for (const code of [429, 503]) {
+for (const code of [429, 503, 'ECONNRESET'] as const) {
   test(
     `recovers from ${code} error`,
     timeout(async ({rig, server}) => {


### PR DESCRIPTION
This should handle ECONNRESET and hopefully also ETIMEDOUT, though the latter is a little trickier to reproduce in a unit test.

Possibly fixes https://github.com/google/wireit/issues/330