### PR TITLE
Add retries to the test rig delete temp dir call

### DIFF
--- a/src/test/util/filesystem-test-rig.ts
+++ b/src/test/util/filesystem-test-rig.ts
@@ -7,6 +7,7 @@
 import * as fs from 'fs/promises';
 import * as pathlib from 'path';
 import {fileURLToPath} from 'url';
+import {gracefulFs} from './graceful-fs.js';
 
 import type {Stats} from 'fs';
 
@@ -202,7 +203,9 @@ export class FilesystemTestRig {
    */
   async delete(filename: string): Promise<void> {
     this._assertState('running');
-    await fs.rm(this.resolve(filename), {force: true, recursive: true});
+    return gracefulFs(() =>
+      fs.rm(this.resolve(filename), {force: true, recursive: true})
+    );
   }
 
   /**

--- a/src/test/util/graceful-fs.ts
+++ b/src/test/util/graceful-fs.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Try running the given async function, but if it fails with a possibly
+ * transient filesystem error (like `EBUSY`), then retry a few times with
+ * exponential(ish) backoff.
+ */
+export async function gracefulFs<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error: unknown) {
+    if (!isRetryableFsError(error)) {
+      throw error;
+    }
+  }
+  let finalError: unknown;
+  for (const sleep of [10, 100, 500, 1000]) {
+    await new Promise((resolve) => setTimeout(resolve, sleep));
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      if (!isRetryableFsError(error)) {
+        throw error;
+      }
+      finalError = error;
+    }
+  }
+  throw finalError;
+}
+
+function isRetryableFsError(error: unknown): boolean {
+  const code = (error as {code?: string}).code;
+  return code === 'EBUSY';
+}


### PR DESCRIPTION
A really common way that our tests fail is hitting `EBUSY` errors on Windows while deleting the test rig folder after each test.

Example run: https://github.com/google/wireit/actions/runs/3500283074/jobs/5862784350

```
🏃 [test:service] Running command "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test "^service\.test\.js$""
service.test.js
uvu after error [Error: EBUSY: resource busy or locked, rmdir 'D:\a\wireit\wireit\temp\0.9363364123985614'] {
  errno: -4082,
  code: 'EBUSY',
  syscall: 'rmdir',
  path: 'D:\\a\\wireit\\wireit\\temp\\0.9363364[123](https://github.com/google/wireit/actions/runs/3500283074/jobs/5862784350#step:7:124)985614'
}
Exiting early before testing is finished.
❌ [test:service] Failed with exit status 1
```

This adds some retry logic around that specific spot. This pattern may prove useful to do in other spots too, but just starting with the spot that I've been seeing a lot of failures for.