### PR TITLE
Fix infinite loop and unnecessary logging in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
-
 ## [Unreleased]
 
 ### Changed
 
 - Better attribute socket errors, and don't crash when a socket is closed
   unexpectedly.
+
+### Fixed
+
+- Fixed infinite loops that could occur in watch mode when a script failed, but
+  still emitted output that was configured as the input files for another
+  script.
+
+- Don't clear the console or emit "no-op" style log messages in watch mode for
+  iterations that don't do anything useful.
 
 ## [0.9.4] - 2023-01-30
 

--- a/src/event.ts
+++ b/src/event.ts
@@ -75,6 +75,7 @@ export type Failure =
   | ExitSignal
   | SpawnError
   | StartCancelled
+  | FailedPreviousWatchIteration
   | Killed
   | LaunchedIncorrectly
   | MissingPackageJson
@@ -133,6 +134,14 @@ export interface SpawnError extends ErrorBase {
  */
 export interface StartCancelled extends ErrorBase {
   reason: 'start-cancelled';
+}
+
+/**
+ * A script failed on the previous watch iteration, and its fingerprint hasn't
+ * changed, so it was skipped.
+ */
+export interface FailedPreviousWatchIteration extends ErrorBase {
+  reason: 'failed-previous-watch-iteration';
 }
 
 /**

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -180,6 +180,10 @@ export class DefaultLogger implements Logger {
             // fairly noisy. Maybe in a verbose mode.
             break;
           }
+          case 'failed-previous-watch-iteration': {
+            console.error(`❌${prefix} Failed on previous watch iteration`);
+            break;
+          }
           case 'killed': {
             console.error(`💀${prefix} Killed`);
             break;

--- a/src/logging/watch-logger.ts
+++ b/src/logging/watch-logger.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {Event} from '../event.js';
+import type {Logger} from './logger.js';
+
+/**
+ * A logger for watch mode that avoids useless output.
+ */
+export class WatchLogger implements Logger {
+  private readonly _actualLogger: Logger;
+  private readonly _iterationBuffer: Event[] = [];
+  private _iterationIsInteresting =
+    /* The first iteration is always interesting. */ true;
+
+  constructor(actualLogger: Logger) {
+    this._actualLogger = actualLogger;
+  }
+
+  log(event: Event) {
+    if (this._iterationIsInteresting) {
+      // This iteration previously had an interesting event (or it's the very
+      // first one, which we always show).
+      this._actualLogger.log(event);
+      if (this._isWatchRunEnd(event)) {
+        this._iterationIsInteresting = false;
+      }
+    } else if (this._isWatchRunEnd(event)) {
+      // We finished a watch iteration and nothing interesting ever happened.
+      // Discard the buffer.
+      this._iterationBuffer.length = 0;
+    } else if (this._isInteresting(event)) {
+      // The first interesting event of the iteration. Flush the buffer and log
+      // everything from now until the next iteration.
+      while (this._iterationBuffer.length > 0) {
+        this._actualLogger.log(this._iterationBuffer.shift()!);
+      }
+      this._actualLogger.log(event);
+      this._iterationIsInteresting = true;
+    } else {
+      // An uninteresting event in a thus far uninteresting iteration.
+      this._iterationBuffer.push(event);
+    }
+  }
+
+  private _isInteresting(event: Event): boolean {
+    const code =
+      event.type === 'output'
+        ? event.stream
+        : event.type === 'info'
+        ? event.detail
+        : event.reason;
+    switch (code) {
+      case 'fresh':
+      case 'no-command':
+      case 'failed-previous-watch-iteration':
+      case 'watch-run-start':
+      case 'start-cancelled':
+      case 'locked': {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private _isWatchRunEnd(event: Event): boolean {
+    return event.type === 'info' && event.detail === 'watch-run-end';
+  }
+}

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -869,12 +869,7 @@ test(
             command: cmdA.command,
             files: ['b.out'],
             output: ['a.out'],
-            dependencies: [
-              {
-                script: 'b',
-                cascade: false,
-              },
-            ],
+            dependencies: ['b'],
           },
           b: {
             command: cmdB.command,

--- a/src/test/watch.test.ts
+++ b/src/test/watch.test.ts
@@ -853,4 +853,111 @@ test(
   })
 );
 
+test(
+  'script fails but still emits output consumed by another script',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    const cmdB = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            files: ['b.out'],
+            output: ['a.out'],
+            dependencies: [
+              {
+                script: 'b',
+                cascade: false,
+              },
+            ],
+          },
+          b: {
+            command: cmdB.command,
+            files: ['b.in'],
+            output: ['b.out'],
+          },
+        },
+      },
+    });
+
+    const exec = rig.exec('npm run a --watch');
+
+    // B fails, but still emits an output file.
+    const invB = await cmdB.nextInvocation();
+    await rig.write('b.out', 'v0');
+    invB.exit(1);
+
+    // Since the output file was emitted while B was running, and A directly
+    // consumes that input file, another execution iteration is going to get
+    // queued up.
+    //
+    // However, it doesn't make sense to re-run B, because none of its input
+    // files changed. If we do, and it emits another copy of its output file,
+    // we'll get into an infinite loop.
+    //
+    // The standard Wireit behavior for non-watch mode is to not keep any memory
+    // of failures, so that the next time the user runs wireit failed scripts
+    // will always be retried. In watch mode, however, we do need to store a
+    // record of failures to prevent this kind of loop.
+    //
+    // Wait a moment to ensure the second run of B doesn't occur.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    exec.kill();
+    const {stdout, stderr} = await exec.exit;
+    assert.equal(cmdA.numInvocations, 0);
+    assert.equal(cmdB.numInvocations, 1);
+
+    // Also check that we don't log anything for the second iteration which
+    // ultimately doesn't do anything new.
+    assert.equal([...stdout.matchAll(/Running command/gi)].length, 1);
+    assert.equal([...stdout.matchAll(/Watching for file changes/gi)].length, 1);
+    assert.equal([...stderr.matchAll(/Failed/gi)].length, 1);
+  })
+);
+
+test(
+  'input file changes but the contents are the same',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            files: ['input'],
+            output: [],
+          },
+        },
+      },
+      input: 'foo',
+    });
+
+    const exec = rig.exec('npm run a --watch');
+    const inv = await cmdA.nextInvocation();
+    inv.exit(0);
+
+    // Write an input file, but it's the same content. This will cause the file
+    // watcher to trigger, and will start an execution, but the execution will
+    // ultimately do nothing interesting because the fingerprint is the same, so
+    // we shouldn't actually expect any logging.
+    await rig.writeAtomic('input', 'foo');
+    // Wait a moment to give the watcher time to react.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    exec.kill();
+    const {stdout} = await exec.exit;
+    assert.equal(cmdA.numInvocations, 1);
+    assert.equal([...stdout.matchAll(/Watching for file changes/gi)].length, 1);
+  })
+);
+
 test.run();

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -11,6 +11,7 @@ import {Executor, FailureMode, ServiceMap} from './executor.js';
 import {Logger} from './logging/logger.js';
 import {Deferred} from './util/deferred.js';
 import {WorkerPool} from './util/worker-pool.js';
