### PR TITLE
Bump wireit version and remove cross-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@typescript-eslint/parser": "^5.17.0",
         "@vscode/test-electron": "^2.1.3",
         "cmd-shim": "^6.0.0",
-        "cross-env": "^7.0.3",
         "esbuild": "^0.15.0",
         "eslint": "^8.15.0",
         "eslint-plugin-no-only-tests": "^3.0.0",
@@ -48,7 +47,7 @@
         "vscode-languageclient": "^8.0.1",
         "vscode-languageserver": "^8.0.1",
         "vscode-languageserver-textdocument": "^1.0.4",
-        "wireit": "^0.8.0",
+        "wireit": "^0.9.1",
         "yarn": "^1.22.18"
       },
       "engines": {
@@ -1014,6 +1013,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@web/dev-server-core/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
     "node_modules/@web/dev-server-rollup": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.19.tgz",
@@ -1030,6 +1034,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@web/dev-server-rollup/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
     "node_modules/@web/parse5-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.3.0.tgz",
@@ -1041,6 +1050,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@web/parse5-utils/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/@wireit/internal-vscode-extension": {
       "resolved": "vscode-extension",
@@ -1447,6 +1461,14 @@
         "stream-throttle": "^0.1.3"
       }
     },
+    "node_modules/browser-sync/node_modules/qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha512-AY4g8t3LMboim0t6XWFdz6J5OuJ1ZNYu54SXihS/OMpgyCqYmcAJnWqkNSOjSjWmq3xxy+GF9uWQI2lI/7tKIA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
@@ -1642,18 +1664,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -2016,24 +2026,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -5145,9 +5137,16 @@
       }
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
@@ -5157,18 +5156,6 @@
       "dependencies": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -5571,11 +5558,18 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-      "integrity": "sha512-AY4g8t3LMboim0t6XWFdz6J5OuJ1ZNYu54SXihS/OMpgyCqYmcAJnWqkNSOjSjWmq3xxy+GF9uWQI2lI/7tKIA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -6801,21 +6795,6 @@
         "underscore": "^1.12.1"
       }
     },
-    "node_modules/typed-rest-client/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
@@ -7186,9 +7165,9 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.8.0.tgz",
-      "integrity": "sha512-WaTaSmu6oc68dogY7u7BpWNNRNvd8wRJbXrOAQRVe0BvU6K5nnFkLH5YAwf/GHOGSCdMN1ss8HpAQfICgPNBdQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.1.tgz",
+      "integrity": "sha512-QqDzpy0CkePmyN9h3xk8fcSABUfcNky9m8mvszHN/oZAzXKQiy3BpdKqORI00W1r+Wc+r0M/tYKMyIM+4Se3TQ==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
@@ -7436,8 +7415,7 @@
     },
     "website/node_modules/entities": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -7447,16 +7425,14 @@
     },
     "website/node_modules/linkify-it": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
     },
     "website/node_modules/markdown-it": {
       "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
-      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",
@@ -8192,6 +8168,13 @@
         "parse5": "^6.0.1",
         "picomatch": "^2.2.2",
         "ws": "^7.4.2"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+        }
       }
     },
     "@web/dev-server-rollup": {
@@ -8205,6 +8188,13 @@
         "parse5": "^6.0.1",
         "rollup": "^2.67.0",
         "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+        }
       }
     },
     "@web/parse5-utils": {
@@ -8214,6 +8204,13 @@
       "requires": {
         "@types/parse5": "^6.0.1",
         "parse5": "^6.0.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+        }
       }
     },
     "@wireit/internal-vscode-extension": {
@@ -8232,22 +8229,16 @@
       },
       "dependencies": {
         "entities": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+          "version": "3.0.1"
         },
         "linkify-it": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-          "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
           "requires": {
             "uc.micro": "^1.0.1"
           }
         },
         "markdown-it": {
           "version": "13.0.1",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
-          "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
           "requires": {
             "argparse": "^2.0.1",
             "entities": "~3.0.1",
@@ -8538,6 +8529,13 @@
         "socket.io": "^4.4.1",
         "ua-parser-js": "1.0.2",
         "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha512-AY4g8t3LMboim0t6XWFdz6J5OuJ1ZNYu54SXihS/OMpgyCqYmcAJnWqkNSOjSjWmq3xxy+GF9uWQI2lI/7tKIA=="
+        }
       }
     },
     "browser-sync-client": {
@@ -8681,17 +8679,6 @@
         "htmlparser2": "^8.0.1",
         "parse5": "^7.0.0",
         "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
       }
     },
     "cheerio-select": {
@@ -8978,15 +8965,6 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
-      }
-    },
-    "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {
@@ -11196,9 +11174,13 @@
       }
     },
     "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "requires": {
+        "entities": "^4.4.0"
+      }
     },
     "parse5-htmlparser2-tree-adapter": {
       "version": "7.0.0",
@@ -11208,17 +11190,6 @@
       "requires": {
         "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
       }
     },
     "parseurl": {
@@ -11554,9 +11525,13 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-      "integrity": "sha512-AY4g8t3LMboim0t6XWFdz6J5OuJ1ZNYu54SXihS/OMpgyCqYmcAJnWqkNSOjSjWmq3xxy+GF9uWQI2lI/7tKIA=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -12471,17 +12446,6 @@
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-          "dev": true,
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        }
       }
     },
     "typescript": {
@@ -12760,9 +12724,9 @@
       }
     },
     "wireit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.8.0.tgz",
