### PR TITLE
Run all glob tests against chokidar too

### DIFF
--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -120,491 +120,496 @@ test.after.each(async (ctx) => {
   }
 });
 
-test('empty patterns', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: [],
-    expected: [],
-  }));
+for (const mode of ['once', 'watch'] as const) {
+  test('empty patterns', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: [],
+      expected: [],
+    }));
 
-test('normalizes trailing / in pattern', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['foo/'],
-    expected: ['foo'],
-  }));
+  test('normalizes trailing / in pattern', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['foo/'],
+      expected: ['foo'],
+    }));
 
-test('normalizes ../ in pattern', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['bar/../foo'],
-    expected: ['foo'],
-  }));
+  test('normalizes ../ in pattern', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['bar/../foo'],
+      expected: ['foo'],
+    }));
 
-test('explicit file that does not exist', ({check}) =>
-  check({
-    files: [],
-    patterns: ['foo'],
-    expected: [],
-  }));
+  test('explicit file that does not exist', ({check}) =>
+    check({
+      files: [],
+      patterns: ['foo'],
+      expected: [],
+    }));
 
-test('* star', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: ['*'],
-    expected: ['foo', 'bar'],
-  }));
+  test('* star', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: ['*'],
+      expected: ['foo', 'bar'],
+    }));
 
-test('* star with ! negation', ({check}) =>
-  check({
-    files: ['foo', 'bar', 'baz'],
-    patterns: ['*', '!bar'],
-    expected: ['foo', 'baz'],
-  }));
+  test('* star with ! negation', ({check}) =>
+    check({
+      files: ['foo', 'bar', 'baz'],
+      patterns: ['*', '!bar'],
+      expected: ['foo', 'baz'],
+    }));
 
-test('inclusion of directory with trailing slash', ({check}) =>
-  check({
-    files: ['foo/good/1', 'foo/good/2'],
-    patterns: ['foo/'],
-    expected: ['foo/good/1', 'foo/good/2'],
-    expandDirectories: true,
-  }));
+  test('inclusion of directory with trailing slash', ({check}) =>
+    check({
+      files: ['foo/good/1', 'foo/good/2'],
+      patterns: ['foo/'],
+      expected: ['foo/good/1', 'foo/good/2'],
+      expandDirectories: true,
+    }));
 
-test('inclusion of directory without trailing slash', ({check}) =>
-  check({
-    files: ['foo/good/1', 'foo/good/2'],
-    patterns: ['foo'],
-    expected: ['foo/good/1', 'foo/good/2'],
-    expandDirectories: true,
-  }));
+  test('inclusion of directory without trailing slash', ({check}) =>
+    check({
+      files: ['foo/good/1', 'foo/good/2'],
+      patterns: ['foo'],
+      expected: ['foo/good/1', 'foo/good/2'],
+      expandDirectories: true,
+    }));
 
-test('!exclusion of directory with trailing slash', ({check}) =>
-  check({
-    files: ['foo/good/1', 'foo/bad/1'],
-    patterns: ['foo', '!foo/bad/'],
-    expected: ['foo/good/1'],
-    expandDirectories: true,
-  }));
+  test('!exclusion of directory with trailing slash', ({check}) =>
+    check({
+      files: ['foo/good/1', 'foo/bad/1'],
+      patterns: ['foo', '!foo/bad/'],
+      expected: ['foo/good/1'],
+      expandDirectories: true,
+    }));
 
-test('!exclusion of directory without trailing slash', ({check}) =>
-  check({
-    files: ['foo/good/1', 'foo/bad/1'],
-    patterns: ['foo', '!foo/bad'],
-    expected: ['foo/good/1'],
-    expandDirectories: true,
-  }));
+  test('!exclusion of directory without trailing slash', ({check}) =>
+    check({
+      files: ['foo/good/1', 'foo/bad/1'],
+      patterns: ['foo', '!foo/bad'],
+      expected: ['foo/good/1'],
+      expandDirectories: true,
+    }));
 
-test('explicit .dotfile', ({check}) =>
-  check({
-    files: ['.foo'],
-    patterns: ['.foo'],
-    expected: ['.foo'],
-  }));
+  test('explicit .dotfile', ({check}) =>
+    check({
+      files: ['.foo'],
+      patterns: ['.foo'],
+      expected: ['.foo'],
+    }));
 
-test('* star matches .dotfiles', ({check}) =>
-  check({
-    files: ['.foo'],
-    patterns: ['*'],
-    expected: ['.foo'],
-  }));
+  test('* star matches .dotfiles', ({check}) =>
+    check({
+      files: ['.foo'],
+      patterns: ['*'],
+      expected: ['.foo'],
+    }));
 
-test('{} groups', ({check}) =>
-  check({
-    files: ['foo', 'bar', 'baz'],
-    patterns: ['{foo,baz}'],
-    expected: ['foo', 'baz'],
-  }));
+  test('{} groups', ({check}) =>
+    check({
+      files: ['foo', 'bar', 'baz'],
+      patterns: ['{foo,baz}'],
+      expected: ['foo', 'baz'],
+    }));
 
-test('matches explicit symlink', ({check}) =>
-  check({
-    files: ['target', {target: 'target', path: 'symlink', windowsType: 'file'}],
-    patterns: ['symlink'],
-    expected: ['symlink'],
-  }));
+  test('matches explicit symlink', ({check}) =>
+    check({
+      files: [
+        'target',
+        {target: 'target', path: 'symlink', windowsType: 'file'},
+      ],
+      patterns: ['symlink'],
+      expected: ['symlink'],
+    }));
 
-test('explicit directory excluded when includeDirectories=false', ({check}) =>
-  check({
-    files: ['foo/'],
-    patterns: ['foo'],
-    expected: [],
-  }));
+  test('explicit directory excluded when includeDirectories=false', ({check}) =>
+    check({
+      files: ['foo/'],
+      patterns: ['foo'],
+      expected: [],
+    }));
 
-test('explicit directory included when includeDirectories=true', ({check}) =>
-  check({
-    files: ['foo/'],
-    patterns: ['foo'],
-    expected: ['foo'],
-    includeDirectories: true,
-  }));
+  test('explicit directory included when includeDirectories=true', ({check}) =>
+    check({
+      files: ['foo/'],
+      patterns: ['foo'],
+      expected: ['foo'],
+      includeDirectories: true,
+    }));
 
-test('* star excludes directory when includeDirectories=false', ({check}) =>
-  check({
-    files: ['foo/'],
-    patterns: ['*'],
-    expected: [],
-  }));
+  test('* star excludes directory when includeDirectories=false', ({check}) =>
+    check({
+      files: ['foo/'],
+      patterns: ['*'],
+      expected: [],
+    }));
 
-test('* star includes directory when includeDirectories=true', ({check}) =>
-  check({
-    files: ['foo/'],
-    patterns: ['*'],
-    expected: ['foo'],
-    includeDirectories: true,
-  }));
+  test('* star includes directory when includeDirectories=true', ({check}) =>
+    check({
+      files: ['foo/'],
+      patterns: ['*'],
+      expected: ['foo'],
+      includeDirectories: true,
+    }));
 
-test('includeDirectories=false + expandDirectories=false', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['foo'],
-    expected: [],
-    includeDirectories: false,
-    expandDirectories: false,
-  }));
+  test('includeDirectories=false + expandDirectories=false', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['foo'],
+      expected: [],
+      includeDirectories: false,
+      expandDirectories: false,
+    }));
 
-test('includeDirectories=true + expandDirectories=false', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['foo'],
-    expected: ['foo'],
-    includeDirectories: true,
-    expandDirectories: false,
-  }));
+  test('includeDirectories=true + expandDirectories=false', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['foo'],
+      expected: ['foo'],
+      includeDirectories: true,
+      expandDirectories: false,
+    }));
 
-test('includeDirectories=false + expandDirectories=true', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['foo'],
-    expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
-    includeDirectories: false,
-    expandDirectories: true,
-  }));
+  test('includeDirectories=false + expandDirectories=true', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['foo'],
+      expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
+      includeDirectories: false,
+      expandDirectories: true,
+    }));
 
-test('includeDirectories=true + expandDirectories=true', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['foo'],
-    expected: [
-      'foo',
-      'foo/1',
-      'foo/2',
-      'foo/bar',
-      'foo/bar/1',
-      'foo/bar/2',
-      'foo/baz',
-    ],
-    includeDirectories: true,
-    expandDirectories: true,
-  }));
+  test('includeDirectories=true + expandDirectories=true', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['foo'],
+      expected: [
+        'foo',
+        'foo/1',
+        'foo/2',
+        'foo/bar',
+        'foo/bar/1',
+        'foo/bar/2',
+        'foo/baz',
+      ],
+      includeDirectories: true,
+      expandDirectories: true,
+    }));
 
