### PR TITLE
Fix fast-glob issue with trailing slashes on ignored folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed `Invalid string length` and `heap out of memory` errors when writing the
   fingerprint files for large script graphs.
 
+- Fixed bug where an exclude pattern for a folder with a trailing slash would
+  not be applied (e.g. `!foo` worked but `!foo/` did not).
+
 ## [0.7.3] - 2022-11-14
 
 ### Added

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -162,6 +162,38 @@ test('* star with ! negation', ({check}) =>
     expected: ['foo', 'baz'],
   }));
 
+test('inclusion of directory with trailing slash', ({check}) =>
+  check({
+    files: ['foo/good/1', 'foo/good/2'],
+    patterns: ['foo/'],
+    expected: ['foo/good/1', 'foo/good/2'],
+    expandDirectories: true,
+  }));
+
+test('inclusion of directory without trailing slash', ({check}) =>
+  check({
+    files: ['foo/good/1', 'foo/good/2'],
+    patterns: ['foo'],
+    expected: ['foo/good/1', 'foo/good/2'],
+    expandDirectories: true,
+  }));
+
+test('!exclusion of directory with trailing slash', ({check}) =>
+  check({
+    files: ['foo/good/1', 'foo/bad/1'],
+    patterns: ['foo', '!foo/bad/'],
+    expected: ['foo/good/1'],
+    expandDirectories: true,
+  }));
+
+test('!exclusion of directory without trailing slash', ({check}) =>
+  check({
+    files: ['foo/good/1', 'foo/bad/1'],
+    patterns: ['foo', '!foo/bad'],
+    expected: ['foo/good/1'],
+    expandDirectories: true,
+  }));
+
 test('explicit .dotfile', ({check}) =>
   check({
     files: ['.foo'],


### PR DESCRIPTION
I noticed a bug where if you pass a folder with a trailing slash to fast-glob's `ignore` list, it has no effect (e.g. you have to pass `"foo/ignore"`, not `"foo/ignore/"`)! Now we normalize exclude paths to account for this.