### PR TITLE
Prevent fingerprint size explosion by using hashes of dependency fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- Fixed `Invalid string length` and `heap out of memory` errors when writing the
+  fingerprint files for large script graphs.
 
 ## [0.7.3] - 2022-11-14
 

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -241,7 +241,6 @@ export class Fingerprint {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._str = JSON.stringify(this._data!) as FingerprintString;
     }
-    console.log(JSON.stringify(this._data, null, 2));
     return this._str;
   }
 

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -61,7 +61,7 @@ export interface FingerprintData {
   clean: boolean | 'if-file-deleted';
 
   // Must be sorted.
-  files: {[packageDirRelativeFilename: string]: Sha256HexDigest};
+  files: {[packageDirRelativeFilename: string]: FileSha256HexDigest};
 
   /**
    * The "output" glob patterns from the Wireit config.
@@ -77,7 +77,9 @@ export interface FingerprintData {
   output: string[];
 
   // Must be sorted.
-  dependencies: {[dependency: ScriptReferenceString]: FingerprintData};
+  dependencies: {
+    [dependency: ScriptReferenceString]: FingerprintSha256HexDigest;
+  };
 
   service:
     | {
@@ -98,8 +100,15 @@ export type FingerprintString = string & {
 /**
  * SHA256 hash hexadecimal digest of a file's content.
  */
-export type Sha256HexDigest = string & {
-  __Sha256HexDigestBrand__: never;
+export type FileSha256HexDigest = string & {
+  __FileSha256HexDigestBrand__: never;
+};
+
+/**
+ * SHA256 hash hexadecimal digest of a JSON-stringified fingerprint.
+ */
+type FingerprintSha256HexDigest = string & {
+  __FingerprintSha256HexDigestBrand__: never;
 };
 
 /**
@@ -123,7 +132,7 @@ export class Fingerprint {
   ): Promise<Fingerprint> {
     let allDependenciesAreFullyTracked = true;
     const filteredDependencyFingerprints: Array<
-      [ScriptReferenceString, FingerprintData]
+      [ScriptReferenceString, FingerprintSha256HexDigest]
     > = [];
     for (const [dep, depFingerprint] of dependencyFingerprints) {
       if (!dep.cascade) {
@@ -136,11 +145,11 @@ export class Fingerprint {
       }
       filteredDependencyFingerprints.push([
         scriptReferenceToString(dep.config),
-        depFingerprint.data,
+        depFingerprint.hash,
       ]);
     }
 
-    let fileHashes: Array<[string, Sha256HexDigest]>;
+    let fileHashes: Array<[string, FileSha256HexDigest]>;
     if (script.files?.values.length) {
       const files = await glob(script.files.values, {
         cwd: script.packageDir,
@@ -162,13 +171,13 @@ export class Fingerprint {
       // otherwise re-use cached hashes that we store in e.g.
       // ".wireit/<script>/hashes".
       fileHashes = await Promise.all(
-        files.map(async (file): Promise<[string, Sha256HexDigest]> => {
+        files.map(async (file): Promise<[string, FileSha256HexDigest]> => {
           const absolutePath = file.path;
           const hash = createHash('sha256');
           for await (const chunk of createReadStream(absolutePath)) {
             hash.update(chunk as Buffer);
           }
-          return [file.path, hash.digest('hex') as Sha256HexDigest];
+          return [file.path, hash.digest('hex') as FileSha256HexDigest];
         })
       );
     } else {
@@ -225,12 +234,14 @@ export class Fingerprint {
 
   private _str?: FingerprintString;
   private _data?: FingerprintData;
+  private _hash?: FingerprintSha256HexDigest;
 
   get string(): FingerprintString {
     if (this._str === undefined) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._str = JSON.stringify(this._data!) as FingerprintString;
     }
+    console.log(JSON.stringify(this._data, null, 2));
     return this._str;
   }
 
@@ -240,6 +251,15 @@ export class Fingerprint {
       this._data = JSON.parse(this._str!) as FingerprintData;
     }
     return this._data;
+  }
+
+  get hash(): FingerprintSha256HexDigest {
+    if (this._hash === undefined) {
+      this._hash = createHash('sha256')
+        .update(this.string)
+        .digest('hex') as FingerprintSha256HexDigest;
+    }
+    return this._hash;
   }
 
   equal(other: Fingerprint): boolean {


### PR DESCRIPTION
After each script runs, we write its JSON-stringified *fingerprint* to a file, so that the next time it runs we can compare the fingerprint to decide whether it needs to run again or not.

Part of a fingerprint is the fingerprint of its dependencies (this is how what we now describe as the "cascade" behavior works). (The full list of things in the fingerprint is at https://github.com/google/wireit#fingerprint).

Previously, when nesting dependency fingerprints, we nested the *entire data object for that dependency*. The problem with this is that it can cause an explosion of data in the fingerprint, which at a certain point will be too large for V8's `JSON.stringify` function to handle, causing either an `Invalid string length` error or a `heap out of memory` error. This also would have hurt performance, since we were serializing and writing unnecessarily large amounts of data.

This PR fixes that problem. Now, when embedding the fingerprints of dependencies, we instead embed a *hash* of the fingerprint, instead of the whole object. This bounds the size of any given fingerprint dependency to 64 bytes, whereas previously it could grow to any size -- in some configurations expontentially.

Fixes https://github.com/google/wireit/issues/543