### PR TITLE
Services: Don't fail in watch mode when a dependency restarts or fails

### DIFF
--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -818,6 +818,11 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         return;
       }
       case 'failing': {
+        this._logger.log({
+          script: this._config,
+          type: 'info',
+          detail: 'service-stopped',
+        });
         this._enterFailedState(this._state.failure);
         return;
       }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -253,7 +253,8 @@ export class Executor {
           this,
           this._logger,
           this._stopServices.promise,
-          this._previousIterationServices?.get(key)
+          this._previousIterationServices?.get(key),
+          this._isWatchMode
         );
         if (config.isPersistent) {
           this._persistentServices.set(key, execution);

--- a/src/test/service.test.ts
+++ b/src/test/service.test.ts
@@ -1145,79 +1145,79 @@ test(
 
 test(
   'service in watch mode persists when non-cascading dependency restarts or fails',
-  // service1
+  // parentService
   //    |
   //    v
-  // service2 (restarts and fails)
+  // childService (restarts and fails)
   timeout(async ({rig}) => {
-    const service1 = await rig.newCommand();
-    const service2 = await rig.newCommand();
+    const parentService = await rig.newCommand();
+    const childParent = await rig.newCommand();
     await rig.writeAtomic({
       'package.json': {
         scripts: {
-          service1: 'wireit',
-          service2: 'wireit',
+          parentService: 'wireit',
+          childService: 'wireit',
         },
         wireit: {
-          service1: {
-            command: service1.command,
+          parentService: {
+            command: parentService.command,
             service: true,
             dependencies: [
               {
-                script: 'service2',
+                script: 'childService',
                 cascade: false,
               },
             ],
-            files: ['input/service1'],
+            files: ['input/parentService'],
           },
-          service2: {
-            command: service2.command,
+          childService: {
+            command: childParent.command,
             service: true,
-            files: ['input/service2'],
+            files: ['input/childService'],
           },
         },
       },
     });
 
-    await rig.write('input/service1', '1');
-    await rig.write('input/service2', '1');
-    const wireit = rig.exec('npm run service1 --watch');
+    await rig.write('input/parentService', '1');
+    await rig.write('input/childService', '1');
+    const wireit = rig.exec('npm run parentService --watch');
 
     // Services start in bottom-up order.
-    const service2Inv1 = await service2.nextInvocation();
-    await wireit.waitForLog(/\[service2\] Service started/);
-    const service1Inv1 = await service1.nextInvocation();
-    await wireit.waitForLog(/\[service1\] Service started/);
-    await wireit.waitForLog(/\[service1\] Watching for file changes/);
+    const childServiceInv1 = await childParent.nextInvocation();
+    await wireit.waitForLog(/\[childService\] Service started/);
+    const parentServiceInv1 = await parentService.nextInvocation();
+    await wireit.waitForLog(/\[parentService\] Service started/);
+    await wireit.waitForLog(/\[parentService\] Watching for file changes/);
 
-    // service2 restarts.
-    await rig.write('input/service2', '2');
-    await service2Inv1.closed;
-    await wireit.waitForLog(/\[service2\] Service stopped/);
-    const service2Inv2 = await service2.nextInvocation();
-    await wireit.waitForLog(/\[service2\] Service started/);
+    // childService restarts.
+    await rig.write('input/childService', '2');
+    await childServiceInv1.closed;
+    await wireit.waitForLog(/\[childService\] Service stopped/);
+    const childServiceInv2 = await childParent.nextInvocation();
+    await wireit.waitForLog(/\[childService\] Service started/);
 
     // Wait a moment to increase confidence.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.ok(service1Inv1.isRunning);
-    assert.ok(service2Inv2.isRunning);
-    assert.not(service2Inv1.isRunning);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.ok(parentServiceInv1.isRunning);
+    assert.ok(childServiceInv2.isRunning);
+    assert.not(childServiceInv1.isRunning);
 
-    // service2 fails.
-    service2Inv2.exit(1);
-    await wireit.waitForLog(/\[service2\] Service exited unexpectedly/);
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    assert.ok(service1Inv1.isRunning);
-    assert.not(service2Inv2.isRunning);
-    assert.not(service2Inv1.isRunning);
+    // childService fails.
+    childServiceInv2.exit(1);
+    await wireit.waitForLog(/\[childService\] Service exited unexpectedly/);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.ok(parentServiceInv1.isRunning);
+    assert.not(childServiceInv2.isRunning);
+    assert.not(childServiceInv1.isRunning);
 
     wireit.kill();
     await wireit.exit;
-    assert.not(service1Inv1.isRunning);
-    assert.not(service2Inv2.isRunning);
-    assert.not(service2Inv1.isRunning);
-    assert.equal(service1.numInvocations, 1);
-    assert.equal(service2.numInvocations, 2);
+    assert.not(parentServiceInv1.isRunning);
+    assert.not(childServiceInv2.isRunning);
+    assert.not(childServiceInv1.isRunning);
+    assert.equal(parentService.numInvocations, 1);
+    assert.equal(childParent.numInvocations, 2);
   })
 );
 


### PR DESCRIPTION
In non-watch mode, if service A depends on service B, and service B exits unexpectedly, then service A is automatically killed. We do this because otherwise wireit will just continue running, even though there has been an error. We instead want to exit with a non-zero code.

Before this PR, we did the same thing in watch mode. However, this was wrong for 2 reasons:

1. If we're iteration N-1 which is about to be adopted into iteration N, our dependencies will sometimes *intentionally* restart, but we were treating this as though it was unexpected. This should not cause us to fail, since we'll either also restart very shortly (when cascade is true), or we'll just keep running (when cascade is false).
          
2. If we're iteration N and our dependency unexpectedly exits by itself, it's not actually helpful if we also aggressively exit. We can just keep running, and hopefully the user can fix the problem with the server dependency, which will then either cause us to restart or not depending on the cascade setting.

As part of this I found these other related issues, which were compounding the problem above and making it harder to debug:

- We were returning `undefined` when we detached, if the service was in its "failing" or "stopping" state, instead of the child process. This was compounding the issue described above, because if iteration N-1 was failing, iteration N would think the child wasn't running *at all*, and would not wait for it to fully shut down. We are now much stricter about communicating from iteration N-1 to iteration N that there is a running child process, regardless of the state.

- We didn't log when a service shut down because of a failure in its dependencies.

Part of https://github.com/google/wireit/issues/33