-test('includeDirectories=true + expandDirectories=true + recursive !exclusion', ({
-  check,
-}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: [
-      'foo',
-      // This exclusion pattern needs to match recursively too. We don't just
-      // exclude the "foo/bar" directory, we also exclude its recursive
-      // children.
-      '!foo/bar',
-    ],
-    expected: ['foo', 'foo/1', 'foo/2', 'foo/baz'],
-    includeDirectories: true,
-    expandDirectories: true,
-  }));
+  test('includeDirectories=true + expandDirectories=true + recursive !exclusion', ({
+    check,
+  }) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: [
+        'foo',
+        // This exclusion pattern needs to match recursively too. We don't just
+        // exclude the "foo/bar" directory, we also exclude its recursive
+        // children.
+        '!foo/bar',
+      ],
+      expected: ['foo', 'foo/1', 'foo/2', 'foo/baz'],
+      includeDirectories: true,
+      expandDirectories: true,
+    }));
 
-test('. matches current directory with includeDirectories=true', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['.'],
-    expected: ['.'],
-    includeDirectories: true,
-  }));
+  test('. matches current directory with includeDirectories=true', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['.'],
+      expected: ['.'],
+      includeDirectories: true,
+    }));
 
-test('. matches current directory with expandDirectories=true', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['.'],
-    expected: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
-    expandDirectories: true,
-  }));
+  test('. matches current directory with expandDirectories=true', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['.'],
+      expected: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
+      expandDirectories: true,
+    }));
 
-test('{} groups with expand directories', ({check}) =>
-  check({
-    files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-    patterns: ['{foo,baz}'],
-    expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
-    expandDirectories: true,
-  }));
+  test('{} groups with expand directories', ({check}) =>
+    check({
+      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
+      patterns: ['{foo,baz}'],
+      expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
+      expandDirectories: true,
+    }));
 
-test('empty pattern throws', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: [''],
-    expected: 'ERROR',
-  }));
+  test('empty pattern throws', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: [''],
+      expected: 'ERROR',
+    }));
 
-test('empty pattern throws with expandDirectories=true', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: [''],
-    expected: 'ERROR',
-    expandDirectories: true,
-  }));
+  test('empty pattern throws with expandDirectories=true', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: [''],
+      expected: 'ERROR',
+      expandDirectories: true,
+    }));
 
-test('whitespace pattern throws', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: [' '],
-    expected: 'ERROR',
-  }));
+  test('whitespace pattern throws', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: [' '],
+      expected: 'ERROR',
+    }));
 
-test('whitespace pattern throws with expandDirectories=true', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: [' '],
-    expected: 'ERROR',
-    expandDirectories: true,
-  }));
+  test('whitespace pattern throws with expandDirectories=true', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: [' '],
+      expected: 'ERROR',
+      expandDirectories: true,
+    }));
 
-test('re-inclusion of file', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['!foo', 'foo'],
-    expected: ['foo'],
-  }));
+  test('re-inclusion of file', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['!foo', 'foo'],
+      expected: ['foo'],
+    }));
 
-test('re-inclusion of directory', ({check}) =>
-  check({
-    files: ['foo/'],
-    patterns: ['!foo', 'foo'],
-    expected: ['foo'],
-    includeDirectories: true,
-  }));
+  test('re-inclusion of directory', ({check}) =>
+    check({
+      files: ['foo/'],
+      patterns: ['!foo', 'foo'],
+      expected: ['foo'],
+      includeDirectories: true,
+    }));
 
-test('re-inclusion of file into directory', ({check}) =>
-  check({
-    files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
-    patterns: ['foo/**', '!foo/bar/**', 'foo/bar/baz', '!foo/qux'],
-    expected: ['foo/1', 'foo/bar/baz'],
-  }));
+  test('re-inclusion of file into directory', ({check}) =>
+    check({
+      files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
+      patterns: ['foo/**', '!foo/bar/**', 'foo/bar/baz', '!foo/qux'],
+      expected: ['foo/1', 'foo/bar/baz'],
+    }));
 
-test('re-inclusion of file into directory with expandDirectories=true', ({
-  check,
-}) =>
-  check({
-    files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
-    patterns: ['foo', '!foo/bar', 'foo/bar/baz', '!foo/qux'],
-    expected: ['foo/1', 'foo/bar/baz'],
-    expandDirectories: true,
-  }));
+  test('re-inclusion of file into directory with expandDirectories=true', ({
+    check,
+  }) =>
+    check({
+      files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
+      patterns: ['foo', '!foo/bar', 'foo/bar/baz', '!foo/qux'],
+      expected: ['foo/1', 'foo/bar/baz'],
+      expandDirectories: true,
+    }));
 
-test('re-inclusion of directory into directory with expandDirectories=true', ({
-  check,
-}) =>
-  check({
-    files: ['foo/1', 'foo/bar/1', 'foo/bar/baz/1'],
-    patterns: ['foo', '!foo/bar', 'foo/bar/baz'],
-    expected: ['foo/1', 'foo/bar/baz/1'],
-    expandDirectories: true,
-  }));
+  test('re-inclusion of directory into directory with expandDirectories=true', ({
+    check,
+  }) =>
+    check({
+      files: ['foo/1', 'foo/bar/1', 'foo/bar/baz/1'],
+      patterns: ['foo', '!foo/bar', 'foo/bar/baz'],
+      expected: ['foo/1', 'foo/bar/baz/1'],
+      expandDirectories: true,
+    }));
 
-test('walks through symlinked directories when followSymlinks=true', ({
-  check,
-}) =>
-  check({
-    files: [
-      'target/foo',
-      {target: 'target', path: 'symlink', windowsType: 'dir'},
-    ],
-    patterns: ['**'],
-    expected: ['target', 'target/foo', 'symlink', 'symlink/foo'],
-    includeDirectories: true,
-    followSymlinks: true,
-  }));
+  test('walks through symlinked directories when followSymlinks=true', ({
+    check,
+  }) =>
+    check({
+      files: [
+        'target/foo',
+        {target: 'target', path: 'symlink', windowsType: 'dir'},
+      ],
+      patterns: ['**'],
+      expected: ['target', 'target/foo', 'symlink', 'symlink/foo'],
+      includeDirectories: true,
+      followSymlinks: true,
+    }));
 
-test('does not walk through symlinked directories when followSymlinks=false', ({
-  check,
-}) =>
-  check({
-    files: [
-      'target/foo',
-      {target: 'target', path: 'symlink', windowsType: 'dir'},
-    ],
-    patterns: ['**'],
-    expected: ['target', 'target/foo', 'symlink'],
-    includeDirectories: true,
-    followSymlinks: false,
-  }));
+  test('does not walk through symlinked directories when followSymlinks=false', ({
+    check,
+  }) =>
+    check({
+      files: [
+        'target/foo',
+        {target: 'target', path: 'symlink', windowsType: 'dir'},
+      ],
+      patterns: ['**'],
+      expected: ['target', 'target/foo', 'symlink'],
+      includeDirectories: true,
+      followSymlinks: false,
+    }));
 