-      "integrity": "sha512-WaTaSmu6oc68dogY7u7BpWNNRNvd8wRJbXrOAQRVe0BvU6K5nnFkLH5YAwf/GHOGSCdMN1ss8HpAQfICgPNBdQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.9.1.tgz",
+      "integrity": "sha512-QqDzpy0CkePmyN9h3xk8fcSABUfcNky9m8mvszHN/oZAzXKQiy3BpdKqORI00W1r+Wc+r0M/tYKMyIM+4Se3TQ==",
       "dev": true,
       "requires": {
         "braces": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,10 @@
       "output": []
     },
     "test:analysis": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^analysis\\.test\\.js$\"",
+      "command": "uvu lib/test \"^analysis\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -121,7 +124,10 @@
       "output": []
     },
     "test:basic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^basic\\.test\\.js$\"",
+      "command": "uvu lib/test \"^basic\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -129,7 +135,10 @@
       "output": []
     },
     "test:cache-github": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-github\\.test\\.js$\"",
+      "command": "uvu lib/test \"^cache-github\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -137,7 +146,10 @@
       "output": []
     },
     "test:cache-local": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cache-local\\.test\\.js$\"",
+      "command": "uvu lib/test \"^cache-local\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -145,7 +157,10 @@
       "output": []
     },
     "test:clean": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^clean\\.test\\.js$\"",
+      "command": "uvu lib/test \"^clean\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -153,7 +168,10 @@
       "output": []
     },
     "test:cli-options": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^cli-options\\.test\\.js$\"",
+      "command": "uvu lib/test \"^cli-options\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -161,7 +179,10 @@
       "output": []
     },
     "test:codeactions": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^codeactions\\.test\\.js$\"",
+      "command": "uvu lib/test \"^codeactions\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -169,7 +190,10 @@
       "output": []
     },
     "test:copy": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^copy\\.test\\.js$\"",
+      "command": "uvu lib/test \"^copy\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -177,7 +201,10 @@
       "output": []
     },
     "test:delete": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^delete\\.test\\.js$\"",
+      "command": "uvu lib/test \"^delete\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -185,7 +212,10 @@
       "output": []
     },
     "test:diagnostic": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^diagnostic\\.test\\.js$\"",
+      "command": "uvu lib/test \"^diagnostic\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -193,7 +223,10 @@
       "output": []
     },
     "test:errors-analysis": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-analysis\\.test\\.js$\"",
+      "command": "uvu lib/test \"^errors-analysis\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -201,7 +234,10 @@
       "output": []
     },
     "test:errors-usage": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^errors-usage\\.test\\.js$\"",
+      "command": "uvu lib/test \"^errors-usage\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -209,7 +245,10 @@
       "output": []
     },
     "test:failures": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^failures\\.test\\.js$\"",
+      "command": "uvu lib/test \"^failures\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -217,7 +256,10 @@
       "output": []
     },
     "test:freshness": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^freshness\\.test\\.js$\"",
+      "command": "uvu lib/test \"^freshness\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -225,7 +267,10 @@
       "output": []
     },
     "test:gc": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps node --expose-gc node_modules/uvu/bin.js lib/test \"^gc\\.test\\.js$\"",
+      "command": "node --expose-gc node_modules/uvu/bin.js lib/test \"^gc\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -233,7 +278,10 @@
       "output": []
     },
     "test:glob": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^glob\\.test\\.js$\"",
+      "command": "uvu lib/test \"^glob\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -241,7 +289,10 @@
       "output": []
     },
     "test:ide": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^ide\\.test\\.js$\"",
+      "command": "uvu lib/test \"^ide\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -249,7 +300,10 @@
       "output": []
     },
     "test:json-schema": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^json-schema\\.test\\.js$\"",
+      "command": "uvu lib/test \"^json-schema\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -259,7 +313,10 @@
       "output": []
     },
     "test:optimize-mkdirs": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^optimize-mkdirs\\.test\\.js$\"",
+      "command": "uvu lib/test \"^optimize-mkdirs\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -267,7 +324,10 @@
       "output": []
     },
     "test:parallelism": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^parallelism\\.test\\.js$\"",
+      "command": "uvu lib/test \"^parallelism\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -275,7 +335,10 @@
       "output": []
     },
     "test:service": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^service\\.test\\.js$\"",
+      "command": "uvu lib/test \"^service\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -283,7 +346,10 @@
       "output": []
     },
     "test:watch": {
-      "command": "cross-env NODE_OPTIONS=--enable-source-maps uvu lib/test \"^watch\\.test\\.js$\"",
+      "command": "uvu lib/test \"^watch\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
       "dependencies": [
         "build"
       ],
@@ -302,7 +368,6 @@
     "@typescript-eslint/parser": "^5.17.0",
     "@vscode/test-electron": "^2.1.3",
     "cmd-shim": "^6.0.0",
-    "cross-env": "^7.0.3",
     "esbuild": "^0.15.0",
     "eslint": "^8.15.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
@@ -317,7 +382,7 @@
     "vscode-languageclient": "^8.0.1",
     "vscode-languageserver": "^8.0.1",
     "vscode-languageserver-textdocument": "^1.0.4",
-    "wireit": "^0.8.0",
+    "wireit": "^0.9.1",
     "yarn": "^1.22.18"
   },
   "prettier": {


### PR DESCRIPTION
Upgrades wireit to 0.9.1 and replaces use of `cross-env` with the new `env` setting.