### PR TITLE
Add environment variable configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Added `env` setting which allows either directly assigning environment
+  variables, or indicating that an externally-provided environment variable
+  should affect the fingerprint (and hence freshness/caching). Example:
+
+```json
+{
+"wireit": {
+  "rollup": {
+    "command": "rollup -c",
+    "files": ["lib/**/*.js", "rollup.config.js"],
+    "output": "dist/bundle.js",
+    "env": {
+      "MODE": "prod",
+      "DEBUG": {
+        "external": true
+      }
+    }
+  }
+}
+```
 
 ## [0.9.0] - 2022-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ```json
 {
-"wireit": {
-  "rollup": {
-    "command": "rollup -c",
-    "files": ["lib/**/*.js", "rollup.config.js"],
-    "output": "dist/bundle.js",
-    "env": {
-      "MODE": "prod",
-      "DEBUG": {
-        "external": true
+  "wireit": {
+    "bundle:prod": {
+      "command": "rollup -c",
+      "files": ["lib/**/*.js", "rollup.config.js"],
+      "output": ["dist/bundle.js"],
+      "env": {
+        "MODE": "prod",
+        "DEBUG": {
+          "external": true
+        }
       }
     }
   }
@@ -122,7 +123,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
       "bundle": {
         "command": "rollup -c",
         "files": ["rollup.config.json", "lib/**/*.js", "!lib/test"],
-        "output": "dist/bundle.js",
+        "output": ["dist/bundle.js"],
         "dependencies": {
           [
             "script": "build",

--- a/schema.json
+++ b/schema.json
@@ -94,6 +94,29 @@
                 }
               }
             ]
+          },
+          "env": {
+            "type": "object",
+            "markdownDescription": "Environment variables to either set directly, or which are set externally and affect the behavior of the script.\n\nFor more info see: https://github.com/google/wireit#environment-variables",
+            "additionalProperties": {
+              "markdownDescription": "An environment variable setting.\n\nFor more info see: https://github.com/google/wireit#environment-variables",
+              "additionalProperties": true,
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "required": ["external"],
+                  "properties": {
+                    "external": {
+                      "markdownDescription": "Do not re-use output if this externally-provided environment variable changes across iterations.\n\nFor more info see: https://github.com/google/wireit#indicating-external-environment-variables",
+                      "const": true
+                    }
+                  }
+                }
+              ]
+            }
           }
         },
         "type": "object"

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,11 @@ export interface ScriptReferenceWithCommand extends ScriptReference {
    * Extra arguments to pass to the command.
    */
   extraArgs: string[] | undefined;
+
+  /**
+   * Environment variables.
+   */
+  env: Record<string, string>;
 }
 
 export interface Dependency<
@@ -65,6 +70,7 @@ export interface NoCommandScriptConfig extends BaseScriptConfig {
   command: undefined;
   extraArgs: undefined;
   service: undefined;
+  env: Record<string, string>;
 }
 
 /**

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -88,6 +88,8 @@ export interface FingerprintData {
         };
       }
     | undefined;
+
+  env: Record<string, string>;
 }
 
 /**
@@ -227,6 +229,7 @@ export class Fingerprint {
                 lineMatches: script.service.readyWhen.lineMatches?.toString(),
               },
             },
+      env: script.env,
     };
     fingerprint._data = data as FingerprintData;
     return fingerprint;

--- a/src/script-child-process.ts
+++ b/src/script-child-process.ts
@@ -84,6 +84,7 @@ export class ScriptChildProcess {
       name: script.name,
       command: script.command,
       extraArgs: script.extraArgs,
+      env: script.env,
     };
 
     // TODO(aomarks) Update npm_ environment variables to reflect the new
@@ -105,6 +106,7 @@ export class ScriptChildProcess {
             ? 'true'
             : process.env.FORCE_COLOR,
         PATH: this._pathEnvironmentVariable,
+        ...this._script.env,
       }),
       // Set "detached" on Linux and macOS so that we create a new process
       // group, instead of being added to the process group for this Wireit


### PR DESCRIPTION
Adds the ability to either set environment variables directly, or to indicate that an externally-provided environment variable affects the behavior of the script.

Setting variables directly is useful because there is no built-in way to do this in a cross-platform way (especially macOS/Linux shells vs Windows shells). A typical solution is to use https://github.com/kentcdodds/cross-env (which is deprecated), but now wireit can take over this responsibility.

Indicating that an external environment variable affects the behavior of a script is useful because the value will be included in the fingerprint, meaning output will not be re-used if that value changed.

Example:

```json
{
  "wireit": {
    "bundle:prod": {
      "command": "rollup -c",
      "files": ["lib/**/*.js", "rollup.config.js"],
      "output": ["dist/bundle.js"],
      "env": {
        "MODE": "prod",
        "DEBUG": {
          "external": true
        }
      }
    }
  }
}
```

Fixes https://github.com/google/wireit/issues/93