-test('dirent tags files', async ({rig}) => {
-  await rig.touch('foo');
-  const actual = await glob(['foo'], {
-    cwd: rig.temp,
-    followSymlinks: true,
-    includeDirectories: true,
-    expandDirectories: false,
-    throwIfOutsideCwd: false,
+  test('dirent tags files', async ({rig}) => {
+    await rig.touch('foo');
+    const actual = await glob(['foo'], {
+      cwd: rig.temp,
+      followSymlinks: true,
+      includeDirectories: true,
+      expandDirectories: false,
+      throwIfOutsideCwd: false,
+    });
+    assert.equal(actual.length, 1);
+    assert.equal(actual[0].path, rig.resolve('foo'));
+    assert.ok(actual[0].dirent.isFile());
+    assert.not(actual[0].dirent.isDirectory());
+    assert.not(actual[0].dirent.isSymbolicLink());
   });
-  assert.equal(actual.length, 1);
-  assert.equal(actual[0].path, rig.resolve('foo'));
-  assert.ok(actual[0].dirent.isFile());
-  assert.not(actual[0].dirent.isDirectory());
-  assert.not(actual[0].dirent.isSymbolicLink());
-});
 
-test('dirent tags directories', async ({rig}) => {
-  await rig.mkdir('foo');
-  const actual = await glob(['foo'], {
-    cwd: rig.temp,
-    followSymlinks: true,
-    includeDirectories: true,
-    expandDirectories: false,
-    throwIfOutsideCwd: false,
+  test('dirent tags directories', async ({rig}) => {
+    await rig.mkdir('foo');
+    const actual = await glob(['foo'], {
+      cwd: rig.temp,
+      followSymlinks: true,
+      includeDirectories: true,
+      expandDirectories: false,
+      throwIfOutsideCwd: false,
+    });
+    assert.equal(actual.length, 1);
+    assert.equal(actual[0].path, rig.resolve('foo'));
+    assert.not(actual[0].dirent.isFile());
+    assert.ok(actual[0].dirent.isDirectory());
+    assert.not(actual[0].dirent.isSymbolicLink());
   });
-  assert.equal(actual.length, 1);
-  assert.equal(actual[0].path, rig.resolve('foo'));
-  assert.not(actual[0].dirent.isFile());
-  assert.ok(actual[0].dirent.isDirectory());
-  assert.not(actual[0].dirent.isSymbolicLink());
-});
 
-test('dirent tags symlinks when followSymlinks=false', async ({rig}) => {
-  await rig.symlink('target', 'foo', 'file');
-  const actual = await glob(['foo'], {
-    cwd: rig.temp,
-    followSymlinks: false,
-    includeDirectories: true,
-    expandDirectories: false,
-    throwIfOutsideCwd: false,
+  test('dirent tags symlinks when followSymlinks=false', async ({rig}) => {
+    await rig.symlink('target', 'foo', 'file');
+    const actual = await glob(['foo'], {
+      cwd: rig.temp,
+      followSymlinks: false,
+      includeDirectories: true,
+      expandDirectories: false,
+      throwIfOutsideCwd: false,
+    });
+    assert.equal(actual.length, 1);
+    assert.equal(actual[0].path, rig.resolve('foo'));
+    assert.not(actual[0].dirent.isFile());
+    assert.not(actual[0].dirent.isDirectory());
+    assert.ok(actual[0].dirent.isSymbolicLink());
   });
-  assert.equal(actual.length, 1);
-  assert.equal(actual[0].path, rig.resolve('foo'));
-  assert.not(actual[0].dirent.isFile());
-  assert.not(actual[0].dirent.isDirectory());
-  assert.ok(actual[0].dirent.isSymbolicLink());
-});
 
-test('dirent tags symlinks to files as files when followSymlinks=true', async ({
-  rig,
-}) => {
-  await rig.symlink('target', 'foo', 'file');
-  await rig.touch('target');
-  const actual = await glob(['foo'], {
-    cwd: rig.temp,
-    followSymlinks: true,
-    includeDirectories: true,
-    expandDirectories: false,
-    throwIfOutsideCwd: false,
+  test('dirent tags symlinks to files as files when followSymlinks=true', async ({
+    rig,
+  }) => {
+    await rig.symlink('target', 'foo', 'file');
+    await rig.touch('target');
+    const actual = await glob(['foo'], {
+      cwd: rig.temp,
+      followSymlinks: true,
+      includeDirectories: true,
+      expandDirectories: false,
+      throwIfOutsideCwd: false,
+    });
+    assert.equal(actual.length, 1);
+    assert.equal(actual[0].path, rig.resolve('foo'));
+    assert.ok(actual[0].dirent.isFile());
+    assert.not(actual[0].dirent.isDirectory());
+    assert.not(actual[0].dirent.isSymbolicLink());
   });
-  assert.equal(actual.length, 1);
-  assert.equal(actual[0].path, rig.resolve('foo'));
-  assert.ok(actual[0].dirent.isFile());
-  assert.not(actual[0].dirent.isDirectory());
-  assert.not(actual[0].dirent.isSymbolicLink());
-});
 
-test('dirent tags symlinks to directories as directories when followSymlinks=true', async ({
-  rig,
-}) => {
-  await rig.symlink('target', 'foo', 'dir');
-  await rig.mkdir('target');
-  const actual = await glob(['foo'], {
-    cwd: rig.temp,
-    followSymlinks: true,
-    includeDirectories: true,
-    expandDirectories: false,
-    throwIfOutsideCwd: false,
+  test('dirent tags symlinks to directories as directories when followSymlinks=true', async ({
+    rig,
+  }) => {
+    await rig.symlink('target', 'foo', 'dir');
+    await rig.mkdir('target');
+    const actual = await glob(['foo'], {
+      cwd: rig.temp,
+      followSymlinks: true,
+      includeDirectories: true,
+      expandDirectories: false,
+      throwIfOutsideCwd: false,
+    });
+    assert.equal(actual.length, 1);
+    assert.equal(actual[0].path, rig.resolve('foo'));
+    assert.not(actual[0].dirent.isFile());
+    assert.ok(actual[0].dirent.isDirectory());
+    assert.not(actual[0].dirent.isSymbolicLink());
   });
-  assert.equal(actual.length, 1);
-  assert.equal(actual[0].path, rig.resolve('foo'));
-  assert.not(actual[0].dirent.isFile());
-  assert.ok(actual[0].dirent.isDirectory());
-  assert.not(actual[0].dirent.isSymbolicLink());
-});
 
-test('re-roots to cwd', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['/foo'],
-    expected: ['foo'],
-  }));
+  test('re-roots to cwd', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['/foo'],
+      expected: ['foo'],
+    }));
 
-test('re-roots to cwd with exclusion', ({check}) =>
-  check({
-    files: ['foo', 'bar', 'baz'],
-    patterns: ['/*', '!/bar'],
-    expected: ['foo', 'baz'],
-  }));
+  test('re-roots to cwd with exclusion', ({check}) =>
+    check({
+      files: ['foo', 'bar', 'baz'],
+      patterns: ['/*', '!/bar'],
+      expected: ['foo', 'baz'],
+    }));
 
-test('re-rooting allows ../', ({check}) =>
-  check({
-    cwd: 'subdir',
-    files: ['foo', 'subdir/'],
-    patterns: ['../foo'],
-    expected: ['foo'],
-  }));
+  test('re-rooting allows ../', ({check}) =>
+    check({
+      cwd: 'subdir',
+      files: ['foo', 'subdir/'],
+      patterns: ['../foo'],
+      expected: ['foo'],
+    }));
 
-test('re-rooting handles /./foo', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['/./foo'],
-    expected: ['foo'],
-  }));
+  test('re-rooting handles /./foo', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['/./foo'],
+      expected: ['foo'],
+    }));
 
-test('re-rooting handles /../foo', ({check}) =>
-  check({
-    cwd: 'subdir',
-    files: ['foo', 'subdir/'],
-    patterns: ['/../foo'],
-    expected: ['foo'],
-  }));
+  test('re-rooting handles /../foo', ({check}) =>
+    check({
+      cwd: 'subdir',
+      files: ['foo', 'subdir/'],
+      patterns: ['/../foo'],
+      expected: ['foo'],
+    }));
 
-test('re-rooting handles /bar/../foo/', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['/bar/../foo/'],
-    expected: ['foo'],
-  }));
+  test('re-rooting handles /bar/../foo/', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['/bar/../foo/'],
+      expected: ['foo'],
+    }));
 
-test('re-roots to cwd with braces', ({check}) =>
-  check({
-    files: ['foo', 'bar'],
-    patterns: ['{/foo,/bar}'],
-    expected: ['foo', 'bar'],
-  }));
+  test('re-roots to cwd with braces', ({check}) =>
+    check({
+      files: ['foo', 'bar'],
+      patterns: ['{/foo,/bar}'],
+      expected: ['foo', 'bar'],
+    }));
 
-test('braces can be escaped', ({check}) =>
-  check({
-    files: ['{foo,bar}'],
-    patterns: ['\\{foo,bar\\}'],
-    expected: ['{foo,bar}'],
-  }));
+  test('braces can be escaped', ({check}) =>
+    check({
+      files: ['{foo,bar}'],
+      patterns: ['\\{foo,bar\\}'],
+      expected: ['{foo,bar}'],
+    }));
 
-test('disallows path outside cwd when throwIfOutsideCwd=true', ({check}) =>
-  check({
-    cwd: 'subdir',
-    files: ['foo', 'subdir/'],
-    patterns: ['../foo'],
-    expected: 'ERROR',
-    throwIfOutsideCwd: true,
-  }));
+  test('disallows path outside cwd when throwIfOutsideCwd=true', ({check}) =>
+    check({
+      cwd: 'subdir',
+      files: ['foo', 'subdir/'],
+      patterns: ['../foo'],
+      expected: 'ERROR',
+      throwIfOutsideCwd: true,
+    }));
 
