### PR TITLE
Add default excluded folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **[BREAKING]** The following folders are now excluded by default from both the
+  `files` and `output` arrays:
+
+  - `.git/`
+  - `.hg/`
+  - `.svn/`
+  - `.wireit/`
+  - `CVS/`
+  - `node_modules/`
+
+  In the highly unusual case that you need to reference a file in one of those
+  folders, set `allowUsuallyExcludedPaths: true` to remove all default excludes.
+
 ### Fixed
 
 - Fixed `Invalid string length` and `heap out of memory` errors when writing the

--- a/README.md
+++ b/README.md
@@ -261,6 +261,21 @@ Setting these properties allow you to use more features of Wireit:
 }
 ```
 
+#### Default excluded paths
+
+By default, the following folders are excluded from the `files` and `output`
+arrays:
+
+- `.git/`
+- `.hg/`
+- `.svn/`
+- `.wireit/`
+- `CVS/`
+- `node_modules/`
+
+In the highly unusual case that you need to reference a file in one of those
+folders, set `allowUsuallyExcludedPaths: true` to remove all default excludes.
+
 ## Incremental build
 
 Wireit can automatically skip execution of a script if nothing has changed that

--- a/schema.json
+++ b/schema.json
@@ -17,6 +17,10 @@
             "type": "string",
             "minLength": 1
           },
+          "allowUsuallyExcludedPaths": {
+            "markdownDescription": "By default, the following folders are excluded from the `files` and `output` arrays: `.wireit/`, `.git/`, and `node_modules/`. In the highly unusual case that you need to reference a file in one of those folders, set `allowUsuallyExcludedPaths` to `true` to remove these exclusions.\n\nFor more info see: https://github.com/google/wireit#default-excluded-paths",
+            "type": "boolean"
+          },
           "dependencies": {
             "markdownDescription": "Other npm scripts that will run before this one.\n\nThese scripts do not have to use wireit.\n\nDependencies can refer to scripts in other npm packages by using a relative path with the syntax `<relative-path>:<script-name>`. All cross-package dependencies should start with a `\".\"`. Cross-package dependencies work well for npm workspaces, as well as in other kinds of monorepos.\n\nFor example:\n\n```json\n\"dependencies\": [\n  \"build\",\n  \"./packages/foo:build\"\n]\n```\n\nFor more info, see https://github.com/google/wireit#dependencies",
             "items": {

--- a/schema.json
+++ b/schema.json
@@ -18,7 +18,7 @@
             "minLength": 1
           },
           "allowUsuallyExcludedPaths": {
-            "markdownDescription": "By default, the following folders are excluded from the `files` and `output` arrays: `.wireit/`, `.git/`, and `node_modules/`. In the highly unusual case that you need to reference a file in one of those folders, set `allowUsuallyExcludedPaths` to `true` to remove these exclusions.\n\nFor more info see: https://github.com/google/wireit#default-excluded-paths",
+            "markdownDescription": "By default, the following folders are excluded from the `files` and `output` arrays: `.git/`, `.hg/`, '.svn/', '.wireit/', 'CVS/', and `node_modules/`. In the highly unusual case that you need to reference a file in one of those folders, set `allowUsuallyExcludedPaths` to `true` to remove these exclusions.\n\nFor more info see: https://github.com/google/wireit#default-excluded-paths",
             "type": "boolean"
           },
           "dependencies": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -841,7 +841,7 @@ export class Analyzer {
       }
       values.push(result.value.value);
     }
-    if (!allowUsuallyExcludedPaths) {
+    if (!allowUsuallyExcludedPaths && values.length > 0) {
       values.push(...DEFAULT_EXCLUDE_PATHS);
     }
     return {node: filesNode, values};
@@ -898,7 +898,7 @@ export class Analyzer {
       }
       values.push(result.value.value);
     }
-    if (!allowUsuallyExcludedPaths) {
+    if (!allowUsuallyExcludedPaths && values.length > 0) {
       values.push(...DEFAULT_EXCLUDE_PATHS);
     }
     return {node: outputNode, values};

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -91,6 +91,22 @@ interface PlaceholderInfo {
 }
 
 /**
+ * Globs that will be injected into both `files` and `output`, unless
+ * `allowUsuallyExcludedPaths` is `true`.
+ *
+ * See https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files for the
+ * similar list of paths that npm ignores.
+ */
+const DEFAULT_EXCLUDE_PATHS = [
+  '!.git/',
+  '!.hg/',
+  '!.svn/',
+  '!.wireit/',
+  '!CVS/',
+  '!node_modules/',
+] as const;
+
+/**
  * Analyzes and validates a script along with all of its transitive
  * dependencies, producing a build graph that is ready to be executed.
  */
@@ -432,7 +448,18 @@ export class Analyzer {
       }
     }
 
