### PR TITLE
Trim leading slashes from watch paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added graceful recovery from `ECONNRESET` and other connection errors when
   using GitHub Actions caching.
 
+- Fixed bug where a leading slash on a `files` or `output` path was incorrectly
+  interpreted as relative to the filesystem root, instead of relative to the
+  package, in watch mode.
+
 ## [0.7.2] - 2022-09-25
 
 ### Fixed

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -453,14 +453,19 @@ const makeWatcher = (
   cwd: string,
   callback: () => void
 ): FileWatcher => {
-  const watcher = chokidar.watch(patterns, {
-    cwd,
-    // Ignore the initial "add" events emitted when chokidar first discovers
-    // each file. We already do an initial run, so these events are just noise
-    // that may trigger an unnecessary second run.
-    // https://github.com/paulmillr/chokidar#path-filtering
-    ignoreInitial: true,
-  });
+  const watcher = chokidar.watch(
+    // Trim leading slashes from patterns, to "re-root" all paths to the package
+    // directory, just as we do when globbing for script execution.
+    patterns.map((pattern) => pattern.replace(/^\/+/, '')),
+    {
+      cwd,
+      // Ignore the initial "add" events emitted when chokidar first discovers
+      // each file. We already do an initial run, so these events are just noise
+      // that may trigger an unnecessary second run.
+      // https://github.com/paulmillr/chokidar#path-filtering
+      ignoreInitial: true,
+    }
+  );
   watcher.on('all', callback);
   return {
     patterns,


### PR DESCRIPTION
When globbing files for execution, we trim leading slashes from globs, so that everything is always relative to the package, instead of the root filesystem, even if you write e.g. `/src/**`. However, I forgot to do that normalization for those globs when we pass them to chokidar, so they wouldn't get watched.

Fixes https://github.com/google/wireit/issues/529