### PR TITLE
Hacking-docs

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "wireit" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [0.3.1] - 2022-11-14
+## [0.4.0] - 2022-11-14
 
 - Updated to support the new "service" and "cascade" features of Wireit v0.7.3.
 

--- a/vscode-extension/HACKING.md
+++ b/vscode-extension/HACKING.md
@@ -1,0 +1,15 @@
+## Developing
+
+Run `npm run install-extension` to build and install the extension in your local VSCode. If you run `npm run install-extension --watch` it will rebuild and reinstall on every change, though you'll need to run `Developer: Reload Window` in VSCode to pick up on the changes.
+
+## Publishing
+
+To publish to the official `Google.wireit` marketplace you'll need to get your Personal Access Token (and your account will have to have the rights for it).
+
+Docs are at https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token and you may be able to get your token from https://dev.azure.com/polymer-vscode/_usersSettings/tokens.
+
+Then run `vsce login google` and paste in your PAT.
+
+Run `npm run install-extension`, reload VSCode, and do a bit of manual testing to be sure that everything is working (we have automated testing but it's worth double checking little fit and finish details).
+
+Then from the `vscode-extension` directory run `vsce publish -i built/wireit.vsix` to publish the extension that you've manually tested.


### PR DESCRIPTION
This has info on developing and publishing the extension. We don't want this in the main README.md as it would clutter up the marketplace docs.