### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ export WIREIT_PARALLEL=1
 npm run build
 ```
 
-If two or more seperate `npm run` commands are run for the same Wireit script
+If two or more separate `npm run` commands are run for the same Wireit script
 simultaneously, then only one instance will be allowed to run at a time, while
 the others wait their turn. This prevents coordination problems that can result
 in incorrect output files being produced. If `output` is set to an empty array,


### PR DESCRIPTION
seperate -> separate