+import {WatchLogger} from './logging/watch-logger.js';
 import {
   ScriptConfig,
   ScriptReference,
@@ -137,7 +138,7 @@ export class Watcher {
   ) {
     this._rootScript = rootScript;
     this._extraArgs = extraArgs;
-    this._logger = logger;
+    this._logger = new WatchLogger(logger);
     this._workerPool = workerPool;
     this._failureMode = failureMode;
     this._cache = cache;


### PR DESCRIPTION
If A depends on B, and B fails but still writes some output that A consumes via its `files` array, then watch mode will currently get stuck in a loop. That's because:

1. Iteration 1 starts
2. B writes an output file, which is also an input file of A
3. Watcher notices a change to an input file so queues another iteration for after this one ends
4. B fails (e.g. there was a type error)
5. Iteration 2 starts
6. B runs again
7. B writes an output file
8. etc...

Step 6 is where the problem is. There's no reason for B to run again. Its input files didn't change, so its fingerprint is the same, and we know that it failed the previous time we tried to run it with the exact same fingerprint. We ran it again because until now we only ever recorded *successful* executions (on disk). There was not a reason to record *failures* before, because when you're in non-watch mode, you would want to retry failures every wireit invocation. So we now do record previous failures, but only in watch mode, and in-memory instead of on disk. If we see that in the previous watch iteration the script had the same fingerprint and failed, then we just immediately fail instead of retrying.

This PR also adds a new `WatchLogger`, which helps reduce unnecessary logging that can come out of the above and similar situations. Previously, every time we started an execution, we'd immediately clear the screen and stream all log messages -- even if all of the log messages were things like "script already fresh". Now we instead buffer events for each watch iteration until we see something that's actually interesting (like running a script), and only then do we clear the screen and start displaying all of the log messages. If in the entire iteration we only saw boring messages, we never show anything.

Thanks @alyahmedaly for the bug report and repro!