-    const files = this._processFiles(placeholder, packageJson, syntaxInfo);
+    const allowUsuallyExcludedPaths = this._processAllowUsuallyExcludedPaths(
+      placeholder,
+      packageJson,
+      syntaxInfo
+    );
+
+    const files = this._processFiles(
+      placeholder,
+      packageJson,
+      syntaxInfo,
+      allowUsuallyExcludedPaths
+    );
 
     if (
       wireitConfig !== undefined &&
@@ -464,7 +491,8 @@ export class Analyzer {
       placeholder,
       packageJson,
       syntaxInfo,
-      command
+      command,
+      allowUsuallyExcludedPaths
     );
     const clean = this._processClean(placeholder, packageJson, syntaxInfo);
     const service = this._processService(
@@ -748,10 +776,45 @@ export class Analyzer {
     return {dependencies, encounteredError};
   }
 
-  private _processFiles(
+  private _processAllowUsuallyExcludedPaths(
     placeholder: UnvalidatedConfig,
     packageJson: PackageJson,
     syntaxInfo: ScriptSyntaxInfo
+  ): boolean {
+    const defaultValue = false;
+    if (syntaxInfo.wireitConfigNode == null) {
+      return defaultValue;
+    }
+    const node = findNodeAtLocation(syntaxInfo.wireitConfigNode, [
+      'allowUsuallyExcludedPaths',
+    ]);
+    if (node === undefined) {
+      return defaultValue;
+    }
+    if (node.value === true || node.value === false) {
+      return node.value;
+    }
+    placeholder.failures.push({
+      type: 'failure',
+      reason: 'invalid-config-syntax',
+      script: placeholder,
+      diagnostic: {
+        severity: 'error',
+        message: `Must be true or false`,
+        location: {
+          file: packageJson.jsonFile,
+          range: {length: node.length, offset: node.offset},
+        },
+      },
+    });
+    return defaultValue;
+  }
+
+  private _processFiles(
+    placeholder: UnvalidatedConfig,
+    packageJson: PackageJson,
+    syntaxInfo: ScriptSyntaxInfo,
+    allowUsuallyExcludedPaths: boolean
   ): undefined | ArrayNode<string> {
     if (syntaxInfo.wireitConfigNode === undefined) {
       return;
@@ -778,6 +841,9 @@ export class Analyzer {
       }
       values.push(result.value.value);
     }
+    if (!allowUsuallyExcludedPaths) {
+      values.push(...DEFAULT_EXCLUDE_PATHS);
+    }
     return {node: filesNode, values};
   }
 
@@ -785,7 +851,8 @@ export class Analyzer {
     placeholder: UnvalidatedConfig,
     packageJson: PackageJson,
     syntaxInfo: ScriptSyntaxInfo,
-    command: JsonAstNode<string> | undefined
+    command: JsonAstNode<string> | undefined,
+    allowUsuallyExcludedPaths: boolean
   ): undefined | ArrayNode<string> {
     if (syntaxInfo.wireitConfigNode === undefined) {
       return;
@@ -830,6 +897,9 @@ export class Analyzer {
         continue;
       }
       values.push(result.value.value);
+    }
+    if (!allowUsuallyExcludedPaths) {
+      values.push(...DEFAULT_EXCLUDE_PATHS);
     }
     return {node: outputNode, values};
   }

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -227,4 +227,41 @@ test(
   }
 );
 
+test('Default excluded paths are not present when files and output are empty', async ({
+  rig,
+}) => {
+  await rig.write({
+    'package.json': {
+      scripts: {
+        build: 'wireit',
+      },
+      wireit: {
+        build: {
+          command: 'true',
+          files: [],
+          output: [],
+          packageLocks: [],
+        },
+      },
+    },
+  });
+
+  const analyzer = new Analyzer();
+  const result = await analyzer.analyze(
+    {
+      packageDir: rig.temp,
+      name: 'build',
+    },
+    []
+  );
+  if (!result.config.ok) {
+    console.log(result.config.error);
+    throw new Error('Not ok');
+  }
+
+  const build = result.config.value;
+  assert.equal(build.files?.values, []);
+  assert.equal(build.output?.values, []);
+});
+
 test.run();

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -555,6 +555,35 @@ test(
 );
 
 test(
+  'allowUsuallyExcludedPaths is not a boolean',
+  timeout(async ({rig}) => {
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: 'true',
+            allowUsuallyExcludedPaths: 1,
+          },
+        },
+      },
+    });
+    const result = rig.exec('npm run a');
+    const done = await result.exit;
+    assert.equal(done.code, 1);
+    checkScriptOutput(
+      done.stderr,
+      `
+❌ package.json:8:36 Must be true or false
+          "allowUsuallyExcludedPaths": 1
+                                       ~`
+    );
+  })
+);
+
+test(
   'packageLocks is not an array',
   timeout(async ({rig}) => {
     await rig.write({


### PR DESCRIPTION
The following folders are now excluded by default from both the `files` and `output` arrays:

- `.git/`
- `.hg/`
- `.svn/`
- `.wireit/`
- `CVS/`
- `node_modules/`

In the highly unusual case that a user needs to reference a file in one of those folders, they can set `allowUsuallyExcludedPaths: true` to remove all of these default excludes.

Tracking something inside `node_modules/` is a *somewhat* plausible thing that a user might occasionally want to do.

The reason this didn't come up until recently is that I've always been testing on projects which have e.g. `src/`, `lib/`, `dist/` etc. top-level folders that cleanly partition relevant inputs/outputs. However, I am now trying to integrate with a project that has its source very flat, so the file patterns look like e.g. simply `**/*.js`, and I don't want to have to explicitly write exclude patterns for these folders, which are almost always not desired.