### PR TITLE
Only register watchers for package-lock.json files that exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- In watch mode, watchers are no longer created for `package-lock.json` files
+  that don't yet exist at the time of analysis. This saves resources, and on
+  Windows should reduce errors such as
+  `EBUSY: resource busy or locked, lstat 'C:\DumpStack.log.tmp`.
 
 ## [0.9.2] - 2022-12-09
 

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -741,17 +741,9 @@ test(
       inv.exit(0);
     }
 
-    // Create parent's package-lock.json file. Expect another run.
-    {
-      await rig.writeAtomic({'package-lock.json': 'v0'});
-      const inv = await cmdA.nextInvocation();
-      inv.exit(0);
-      await inv.closed;
-    }
-
     exec.kill();
     await exec.exit;
-    assert.equal(cmdA.numInvocations, 3);
+    assert.equal(cmdA.numInvocations, 2);
   })
 );
 


### PR DESCRIPTION
### Background

We automatically add `package-lock.json` (or equivalent depending on the package manager) entries to the `files` of every script during analysis. We do this so that updates to dependencies invalidate the fingerprint and trigger re-runs.

However, previously we added all *potential* `package-lock.json` paths to the `files` array, whether or not they exist. Meaning for a script defined in `/foo/bar/package.json` we would add:
  - `/foo/bar/package-lock.json`
  - `/foo/package-lock.json`
  - `/package-lock.json`

This is technically correct, however the effect of this in watch mode is that we would register a chokidar watcher for all of those paths, which meant asking the OS to listen for any new file created in any of those directories (including the root directory).

It seems that on Windows, this will occasionally cause errors such as `EBUSY: resource busy or locked, lstat 'C:\DumpStack.log.tmp`. I'm a bit unclear as to why an `lstat` is being issued for a file in `C:\`, since it doesn't seem necessary to stat files that we aren't actually interested in -- but that is what happens through chokidar for some reason.

### This PR

We now only add `package-lock.json` files to the `files` array to a script if the `package-lock.json` exists at the time of analysis. This does mean that a new watch iteration won't occur if a new `package-lock.json` is created during a watch session, but that's really not very important, and not worth the cost/bugs associated with always watching all parent directory listings for all scripts.

Fixes https://github.com/google/wireit/issues/606