### PR TITLE
Don't kill services in watch mode unless failure mode is "kill"

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,8 @@ const run = async (): Promise<Result<void, Failure[]>> => {
       workerPool,
       cache,
       options.failureMode,
-      undefined
+      undefined,
+      false
     );
     process.on('SIGINT', () => {
       executor.abort();

--- a/src/test/gc.test.ts
+++ b/src/test/gc.test.ts
@@ -119,7 +119,8 @@ test(
         workerPool,
         undefined,
         'no-new',
-        undefined
+        undefined,
+        true
       );
       const resultPromise = executor.execute();
       assert.ok(numLiveExecutors >= 1);
@@ -185,7 +186,8 @@ test(
         workerPool,
         undefined,
         'no-new',
-        previousServices
+        previousServices,
+        true
       );
       const resultPromise = executor.execute();
       assert.ok(numLiveExecutors >= 1);
@@ -274,7 +276,8 @@ test(
         workerPool,
         undefined,
         'no-new',
-        previousServices
+        previousServices,
+        true
       );
       const resultPromise = executor.execute();
       assert.ok(numLiveExecutors >= 1);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -260,7 +260,8 @@ export class Watcher {
       this._workerPool,
       this._cache,
       this._failureMode,
-      this._previousIterationServices
+      this._previousIterationServices,
+      true
     );
     const result = await this._executor.execute();
     if (result.ok) {


### PR DESCRIPTION
Previously, if anything failed in `watch` mode, then all services would stop -- even if they weren't directly affected. Now that only happens if `WIREIT_FAILURES=kill`.

I think stopping everything makes sense when using `npm run`, but not with `--watch`. The example I hit was a script that starts a server, and in parallel runs a linter. I don't want a lint failure to kill the server.