### PR TITLE
Don't check node/npm version in CI because it's already shown

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,6 @@ jobs:
 
       - uses: google/wireit@setup-github-actions-caching/v1
 
-      - run: node --version; npm --version
-
       - run: npm ci
 
       # Don't bother running the vscode-extension tests on Node 14, because the


### PR DESCRIPTION
It's easy to find the node and npm versions from the "Environment details" dropdown under "Run actions/setup-node@v3", so no need for us to check them again. I think I just didn't notice this before.

![image](https://user-images.githubusercontent.com/48894/201793066-0c41f8b6-3247-4862-b345-f4a9abd7d2c5.png)
