### PR TITLE
Handle a closed socket with error as an error in github-actions-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+### Changed
+
+- Better attribute socket errors, and don't crash when a socket is closed
+  unexpectedly.
+
 ## [0.9.4] - 2023-01-30
 
 ### Changed


### PR DESCRIPTION
Hoping to catch ECONRESET errors this way