-test('allows path outside cwd when throwIfOutsideCwd=false', ({check}) =>
-  check({
-    cwd: 'subdir',
-    files: ['foo', 'subdir/'],
-    patterns: ['../foo'],
-    expected: ['foo'],
-    throwIfOutsideCwd: false,
-  }));
+  test('allows path outside cwd when throwIfOutsideCwd=false', ({check}) =>
+    check({
+      cwd: 'subdir',
+      files: ['foo', 'subdir/'],
+      patterns: ['../foo'],
+      expected: ['foo'],
+      throwIfOutsideCwd: false,
+    }));
 
-test('allows path inside cwd when throwIfOutsideCwd=true', ({check}) =>
-  check({
-    files: ['foo'],
-    patterns: ['foo'],
-    expected: ['foo'],
-    throwIfOutsideCwd: true,
-  }));
+  test('allows path inside cwd when throwIfOutsideCwd=true', ({check}) =>
+    check({
+      files: ['foo'],
+      patterns: ['foo'],
+      expected: ['foo'],
+      throwIfOutsideCwd: true,
+    }));
+}
 
 test.run();

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -10,6 +10,7 @@ import {suite} from 'uvu';
 import {glob} from '../util/glob.js';
 import {FilesystemTestRig} from './util/filesystem-test-rig.js';
 import {makeWatcher} from '../watcher.js';
