### PR TITLE
Forward services to next iteration even with failures

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -19,7 +19,6 @@ import type {
   ServiceScriptConfig,
   StandardScriptConfig,
 } from './config.js';
-import type {Result} from './error.js';
 import type {Failure} from './event.js';
 
 type Execution =
@@ -150,7 +149,10 @@ export class Executor {
   /**
    * Execute the root script.
    */
-  async execute(): Promise<Result<ServiceMap, Failure[]>> {
+  async execute(): Promise<{
+    persistentServices: ServiceMap;
+    errors: Failure[];
+  }> {
     if (
       this._previousIterationServices !== undefined &&
       this._previousIterationServices.size > 0
@@ -204,10 +206,10 @@ export class Executor {
     // mode we'll have a chain of references all the way back through every
     // iteration.
     this._previousIterationServices = undefined;
-    if (errors.length > 0) {
-      return {ok: false, error: errors};
-    }
-    return {ok: true, value: this._persistentServices};
+    return {
+      persistentServices: this._persistentServices,
+      errors,
+    };
   }
 
   /**

--- a/src/test/gc.test.ts
+++ b/src/test/gc.test.ts
@@ -127,8 +127,8 @@ test(
       assert.ok(numLiveExecutions >= 1);
       (await standard.nextInvocation()).exit(0);
       const result = await resultPromise;
-      if (!result.ok) {
-        for (const error of result.error) {
+      if (result.errors.length > 0) {
+        for (const error of result.errors) {
           logger.log(error);
         }
         throw new Error(`Execution error`);
@@ -193,13 +193,13 @@ test(
       assert.ok(numLiveExecutors >= 1);
       assert.ok(numLiveExecutions >= 1);
       const result = await resultPromise;
-      if (!result.ok) {
-        for (const error of result.error) {
+      if (result.errors.length > 0) {
+        for (const error of result.errors) {
           logger.log(error);
         }
         throw new Error(`Execution error`);
       }
-      previousServices = result.value;
+      previousServices = result.persistentServices;
       if (i === 0) {
         await service.nextInvocation();
       }
@@ -288,13 +288,13 @@ test(
       await serviceEphemeral.nextInvocation();
       (await standard.nextInvocation()).exit(0);
       const result = await resultPromise;
-      if (!result.ok) {
-        for (const error of result.error) {
+      if (result.errors.length > 0) {
+        for (const error of result.errors) {
           logger.log(error);
         }
         throw new Error(`Execution error`);
       }
-      previousServices = result.value;
+      previousServices = result.persistentServices;
     }
 
     for (const service of previousServices!.values()) {

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -264,13 +264,9 @@ export class Watcher {
       true
     );
     const result = await this._executor.execute();
-    if (result.ok) {
-      this._previousIterationServices = result.value;
-    } else {
-      this._previousIterationServices = undefined;
-      for (const error of result.error) {
-        this._logger.log(error);
-      }
+    this._previousIterationServices = result.persistentServices;
+    for (const error of result.errors) {
+      this._logger.log(error);
     }
     this._onRunDone();
   }


### PR DESCRIPTION
Previously, we did not forward services to the next iteration in watch mode if there was a failure anywhere in the graph. Until https://github.com/google/wireit/pull/517, this didn't matter too much, since we'd always eventually shut down all services anyway.

However, now it matters, because by default we'll keep running services as long as the failure didn't affect it or its dependencies. The effect of this bug was that services would start up multiple times, causing e.g. a port conflict.

Now we always forward services, regardless of errors.

Part of https://github.com/google/wireit/issues/33