+import {IS_WINDOWS} from '../util/windows.js';
 
 interface Symlink {
   /** Where the symlink file points to. */
@@ -156,6 +157,7 @@ test.after.each(async (ctx) => {
 for (const mode of ['once', 'watch'] as const) {
   test(`[${mode}] empty patterns`, ({check}) =>
     check({
+      mode,
       files: ['foo'],
       patterns: [],
       expected: [],
@@ -163,6 +165,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] normalizes trailing / in pattern`, ({check}) =>
     check({
+      mode,
       files: ['foo'],
       patterns: ['foo/'],
       expected: ['foo'],
@@ -170,6 +173,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] normalizes ../ in pattern`, ({check}) =>
     check({
+      mode,
       files: ['foo'],
       patterns: ['bar/../foo'],
       expected: ['foo'],
@@ -177,6 +181,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] explicit file that does not exist`, ({check}) =>
     check({
+      mode,
       files: [],
       patterns: ['foo'],
       expected: [],
@@ -184,6 +189,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] * star`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar'],
       patterns: ['*'],
       expected: ['foo', 'bar'],
@@ -191,6 +197,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] * star with ! negation`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar', 'baz'],
       patterns: ['*', '!bar'],
       expected: ['foo', 'baz'],
@@ -198,6 +205,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] inclusion of directory with trailing slash`, ({check}) =>
     check({
+      mode,
       files: ['foo/good/1', 'foo/good/2'],
       patterns: ['foo/'],
       expected: ['foo/good/1', 'foo/good/2'],
@@ -206,6 +214,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] inclusion of directory without trailing slash`, ({check}) =>
     check({
+      mode,
       files: ['foo/good/1', 'foo/good/2'],
       patterns: ['foo'],
       expected: ['foo/good/1', 'foo/good/2'],
@@ -214,6 +223,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] !exclusion of directory with trailing slash`, ({check}) =>
     check({
+      mode,
       files: ['foo/good/1', 'foo/bad/1'],
       patterns: ['foo', '!foo/bad/'],
       expected: ['foo/good/1'],
@@ -222,6 +232,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] !exclusion of directory without trailing slash`, ({check}) =>
     check({
+      mode,
       files: ['foo/good/1', 'foo/bad/1'],
       patterns: ['foo', '!foo/bad'],
       expected: ['foo/good/1'],
@@ -230,6 +241,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] explicit .dotfile`, ({check}) =>
     check({
+      mode,
       files: ['.foo'],
       patterns: ['.foo'],
       expected: ['.foo'],
@@ -237,6 +249,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] * star matches .dotfiles`, ({check}) =>
     check({
+      mode,
       files: ['.foo'],
       patterns: ['*'],
       expected: ['.foo'],
@@ -244,6 +257,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] {} groups`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar', 'baz'],
       patterns: ['{foo,baz}'],
       expected: ['foo', 'baz'],
@@ -251,6 +265,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] matches explicit symlink`, ({check}) =>
     check({
+      mode,
       files: [
         'target',
         {target: 'target', path: 'symlink', windowsType: 'file'},
@@ -263,6 +278,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/'],
       patterns: ['foo'],
       expected: [],
@@ -272,6 +288,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/'],
       patterns: ['foo'],
       expected: ['foo'],
@@ -282,6 +299,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/'],
       patterns: ['*'],
       expected: [],
@@ -291,6 +309,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/'],
       patterns: ['*'],
       expected: ['foo'],
@@ -301,6 +320,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
       expected: [],
@@ -312,6 +332,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
       expected: ['foo'],
@@ -323,6 +344,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
       expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
@@ -334,6 +356,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
       expected: [
@@ -353,6 +376,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: [
         'foo',
@@ -370,6 +394,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['.'],
       expected: ['.'],
@@ -380,6 +405,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['.'],
       expected: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
@@ -388,6 +414,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] {} groups with expand directories`, ({check}) =>
     check({
+      mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['{foo,baz}'],
       expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
@@ -396,6 +423,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] empty pattern throws`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar'],
       patterns: [''],
       expected: 'ERROR',
@@ -405,6 +433,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo', 'bar'],
       patterns: [''],
       expected: 'ERROR',
@@ -412,31 +441,32 @@ for (const mode of ['once', 'watch'] as const) {
     }));
 
   test(`[${mode}] whitespace pattern throws`, ({check}) =>
-    check({
-      files: ['foo', 'bar'],
-      patterns: [' '],
-      expected: 'ERROR',
-    }));
+    check({mode, files: ['foo', 'bar'], patterns: [' '], expected: 'ERROR'}));
 
   test(`[${mode}] whitespace pattern throws with expandDirectories=true`, ({
     check,
   }) =>
     check({
+      mode,
       files: ['foo', 'bar'],
       patterns: [' '],
       expected: 'ERROR',
       expandDirectories: true,
     }));
 
-  test(`[${mode}] re-inclusion of file`, ({check}) =>
-    check({
-      files: ['foo'],
-      patterns: ['!foo', 'foo'],
-      expected: ['foo'],
-    }));
+  if (!(mode === 'watch' && IS_WINDOWS)) {
+    test(`[${mode}] re-inclusion of file`, ({check}) =>
+      check({
+        mode,
+        files: ['foo'],
+        patterns: ['!foo', 'foo'],
+        expected: ['foo'],
+      }));
+  }
 
   test(`[${mode}] re-inclusion of directory`, ({check}) =>
     check({
+      mode,
       files: ['foo/'],
       patterns: ['!foo', 'foo'],
       expected: ['foo'],
@@ -445,6 +475,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] re-inclusion of file into directory`, ({check}) =>
     check({
+      mode,
       files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
       patterns: ['foo/**', '!foo/bar/**', 'foo/bar/baz', '!foo/qux'],
       expected: ['foo/1', 'foo/bar/baz'],
@@ -454,6 +485,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
       patterns: ['foo', '!foo/bar', 'foo/bar/baz', '!foo/qux'],
       expected: ['foo/1', 'foo/bar/baz'],
@@ -464,6 +496,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo/1', 'foo/bar/1', 'foo/bar/baz/1'],
       patterns: ['foo', '!foo/bar', 'foo/bar/baz'],
       expected: ['foo/1', 'foo/bar/baz/1'],
@@ -474,6 +507,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: [
         'target/foo',
         {target: 'target', path: 'symlink', windowsType: 'dir'},
@@ -488,6 +522,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: [
         'target/foo',
         {target: 'target', path: 'symlink', windowsType: 'dir'},
@@ -587,14 +622,11 @@ for (const mode of ['once', 'watch'] as const) {
   });
 
   test(`[${mode}] re-roots to cwd`, ({check}) =>
-    check({
-      files: ['foo'],
-      patterns: ['/foo'],
-      expected: ['foo'],
-    }));
+    check({mode, files: ['foo'], patterns: ['/foo'], expected: ['foo']}));
 
   test(`[${mode}] re-roots to cwd with exclusion`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar', 'baz'],
       patterns: ['/*', '!/bar'],
       expected: ['foo', 'baz'],
@@ -602,6 +634,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] re-rooting allows ../`, ({check}) =>
     check({
+      mode,
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
       patterns: ['../foo'],
@@ -609,14 +642,11 @@ for (const mode of ['once', 'watch'] as const) {
     }));
 
   test(`[${mode}] re-rooting handles /./foo`, ({check}) =>
-    check({
-      files: ['foo'],
-      patterns: ['/./foo'],
-      expected: ['foo'],
-    }));
+    check({mode, files: ['foo'], patterns: ['/./foo'], expected: ['foo']}));
 
   test(`[${mode}] re-rooting handles /../foo`, ({check}) =>
     check({
+      mode,
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
       patterns: ['/../foo'],
@@ -625,6 +655,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] re-rooting handles /bar/../foo/`, ({check}) =>
     check({
+      mode,
       files: ['foo'],
       patterns: ['/bar/../foo/'],
       expected: ['foo'],
@@ -632,6 +663,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] re-roots to cwd with braces`, ({check}) =>
     check({
+      mode,
       files: ['foo', 'bar'],
       patterns: ['{/foo,/bar}'],
       expected: ['foo', 'bar'],
@@ -639,6 +671,7 @@ for (const mode of ['once', 'watch'] as const) {
 
   test(`[${mode}] braces can be escaped`, ({check}) =>
     check({
+      mode,
       files: ['{foo,bar}'],
       patterns: ['\\{foo,bar\\}'],
       expected: ['{foo,bar}'],
@@ -648,6 +681,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
       patterns: ['../foo'],
@@ -659,6 +693,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
       patterns: ['../foo'],
@@ -670,6 +705,7 @@ for (const mode of ['once', 'watch'] as const) {
     check,
   }) =>
     check({
+      mode,
       files: ['foo'],
       patterns: ['foo'],
       expected: ['foo'],

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -487,7 +487,12 @@ for (const mode of ['once', 'watch'] as const) {
   );
 
   skipIfWatch(`[${mode}] empty pattern throws`, ({check}) =>
-    check({mode, files: ['foo', 'bar'], patterns: [''], expected: 'ERROR'})
+    check({
+      mode,
+      files: ['foo', 'bar'],
+      patterns: [''],
+      expected: 'ERROR',
+    })
   );
 
   skipIfWatch(
@@ -503,7 +508,12 @@ for (const mode of ['once', 'watch'] as const) {
   );
 
   skipIfWatch(`[${mode}] whitespace pattern throws`, ({check}) =>
-    check({mode, files: ['foo', 'bar'], patterns: [' '], expected: 'ERROR'})
+    check({
+      mode,
+      files: ['foo', 'bar'],
+      patterns: [' '],
+      expected: 'ERROR',
+    })
   );
 
   skipIfWatch(

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -154,49 +154,49 @@ test.after.each(async (ctx) => {
 });
 
 for (const mode of ['once', 'watch'] as const) {
-  test('empty patterns', ({check}) =>
+  test(`[${mode}] empty patterns`, ({check}) =>
     check({
       files: ['foo'],
       patterns: [],
       expected: [],
     }));
 
-  test('normalizes trailing / in pattern', ({check}) =>
+  test(`[${mode}] normalizes trailing / in pattern`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['foo/'],
       expected: ['foo'],
     }));
 
-  test('normalizes ../ in pattern', ({check}) =>
+  test(`[${mode}] normalizes ../ in pattern`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['bar/../foo'],
       expected: ['foo'],
     }));
 
-  test('explicit file that does not exist', ({check}) =>
+  test(`[${mode}] explicit file that does not exist`, ({check}) =>
     check({
       files: [],
       patterns: ['foo'],
       expected: [],
     }));
 
-  test('* star', ({check}) =>
+  test(`[${mode}] * star`, ({check}) =>
     check({
       files: ['foo', 'bar'],
       patterns: ['*'],
       expected: ['foo', 'bar'],
     }));
 
-  test('* star with ! negation', ({check}) =>
+  test(`[${mode}] * star with ! negation`, ({check}) =>
     check({
       files: ['foo', 'bar', 'baz'],
       patterns: ['*', '!bar'],
       expected: ['foo', 'baz'],
     }));
 
-  test('inclusion of directory with trailing slash', ({check}) =>
+  test(`[${mode}] inclusion of directory with trailing slash`, ({check}) =>
     check({
       files: ['foo/good/1', 'foo/good/2'],
       patterns: ['foo/'],
@@ -204,7 +204,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('inclusion of directory without trailing slash', ({check}) =>
+  test(`[${mode}] inclusion of directory without trailing slash`, ({check}) =>
     check({
       files: ['foo/good/1', 'foo/good/2'],
       patterns: ['foo'],
@@ -212,7 +212,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('!exclusion of directory with trailing slash', ({check}) =>
+  test(`[${mode}] !exclusion of directory with trailing slash`, ({check}) =>
     check({
       files: ['foo/good/1', 'foo/bad/1'],
       patterns: ['foo', '!foo/bad/'],
@@ -220,7 +220,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('!exclusion of directory without trailing slash', ({check}) =>
+  test(`[${mode}] !exclusion of directory without trailing slash`, ({check}) =>
     check({
       files: ['foo/good/1', 'foo/bad/1'],
       patterns: ['foo', '!foo/bad'],
@@ -228,28 +228,28 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('explicit .dotfile', ({check}) =>
+  test(`[${mode}] explicit .dotfile`, ({check}) =>
     check({
       files: ['.foo'],
       patterns: ['.foo'],
       expected: ['.foo'],
     }));
 
-  test('* star matches .dotfiles', ({check}) =>
+  test(`[${mode}] * star matches .dotfiles`, ({check}) =>
     check({
       files: ['.foo'],
       patterns: ['*'],
       expected: ['.foo'],
     }));
 
-  test('{} groups', ({check}) =>
+  test(`[${mode}] {} groups`, ({check}) =>
     check({
       files: ['foo', 'bar', 'baz'],
       patterns: ['{foo,baz}'],
       expected: ['foo', 'baz'],
     }));
 
-  test('matches explicit symlink', ({check}) =>
+  test(`[${mode}] matches explicit symlink`, ({check}) =>
     check({
       files: [
         'target',
@@ -259,14 +259,18 @@ for (const mode of ['once', 'watch'] as const) {
       expected: ['symlink'],
     }));
 
-  test('explicit directory excluded when includeDirectories=false', ({check}) =>
+  test(`[${mode}] explicit directory excluded when includeDirectories=false`, ({
+    check,
+  }) =>
     check({
       files: ['foo/'],
       patterns: ['foo'],
       expected: [],
     }));
 
-  test('explicit directory included when includeDirectories=true', ({check}) =>
+  test(`[${mode}] explicit directory included when includeDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['foo/'],
       patterns: ['foo'],
@@ -274,14 +278,18 @@ for (const mode of ['once', 'watch'] as const) {
       includeDirectories: true,
     }));
 
-  test('* star excludes directory when includeDirectories=false', ({check}) =>
+  test(`[${mode}] * star excludes directory when includeDirectories=false`, ({
+    check,
+  }) =>
     check({
       files: ['foo/'],
       patterns: ['*'],
       expected: [],
     }));
 
-  test('* star includes directory when includeDirectories=true', ({check}) =>
+  test(`[${mode}] * star includes directory when includeDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['foo/'],
       patterns: ['*'],
@@ -289,7 +297,9 @@ for (const mode of ['once', 'watch'] as const) {
       includeDirectories: true,
     }));
 
-  test('includeDirectories=false + expandDirectories=false', ({check}) =>
+  test(`[${mode}] includeDirectories=false + expandDirectories=false`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
@@ -298,7 +308,9 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: false,
     }));
 
-  test('includeDirectories=true + expandDirectories=false', ({check}) =>
+  test(`[${mode}] includeDirectories=true + expandDirectories=false`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
@@ -307,7 +319,9 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: false,
     }));
 
-  test('includeDirectories=false + expandDirectories=true', ({check}) =>
+  test(`[${mode}] includeDirectories=false + expandDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
@@ -316,7 +330,9 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('includeDirectories=true + expandDirectories=true', ({check}) =>
+  test(`[${mode}] includeDirectories=true + expandDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['foo'],
@@ -333,7 +349,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('includeDirectories=true + expandDirectories=true + recursive !exclusion', ({
+  test(`[${mode}] includeDirectories=true + expandDirectories=true + recursive !exclusion`, ({
     check,
   }) =>
     check({
@@ -350,7 +366,9 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('. matches current directory with includeDirectories=true', ({check}) =>
+  test(`[${mode}] . matches current directory with includeDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['.'],
@@ -358,7 +376,9 @@ for (const mode of ['once', 'watch'] as const) {
       includeDirectories: true,
     }));
 
-  test('. matches current directory with expandDirectories=true', ({check}) =>
+  test(`[${mode}] . matches current directory with expandDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['.'],
@@ -366,7 +386,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('{} groups with expand directories', ({check}) =>
+  test(`[${mode}] {} groups with expand directories`, ({check}) =>
     check({
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['{foo,baz}'],
@@ -374,14 +394,16 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('empty pattern throws', ({check}) =>
+  test(`[${mode}] empty pattern throws`, ({check}) =>
     check({
       files: ['foo', 'bar'],
       patterns: [''],
       expected: 'ERROR',
     }));
 
-  test('empty pattern throws with expandDirectories=true', ({check}) =>
+  test(`[${mode}] empty pattern throws with expandDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['foo', 'bar'],
       patterns: [''],
@@ -389,14 +411,16 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('whitespace pattern throws', ({check}) =>
+  test(`[${mode}] whitespace pattern throws`, ({check}) =>
     check({
       files: ['foo', 'bar'],
       patterns: [' '],
       expected: 'ERROR',
     }));
 
-  test('whitespace pattern throws with expandDirectories=true', ({check}) =>
+  test(`[${mode}] whitespace pattern throws with expandDirectories=true`, ({
+    check,
+  }) =>
     check({
       files: ['foo', 'bar'],
       patterns: [' '],
@@ -404,14 +428,14 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('re-inclusion of file', ({check}) =>
+  test(`[${mode}] re-inclusion of file`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['!foo', 'foo'],
       expected: ['foo'],
     }));
 
-  test('re-inclusion of directory', ({check}) =>
+  test(`[${mode}] re-inclusion of directory`, ({check}) =>
     check({
       files: ['foo/'],
       patterns: ['!foo', 'foo'],
@@ -419,14 +443,14 @@ for (const mode of ['once', 'watch'] as const) {
       includeDirectories: true,
     }));
 
-  test('re-inclusion of file into directory', ({check}) =>
+  test(`[${mode}] re-inclusion of file into directory`, ({check}) =>
     check({
       files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
       patterns: ['foo/**', '!foo/bar/**', 'foo/bar/baz', '!foo/qux'],
       expected: ['foo/1', 'foo/bar/baz'],
     }));
 
-  test('re-inclusion of file into directory with expandDirectories=true', ({
+  test(`[${mode}] re-inclusion of file into directory with expandDirectories=true`, ({
     check,
   }) =>
     check({
@@ -436,7 +460,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('re-inclusion of directory into directory with expandDirectories=true', ({
+  test(`[${mode}] re-inclusion of directory into directory with expandDirectories=true`, ({
     check,
   }) =>
     check({
@@ -446,7 +470,7 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test('walks through symlinked directories when followSymlinks=true', ({
+  test(`[${mode}] walks through symlinked directories when followSymlinks=true`, ({
     check,
   }) =>
     check({
@@ -460,7 +484,7 @@ for (const mode of ['once', 'watch'] as const) {
       followSymlinks: true,
     }));
 
-  test('does not walk through symlinked directories when followSymlinks=false', ({
+  test(`[${mode}] does not walk through symlinked directories when followSymlinks=false`, ({
     check,
   }) =>
     check({
@@ -474,7 +498,7 @@ for (const mode of ['once', 'watch'] as const) {
       followSymlinks: false,
     }));
 
-  test('dirent tags files', async ({rig}) => {
+  test(`[${mode}] dirent tags files`, async ({rig}) => {
     await rig.touch('foo');
     const actual = await glob(['foo'], {
       cwd: rig.temp,
@@ -490,7 +514,7 @@ for (const mode of ['once', 'watch'] as const) {
     assert.not(actual[0].dirent.isSymbolicLink());
   });
 
-  test('dirent tags directories', async ({rig}) => {
+  test(`[${mode}] dirent tags directories`, async ({rig}) => {
     await rig.mkdir('foo');
     const actual = await glob(['foo'], {
       cwd: rig.temp,
@@ -506,7 +530,9 @@ for (const mode of ['once', 'watch'] as const) {
     assert.not(actual[0].dirent.isSymbolicLink());
   });
 
-  test('dirent tags symlinks when followSymlinks=false', async ({rig}) => {
+  test(`[${mode}] dirent tags symlinks when followSymlinks=false`, async ({
+    rig,
+  }) => {
     await rig.symlink('target', 'foo', 'file');
     const actual = await glob(['foo'], {
       cwd: rig.temp,
@@ -522,7 +548,7 @@ for (const mode of ['once', 'watch'] as const) {
     assert.ok(actual[0].dirent.isSymbolicLink());
   });
 
-  test('dirent tags symlinks to files as files when followSymlinks=true', async ({
+  test(`[${mode}] dirent tags symlinks to files as files when followSymlinks=true`, async ({
     rig,
   }) => {
     await rig.symlink('target', 'foo', 'file');
@@ -541,7 +567,7 @@ for (const mode of ['once', 'watch'] as const) {
     assert.not(actual[0].dirent.isSymbolicLink());
   });
 
-  test('dirent tags symlinks to directories as directories when followSymlinks=true', async ({
+  test(`[${mode}] dirent tags symlinks to directories as directories when followSymlinks=true`, async ({
     rig,
   }) => {
     await rig.symlink('target', 'foo', 'dir');
@@ -560,21 +586,21 @@ for (const mode of ['once', 'watch'] as const) {
     assert.not(actual[0].dirent.isSymbolicLink());
   });
 
-  test('re-roots to cwd', ({check}) =>
+  test(`[${mode}] re-roots to cwd`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['/foo'],
       expected: ['foo'],
     }));
 
-  test('re-roots to cwd with exclusion', ({check}) =>
+  test(`[${mode}] re-roots to cwd with exclusion`, ({check}) =>
     check({
       files: ['foo', 'bar', 'baz'],
       patterns: ['/*', '!/bar'],
       expected: ['foo', 'baz'],
     }));
 
-  test('re-rooting allows ../', ({check}) =>
+  test(`[${mode}] re-rooting allows ../`, ({check}) =>
     check({
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
@@ -582,14 +608,14 @@ for (const mode of ['once', 'watch'] as const) {
       expected: ['foo'],
     }));
 
-  test('re-rooting handles /./foo', ({check}) =>
+  test(`[${mode}] re-rooting handles /./foo`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['/./foo'],
       expected: ['foo'],
     }));
 
-  test('re-rooting handles /../foo', ({check}) =>
+  test(`[${mode}] re-rooting handles /../foo`, ({check}) =>
     check({
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
@@ -597,28 +623,30 @@ for (const mode of ['once', 'watch'] as const) {
       expected: ['foo'],
     }));
 
-  test('re-rooting handles /bar/../foo/', ({check}) =>
+  test(`[${mode}] re-rooting handles /bar/../foo/`, ({check}) =>
     check({
       files: ['foo'],
       patterns: ['/bar/../foo/'],
       expected: ['foo'],
     }));
 
-  test('re-roots to cwd with braces', ({check}) =>
+  test(`[${mode}] re-roots to cwd with braces`, ({check}) =>
     check({
       files: ['foo', 'bar'],
       patterns: ['{/foo,/bar}'],
       expected: ['foo', 'bar'],
     }));
 
-  test('braces can be escaped', ({check}) =>
+  test(`[${mode}] braces can be escaped`, ({check}) =>
     check({
       files: ['{foo,bar}'],
       patterns: ['\\{foo,bar\\}'],
       expected: ['{foo,bar}'],
     }));
 
-  test('disallows path outside cwd when throwIfOutsideCwd=true', ({check}) =>
+  test(`[${mode}] disallows path outside cwd when throwIfOutsideCwd=true`, ({
+    check,
+  }) =>
     check({
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
@@ -627,7 +655,9 @@ for (const mode of ['once', 'watch'] as const) {
       throwIfOutsideCwd: true,
     }));
 
-  test('allows path outside cwd when throwIfOutsideCwd=false', ({check}) =>
+  test(`[${mode}] allows path outside cwd when throwIfOutsideCwd=false`, ({
+    check,
+  }) =>
     check({
       cwd: 'subdir',
       files: ['foo', 'subdir/'],
@@ -636,7 +666,9 @@ for (const mode of ['once', 'watch'] as const) {
       throwIfOutsideCwd: false,
     }));
 
-  test('allows path inside cwd when throwIfOutsideCwd=true', ({check}) =>
+  test(`[${mode}] allows path inside cwd when throwIfOutsideCwd=true`, ({
+    check,
+  }) =>
     check({
       files: ['foo'],
       patterns: ['foo'],

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -155,6 +155,12 @@ test.after.each(async (ctx) => {
 });
 
 for (const mode of ['once', 'watch'] as const) {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const skipIfWatch = mode === 'watch' ? test.skip : test;
+  const skipIfWatchOnWindows =
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    mode === 'watch' && IS_WINDOWS ? test.skip : test;
+
   test(`[${mode}] empty patterns`, ({check}) =>
     check({
       mode,
@@ -163,13 +169,14 @@ for (const mode of ['once', 'watch'] as const) {
       expected: [],
     }));
 
-  test(`[${mode}] normalizes trailing / in pattern`, ({check}) =>
+  skipIfWatch(`[${mode}] normalizes trailing / in pattern`, ({check}) =>
     check({
       mode,
       files: ['foo'],
       patterns: ['foo/'],
       expected: ['foo'],
-    }));
+    })
+  );
 
   test(`[${mode}] normalizes ../ in pattern`, ({check}) =>
     check({
@@ -291,9 +298,20 @@ for (const mode of ['once', 'watch'] as const) {
       mode,
       files: ['foo/'],
       patterns: ['foo'],
-      expected: ['foo'],
-      includeDirectories: true,
+      expected: [],
     }));
+
+  skipIfWatch(
+    `[${mode}] explicit directory included when includeDirectories=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: ['foo/'],
+        patterns: ['foo'],
+        expected: ['foo'],
+        includeDirectories: true,
+      })
+  );
 
   test(`[${mode}] * star excludes directory when includeDirectories=false`, ({
     check,
@@ -305,40 +323,59 @@ for (const mode of ['once', 'watch'] as const) {
       expected: [],
     }));
 
-  test(`[${mode}] * star includes directory when includeDirectories=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['foo/'],
-      patterns: ['*'],
-      expected: ['foo'],
-      includeDirectories: true,
-    }));
+  skipIfWatch(
+    `[${mode}] * star includes directory when includeDirectories=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: ['foo/'],
+        patterns: ['*'],
+        expected: ['foo'],
+        includeDirectories: true,
+      })
+  );
 
-  test(`[${mode}] includeDirectories=false + expandDirectories=false`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-      patterns: ['foo'],
-      expected: [],
-      includeDirectories: false,
-      expandDirectories: false,
-    }));
+  skipIfWatch(
+    `[${mode}] includeDirectories=false + expandDirectories=false`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          '1',
+          '2',
+          'foo/1',
+          'foo/2',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz/',
+        ],
+        patterns: ['foo'],
+        expected: [],
+        includeDirectories: false,
+        expandDirectories: false,
+      })
+  );
 
-  test(`[${mode}] includeDirectories=true + expandDirectories=false`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-      patterns: ['foo'],
-      expected: ['foo'],
-      includeDirectories: true,
-      expandDirectories: false,
-    }));
+  skipIfWatch(
+    `[${mode}] includeDirectories=true + expandDirectories=false`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          '1',
+          '2',
+          'foo/1',
+          'foo/2',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz/',
+        ],
+        patterns: ['foo'],
+        expected: ['foo'],
+        includeDirectories: true,
+        expandDirectories: false,
+      })
+  );
 
   test(`[${mode}] includeDirectories=false + expandDirectories=true`, ({
     check,
@@ -352,54 +389,81 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test(`[${mode}] includeDirectories=true + expandDirectories=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-      patterns: ['foo'],
-      expected: [
-        'foo',
-        'foo/1',
-        'foo/2',
-        'foo/bar',
-        'foo/bar/1',
-        'foo/bar/2',
-        'foo/baz',
-      ],
-      includeDirectories: true,
-      expandDirectories: true,
-    }));
+  skipIfWatch(
+    `[${mode}] includeDirectories=true + expandDirectories=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          '1',
+          '2',
+          'foo/1',
+          'foo/2',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz/',
+        ],
+        patterns: ['foo'],
+        expected: [
+          'foo',
+          'foo/1',
+          'foo/2',
+          'foo/bar',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz',
+        ],
+        includeDirectories: true,
+        expandDirectories: true,
+      })
+  );
 
-  test(`[${mode}] includeDirectories=true + expandDirectories=true + recursive !exclusion`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-      patterns: [
-        'foo',
-        // This exclusion pattern needs to match recursively too. We don't just
-        // exclude the "foo/bar" directory, we also exclude its recursive
-        // children.
-        '!foo/bar',
-      ],
-      expected: ['foo', 'foo/1', 'foo/2', 'foo/baz'],
-      includeDirectories: true,
-      expandDirectories: true,
-    }));
+  skipIfWatch(
+    `[${mode}] includeDirectories=true + expandDirectories=true + recursive !exclusion`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          '1',
+          '2',
+          'foo/1',
+          'foo/2',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz/',
+        ],
+        patterns: [
+          'foo',
+          // This exclusion pattern needs to match recursively too. We don't just
+          // exclude the "foo/bar" directory, we also exclude its recursive
+          // children.
+          '!foo/bar',
+        ],
+        expected: ['foo', 'foo/1', 'foo/2', 'foo/baz'],
+        includeDirectories: true,
+        expandDirectories: true,
+      })
+  );
 
-  test(`[${mode}] . matches current directory with includeDirectories=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
-      patterns: ['.'],
-      expected: ['.'],
-      includeDirectories: true,
-    }));
+  skipIfWatch(
+    `[${mode}] . matches current directory with includeDirectories=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          '1',
+          '2',
+          'foo/1',
+          'foo/2',
+          'foo/bar/1',
+          'foo/bar/2',
+          'foo/baz/',
+        ],
+        patterns: ['.'],
+        expected: ['.'],
+        includeDirectories: true,
+      })
+  );
 
   test(`[${mode}] . matches current directory with expandDirectories=true`, ({
     check,
@@ -412,74 +476,75 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test(`[${mode}] {} groups with expand directories`, ({check}) =>
+  skipIfWatch(`[${mode}] {} groups with expand directories`, ({check}) =>
     check({
       mode,
       files: ['1', '2', 'foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2', 'foo/baz/'],
       patterns: ['{foo,baz}'],
       expected: ['foo/1', 'foo/2', 'foo/bar/1', 'foo/bar/2'],
       expandDirectories: true,
-    }));
+    })
+  );
 
-  test(`[${mode}] empty pattern throws`, ({check}) =>
-    check({
-      mode,
-      files: ['foo', 'bar'],
-      patterns: [''],
-      expected: 'ERROR',
-    }));
+  skipIfWatch(`[${mode}] empty pattern throws`, ({check}) =>
+    check({mode, files: ['foo', 'bar'], patterns: [''], expected: 'ERROR'})
+  );
 
-  test(`[${mode}] empty pattern throws with expandDirectories=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['foo', 'bar'],
-      patterns: [''],
-      expected: 'ERROR',
-      expandDirectories: true,
-    }));
-
-  test(`[${mode}] whitespace pattern throws`, ({check}) =>
-    check({mode, files: ['foo', 'bar'], patterns: [' '], expected: 'ERROR'}));
-
-  test(`[${mode}] whitespace pattern throws with expandDirectories=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: ['foo', 'bar'],
-      patterns: [' '],
-      expected: 'ERROR',
-      expandDirectories: true,
-    }));
-
-  if (!(mode === 'watch' && IS_WINDOWS)) {
-    test(`[${mode}] re-inclusion of file`, ({check}) =>
+  skipIfWatch(
+    `[${mode}] empty pattern throws with expandDirectories=true`,
+    ({check}) =>
       check({
         mode,
-        files: ['foo'],
-        patterns: ['!foo', 'foo'],
-        expected: ['foo'],
-      }));
-  }
+        files: ['foo', 'bar'],
+        patterns: [''],
+        expected: 'ERROR',
+        expandDirectories: true,
+      })
+  );
 
-  test(`[${mode}] re-inclusion of directory`, ({check}) =>
+  skipIfWatch(`[${mode}] whitespace pattern throws`, ({check}) =>
+    check({mode, files: ['foo', 'bar'], patterns: [' '], expected: 'ERROR'})
+  );
+
+  skipIfWatch(
+    `[${mode}] whitespace pattern throws with expandDirectories=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: ['foo', 'bar'],
+        patterns: [' '],
+        expected: 'ERROR',
+        expandDirectories: true,
+      })
+  );
+
+  skipIfWatchOnWindows(`[${mode}] re-inclusion of file`, ({check}) =>
+    check({
+      mode,
+      files: ['foo'],
+      patterns: ['!foo', 'foo'],
+      expected: ['foo'],
+    })
+  );
+
+  skipIfWatch(`[${mode}] re-inclusion of directory`, ({check}) =>
     check({
       mode,
       files: ['foo/'],
       patterns: ['!foo', 'foo'],
       expected: ['foo'],
       includeDirectories: true,
-    }));
+    })
+  );
 
-  test(`[${mode}] re-inclusion of file into directory`, ({check}) =>
+  skipIfWatch(`[${mode}] re-inclusion of file into directory`, ({check}) =>
     check({
       mode,
       files: ['foo/1', 'foo/bar/1', 'foo/bar/baz', 'foo/qux'],
       patterns: ['foo/**', '!foo/bar/**', 'foo/bar/baz', '!foo/qux'],
       expected: ['foo/1', 'foo/bar/baz'],
-    }));
+    })
+  );
 
   test(`[${mode}] re-inclusion of file into directory with expandDirectories=true`, ({
     check,
@@ -503,35 +568,37 @@ for (const mode of ['once', 'watch'] as const) {
       expandDirectories: true,
     }));
 
-  test(`[${mode}] walks through symlinked directories when followSymlinks=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: [
-        'target/foo',
-        {target: 'target', path: 'symlink', windowsType: 'dir'},
-      ],
-      patterns: ['**'],
-      expected: ['target', 'target/foo', 'symlink', 'symlink/foo'],
-      includeDirectories: true,
-      followSymlinks: true,
-    }));
+  skipIfWatch(
+    `[${mode}] walks through symlinked directories when followSymlinks=true`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          'target/foo',
+          {target: 'target', path: 'symlink', windowsType: 'dir'},
+        ],
+        patterns: ['**'],
+        expected: ['target', 'target/foo', 'symlink', 'symlink/foo'],
+        includeDirectories: true,
+        followSymlinks: true,
+      })
+  );
 
-  test(`[${mode}] does not walk through symlinked directories when followSymlinks=false`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      files: [
-        'target/foo',
-        {target: 'target', path: 'symlink', windowsType: 'dir'},
-      ],
-      patterns: ['**'],
-      expected: ['target', 'target/foo', 'symlink'],
-      includeDirectories: true,
-      followSymlinks: false,
-    }));
+  skipIfWatch(
+    `[${mode}] does not walk through symlinked directories when followSymlinks=false`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          'target/foo',
+          {target: 'target', path: 'symlink', windowsType: 'dir'},
+        ],
+        patterns: ['**'],
+        expected: ['target', 'target/foo', 'symlink'],
+        includeDirectories: true,
+        followSymlinks: false,
+      })
+  );
 
   test(`[${mode}] dirent tags files`, async ({rig}) => {
     await rig.touch('foo');
@@ -622,7 +689,12 @@ for (const mode of ['once', 'watch'] as const) {
   });
 
   test(`[${mode}] re-roots to cwd`, ({check}) =>
-    check({mode, files: ['foo'], patterns: ['/foo'], expected: ['foo']}));
+    check({
+      mode,
+      files: ['foo'],
+      patterns: ['/foo'],
+      expected: ['foo'],
+    }));
 
   test(`[${mode}] re-roots to cwd with exclusion`, ({check}) =>
     check({
@@ -632,74 +704,85 @@ for (const mode of ['once', 'watch'] as const) {
       expected: ['foo', 'baz'],
     }));
 
-  test(`[${mode}] re-rooting allows ../`, ({check}) =>
-    check({
-      mode,
-      cwd: 'subdir',
-      files: ['foo', 'subdir/'],
-      patterns: ['../foo'],
-      expected: ['foo'],
-    }));
+  if (mode !== 'watch') {
+    test(`[${mode}] re-rooting allows ../`, ({check}) =>
+      check({
+        mode,
+        cwd: 'subdir',
+        files: ['foo', 'subdir/'],
+        patterns: ['../foo'],
+        expected: ['foo'],
+      }));
+  }
 
   test(`[${mode}] re-rooting handles /./foo`, ({check}) =>
-    check({mode, files: ['foo'], patterns: ['/./foo'], expected: ['foo']}));
-
-  test(`[${mode}] re-rooting handles /../foo`, ({check}) =>
-    check({
-      mode,
-      cwd: 'subdir',
-      files: ['foo', 'subdir/'],
-      patterns: ['/../foo'],
-      expected: ['foo'],
-    }));
-
-  test(`[${mode}] re-rooting handles /bar/../foo/`, ({check}) =>
     check({
       mode,
       files: ['foo'],
-      patterns: ['/bar/../foo/'],
+      patterns: ['/./foo'],
       expected: ['foo'],
     }));
 
-  test(`[${mode}] re-roots to cwd with braces`, ({check}) =>
-    check({
-      mode,
-      files: ['foo', 'bar'],
-      patterns: ['{/foo,/bar}'],
-      expected: ['foo', 'bar'],
-    }));
+  if (mode !== 'watch') {
+    test(`[${mode}] re-rooting handles /../foo`, ({check}) =>
+      check({
+        mode,
+        cwd: 'subdir',
+        files: ['foo', 'subdir/'],
+        patterns: ['/../foo'],
+        expected: ['foo'],
+      }));
 
-  test(`[${mode}] braces can be escaped`, ({check}) =>
-    check({
-      mode,
-      files: ['{foo,bar}'],
-      patterns: ['\\{foo,bar\\}'],
-      expected: ['{foo,bar}'],
-    }));
+    test(`[${mode}] re-rooting handles /bar/../foo/`, ({check}) =>
+      check({
+        mode,
+        files: ['foo'],
+        patterns: ['/bar/../foo/'],
+        expected: ['foo'],
+      }));
 
-  test(`[${mode}] disallows path outside cwd when throwIfOutsideCwd=true`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      cwd: 'subdir',
-      files: ['foo', 'subdir/'],
-      patterns: ['../foo'],
-      expected: 'ERROR',
-      throwIfOutsideCwd: true,
-    }));
+    test(`[${mode}] re-roots to cwd with braces`, ({check}) =>
+      check({
+        mode,
+        files: ['foo', 'bar'],
+        patterns: ['{/foo,/bar}'],
+        expected: ['foo', 'bar'],
+      }));
 
-  test(`[${mode}] allows path outside cwd when throwIfOutsideCwd=false`, ({
-    check,
-  }) =>
-    check({
-      mode,
-      cwd: 'subdir',
-      files: ['foo', 'subdir/'],
-      patterns: ['../foo'],
-      expected: ['foo'],
-      throwIfOutsideCwd: false,
-    }));
+    test(`[${mode}] braces can be escaped`, ({check}) =>
+      check({
+        mode,
+        files: ['{foo,bar}'],
+        patterns: ['\\{foo,bar\\}'],
+        expected: ['{foo,bar}'],
+      }));
+  }
+
+  skipIfWatch(
+    `[${mode}] disallows path outside cwd when throwIfOutsideCwd=true`,
+    ({check}) =>
+      check({
+        mode,
+        cwd: 'subdir',
+        files: ['foo', 'subdir/'],
+        patterns: ['../foo'],
+        expected: 'ERROR',
+        throwIfOutsideCwd: true,
+      })
+  );
+
+  skipIfWatch(
+    `[${mode}] allows path outside cwd when throwIfOutsideCwd=false`,
+    ({check}) =>
+      check({
+        mode,
+        cwd: 'subdir',
+        files: ['foo', 'subdir/'],
+        patterns: ['../foo'],
+        expected: ['foo'],
+        throwIfOutsideCwd: false,
+      })
+  );
 
   test(`[${mode}] allows path inside cwd when throwIfOutsideCwd=true`, ({
     check,

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -448,22 +448,30 @@ const watchPathsEqual = (
   return true;
 };
 
-const makeWatcher = (
+/**
+ * Exported for testing.
+ *
+ * @param ignoreInitial Ignore the initial "add" events emitted when chokidar
+ * first discovers each file. We already do an initial run, so these events are
+ * just noise that may trigger an unnecessary second run.
+ * https://github.com/paulmillr/chokidar#path-filtering
+ */
+export const makeWatcher = (
   patterns: string[],
   cwd: string,
-  callback: () => void
+  callback: () => void,
+  ignoreInitial = true
 ): FileWatcher => {
+  // TODO(aomarks) chokidar doesn't work exactly like fast-glob, so there are
+  // currently various differences in what gets watched vs what actually affects
+  // the build. See https://github.com/google/wireit/issues/550.
   const watcher = chokidar.watch(
     // Trim leading slashes from patterns, to "re-root" all paths to the package
     // directory, just as we do when globbing for script execution.
     patterns.map((pattern) => pattern.replace(/^\/+/, '')),
     {
       cwd,
-      // Ignore the initial "add" events emitted when chokidar first discovers
-      // each file. We already do an initial run, so these events are just noise
-      // that may trigger an unnecessary second run.
-      // https://github.com/paulmillr/chokidar#path-filtering
-      ignoreInitial: true,
+      ignoreInitial,
     }
   );
   watcher.on('all', callback);


### PR DESCRIPTION
This PR runs every glob test against chokidar, since we should have identical behavior in theory. We currently don't, so there are a lot of tests that get excluded for the chokidar case.

Tracking the task of making them equivalent at https://github.com/google/wireit/issues/550, but figured I'd land the tests first so that we at least don't regress, and have something easy to track for improvements in future.