### PR TITLE
Implement logging of metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+### Added
+
+- Added tracking of metrics for successful script executions. Metrics are emitted
+  at the end of each run where at least one successful execution occurred.
+
 ## [0.9.5] - 2023-02-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:gc": "wireit",
     "test:glob": "wireit",
     "test:json-schema": "wireit",
+    "test:metrics": "wireit",
     "test:optimize-mkdirs": "wireit",
     "test:parallelism": "wireit",
     "test:service": "wireit",
@@ -310,6 +311,17 @@
       "files": [
         "schema.json"
       ],
+      "output": []
+    },
+    "test:metrics": {
+      "command": "uvu lib/test \"^metrics\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
       "output": []
     },
     "test:optimize-mkdirs": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "test:ide",
         "test:gc",
         "test:json-schema",
+        "test:metrics",
         "test:optimize-mkdirs",
         "test:parallelism",
         "test:service",

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs/promises';
 import * as pathlib from 'path';
 import {Result} from './error.js';
 import {DefaultLogger} from './logging/default-logger.js';
+import {MetricsLogger} from './logging/metrics-logger.js';
 import {ScriptReference} from './config.js';
 import {FailureMode} from './executor.js';
 import {unreachable} from './util/unreachable.js';
@@ -42,7 +43,9 @@ export const packageDir = await (async (): Promise<string | undefined> => {
   }
 })();
 
-export const logger = new DefaultLogger(packageDir ?? process.cwd());
+export const logger = new MetricsLogger(
+  new DefaultLogger(packageDir ?? process.cwd())
+);
 
 export type Agent = 'npm' | 'pnpm' | 'yarnClassic' | 'yarnBerry';
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -8,7 +8,6 @@ import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as pathlib from 'path';
 import {Result} from './error.js';
-import {DefaultLogger} from './logging/default-logger.js';
 import {MetricsLogger} from './logging/metrics-logger.js';
 import {ScriptReference} from './config.js';
 import {FailureMode} from './executor.js';
@@ -43,9 +42,7 @@ export const packageDir = await (async (): Promise<string | undefined> => {
   }
 })();
 
-export const logger = new MetricsLogger(
-  new DefaultLogger(packageDir ?? process.cwd())
-);
+export const logger = new MetricsLogger(packageDir ?? process.cwd());
 
 export type Agent = 'npm' | 'pnpm' | 'yarnClassic' | 'yarnBerry';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,7 @@ const run = async (): Promise<Result<void, Failure[]>> => {
         }
       }
     }
+    logger.printMetrics();
     return errors.length === 0
       ? {ok: true, value: undefined}
       : {ok: false, error: errors};

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -306,4 +306,8 @@ export class DefaultLogger implements Logger {
       }
     }
   }
+
+  printMetrics(): void {
+    // printMetrics() not used in default-logger.
+  }
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -11,4 +11,5 @@ import type {Event} from '../event.js';
  */
 export interface Logger {
   log(event: Event): void;
+  printMetrics(): void;
 }

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -17,7 +17,9 @@ export class MetricsLogger implements Logger {
   private readonly _metrics: Metric[] = [
     {
       name: 'Success',
-      matches: (e: Event) => e.type === 'success',
+      // 'no-command' is technically a success, but we don't want to count it as
+      // a success for this metric because nothing was actually run.
+      matches: (e: Event) => e.type === 'success' && e.reason !== 'no-command',
       count: 0,
     },
     {

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {hrtime} from 'process';
 import {Event} from '../event.js';
 import {DefaultLogger} from './default-logger.js';

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -31,7 +31,7 @@ export class MetricsLogger implements Logger {
       count: 0,
     },
     {
-      name: 'Skipped (cached)',
+      name: 'Restored from cache',
       matches: (e: Event) => e.type === 'success' && e.reason === 'cached',
       count: 0,
     },
@@ -61,7 +61,7 @@ export class MetricsLogger implements Logger {
     }
 
     const elapsed = this._getElapsedTime();
-    const nameOffset = 16;
+    const nameOffset = 20;
 
     const out: string[] = [
       `🏁 [metrics] Executed ${successes} script(s) in ${elapsed} seconds`,

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -56,6 +56,11 @@ export class MetricsLogger extends DefaultLogger {
    * Update relevant metrics for an event and pass it up to the parent logger.
    */
   override log(event: Event): void {
+    // When in watch mode, metrics should reset at the start of each run.
+    if (event.type === 'info' && event.detail === 'watch-run-start') {
+      this._resetMetrics();
+    }
+
     this._updateMetrics(event);
     super.log(event);
   }

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -1,6 +1,6 @@
 import {hrtime} from 'process';
 import {Event} from '../event.js';
-import {Logger} from './logger.js';
+import {DefaultLogger} from './default-logger.js';
 
 interface Metric {
   name: string;
@@ -11,8 +11,7 @@ interface Metric {
 /**
  * A {@link Logger} that keeps track of metrics.
  */
-export class MetricsLogger implements Logger {
-  private readonly _actualLogger: Logger;
+export class MetricsLogger extends DefaultLogger {
   private _startTime: [number, number] = hrtime();
   private readonly _metrics: Metric[] = [
     {
@@ -39,22 +38,26 @@ export class MetricsLogger implements Logger {
     },
   ];
 
-  constructor(actualLogger: Logger) {
-    this._actualLogger = actualLogger;
+  /**
+   * @param rootPackage The npm package directory that the root script being
+   * executed belongs to.
+   */
+  constructor(rootPackage: string) {
+    super(rootPackage);
   }
 
   /**
-   * Update relevant metrics for an event and pass it along to the next logger.
+   * Update relevant metrics for an event and pass it up to the parent logger.
    */
-  log(event: Event): void {
+  override log(event: Event): void {
     this._updateMetrics(event);
-    this._actualLogger.log(event);
+    super.log(event);
   }
 
   /**
    * Log the current metrics and reset the state of each metric.
    */
-  printMetrics(): void {
+  override printMetrics(): void {
     const successes = this._metrics[0].count;
 
     if (!successes) {

--- a/src/logging/metrics-logger.ts
+++ b/src/logging/metrics-logger.ts
@@ -1,0 +1,112 @@
+import {hrtime} from 'process';
+import {Event} from '../event.js';
+import {Logger} from './logger.js';
+
+interface Metric {
+  name: string;
+  matches: (event: Event) => boolean;
+  count: number;
+}
+
+/**
+ * A {@link Logger} that keeps track of metrics.
+ */
+export class MetricsLogger implements Logger {
+  private readonly _actualLogger: Logger;
+  private _startTime: [number, number] = hrtime();
+  private readonly _metrics: Metric[] = [
+    {
+      name: 'Success',
+      matches: (e: Event) => e.type === 'success',
+      count: 0,
+    },
+    {
+      name: 'Ran',
+      matches: (e: Event) => e.type === 'success' && e.reason === 'exit-zero',
+      count: 0,
+    },
+    {
+      name: 'Skipped (fresh)',
+      matches: (e: Event) => e.type === 'success' && e.reason === 'fresh',
+      count: 0,
+    },
+    {
+      name: 'Skipped (cached)',
+      matches: (e: Event) => e.type === 'success' && e.reason === 'cached',
+      count: 0,
+    },
+  ];
+
+  constructor(actualLogger: Logger) {
+    this._actualLogger = actualLogger;
+  }
+
+  /**
+   * Update relevant metrics for an event and pass it along to the next logger.
+   */
+  log(event: Event): void {
+    this._updateMetrics(event);
+    this._actualLogger.log(event);
+  }
+
+  /**
+   * Log the current metrics and reset the state of each metric.
+   */
+  printMetrics(): void {
+    const successes = this._metrics[0].count;
+
+    if (!successes) {
+      this._resetMetrics();
+      return;
+    }
+
+    const elapsed = this._getElapsedTime();
+    const nameOffset = 16;
+
+    const out: string[] = [
+      `🏁 [metrics] Executed ${successes} script(s) in ${elapsed} seconds`,
+    ];
+
+    for (const metric of this._metrics.slice(1)) {
+      const name = metric.name.padEnd(nameOffset);
+      const count = metric.count;
+      const percent = this._calculatePercentage(count, successes);
+
+      out.push(`\t${name}: ${count} (${percent}%)`);
+    }
+
+    console.log(out.join('\n'));
+
+    this._resetMetrics();
+  }
+
+  private _updateMetrics(event: Event): void {
+    for (const metric of this._metrics) {
+      if (metric.matches(event)) {
+        metric.count++;
+      }
+    }
+  }
+
+  private _resetMetrics(): void {
+    this._startTime = hrtime();
+
+    for (const metric of this._metrics) {
+      metric.count = 0;
+    }
+  }
+
+  private _getElapsedTime(): string {
+    const [seconds, nanoseconds] = hrtime(this._startTime);
+    const time = seconds + nanoseconds / 1e9;
+    return time.toFixed(2);
+  }
+
+  private _calculatePercentage(numerator: number, denominator: number): number {
+    if (denominator === 0) {
+      return 0;
+    }
+
+    return Math.floor((numerator / denominator) * 100);
+  }
+}

--- a/src/logging/watch-logger.ts
+++ b/src/logging/watch-logger.ts
@@ -6,18 +6,17 @@
 
 import type {Event} from '../event.js';
 import type {Logger} from './logger.js';
-import {MetricsLogger} from './metrics-logger.js';
 
 /**
  * A logger for watch mode that avoids useless output.
  */
 export class WatchLogger implements Logger {
-  private readonly _actualLogger: MetricsLogger;
+  private readonly _actualLogger: Logger;
   private readonly _iterationBuffer: Event[] = [];
   private _iterationIsInteresting =
     /* The first iteration is always interesting. */ true;
 
-  constructor(actualLogger: MetricsLogger) {
+  constructor(actualLogger: Logger) {
     this._actualLogger = actualLogger;
   }
 
@@ -47,6 +46,10 @@ export class WatchLogger implements Logger {
       // An uninteresting event in a thus far uninteresting iteration.
       this._iterationBuffer.push(event);
     }
+  }
+
+  printMetrics(): void {
+    // printMetrics() not used in watch-logger.
   }
 
   private _isInteresting(event: Event): boolean {

--- a/src/logging/watch-logger.ts
+++ b/src/logging/watch-logger.ts
@@ -6,17 +6,18 @@
 
 import type {Event} from '../event.js';
 import type {Logger} from './logger.js';
+import {MetricsLogger} from './metrics-logger.js';
 
 /**
  * A logger for watch mode that avoids useless output.
  */
 export class WatchLogger implements Logger {
-  private readonly _actualLogger: Logger;
+  private readonly _actualLogger: MetricsLogger;
   private readonly _iterationBuffer: Event[] = [];
   private _iterationIsInteresting =
     /* The first iteration is always interesting. */ true;
 
-  constructor(actualLogger: Logger) {
+  constructor(actualLogger: MetricsLogger) {
     this._actualLogger = actualLogger;
   }
 
@@ -25,6 +26,8 @@ export class WatchLogger implements Logger {
       // This iteration previously had an interesting event (or it's the very
       // first one, which we always show).
       this._actualLogger.log(event);
+      this._actualLogger.printMetrics();
+
       if (this._isWatchRunEnd(event)) {
         this._iterationIsInteresting = false;
       }

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -1,0 +1,323 @@
+import {suite} from 'uvu';
+import {timeout} from './util/uvu-timeout.js';
+import {WireitTestRig} from './util/test-rig.js';
+import {checkScriptOutput} from './util/check-script-output.js';
+import assert from 'assert';
+
+const test = suite<{rig: WireitTestRig}>();
+
+test.before.each(async (ctx) => {
+  try {
+    ctx.rig = new WireitTestRig();
+    await ctx.rig.setup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu before error', error);
+    process.exit(1);
+  }
+});
+
+test.after.each(async (ctx) => {
+  try {
+    await ctx.rig.cleanup();
+  } catch (error) {
+    // Uvu has a bug where it silently ignores failures in before and after,
+    // see https://github.com/lukeed/uvu/issues/191.
+    console.error('uvu after error', error);
+    process.exit(1);
+  }
+});
+
+test(
+  'logs metrics for successful events',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    const cmdB = await rig.newCommand();
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            dependencies: ['b'],
+            files: ['a.txt'],
+            output: [],
+          },
+          b: {
+            command: cmdB.command,
+            files: ['b.txt'],
+            output: [],
+          },
+        },
+      },
+      'a.txt': 'v0',
+    });
+
+    // Initial execution. Both A and B run.
+    {
+      const exec = rig.exec('npm run a');
+      const invB = await cmdB.nextInvocation();
+      invB.exit(0);
+      const invA = await cmdA.nextInvocation();
+      invA.exit(0);
+      const {stdout} = await exec.exit;
+
+      assertNthMetric(0, stdout, {total: 2, ran: 2, percentRan: 100});
+    }
+
+    // Input to A is changed, so A runs again. B is a dependency of A, but it is
+    // unchanged, so B is fresh.
+    {
+      await rig.write('a.txt', 'v1');
+      const exec = rig.exec('npm run a');
+      const invA = await cmdA.nextInvocation();
+      invA.exit(0);
+      const {stdout} = await exec.exit;
+
+      assertNthMetric(0, stdout, {
+        total: 2,
+        ran: 1,
+        percentRan: 50,
+        fresh: 1,
+        percentFresh: 50,
+      });
+    }
+
+    // Input to A is changed back to 'v0', so A is cached. B is a dependency of A,
+    // but it is still unchanged, so B is fresh.
+    {
+      await rig.write('a.txt', 'v0');
+      const exec = rig.exec('npm run a');
+      const {stdout} = await exec.exit;
+
+      assertNthMetric(0, stdout, {
+        total: 2,
+        fresh: 1,
+        percentFresh: 50,
+        cached: 1,
+        percentCached: 50,
+      });
+    }
+  })
+);
+
+test(
+  'does not log metrics for non-success events',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    await rig.write({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+          },
+        },
+      },
+    });
+
+    // Script fails for unknown reason
+    const exec = rig.exec('npm run a');
+    const inv = await cmdA.nextInvocation();
+    inv.exit(1);
+    const {stdout} = await exec.exit;
+
+    // There should be no metrics in the output.
+    assert.equal([...stdout.matchAll(/🏁/gi)].length, 0);
+  })
+);
+
+test(
+  'logs metrics for interesting iterations when in watch mode',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    const cmdB = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            dependencies: ['b'],
+            files: ['a.txt'],
+            output: [],
+          },
+          b: {
+            command: cmdB.command,
+            files: ['b.txt'],
+            output: [],
+          },
+        },
+      },
+      'a.txt': 'v0',
+      'b.txt': 'v0',
+    });
+
+    const exec = rig.exec('npm run a --watch');
+
+    // Initial execution. Both A and B run.
+    {
+      const invB = await cmdB.nextInvocation();
+      invB.exit(0);
+      const invA = await cmdA.nextInvocation();
+      invA.exit(0);
+      assert.equal(cmdA.numInvocations, 1);
+      assert.equal(cmdB.numInvocations, 1);
+    }
+
+    // Input to A is changed, so A runs again. B is a dependency of A, but it is
+    // unchanged, so B is fresh.
+    {
+      await rig.writeAtomic({
+        'a.txt': 'v1',
+      });
+      const invA = await cmdA.nextInvocation();
+      invA.exit(0);
+    }
+
+    // Wait a moment to give the watcher time to react.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    exec.kill();
+    const {stdout} = await exec.exit;
+
+    assert.equal([...stdout.matchAll(/🏁/gi)].length, 3);
+    assertNthMetric(0, stdout, {total: 1, ran: 1, percentRan: 100});
+    assertNthMetric(1, stdout, {total: 1, ran: 1, percentRan: 100});
+    assertNthMetric(2, stdout, {
+      total: 2,
+      ran: 1,
+      percentRan: 50,
+      fresh: 1,
+      percentFresh: 50,
+    });
+  })
+);
+
+test(
+  'does not log metrics for non-interesting iterations in watch mode',
+  timeout(async ({rig}) => {
+    const cmdA = await rig.newCommand();
+    await rig.writeAtomic({
+      'package.json': {
+        scripts: {
+          a: 'wireit',
+        },
+        wireit: {
+          a: {
+            command: cmdA.command,
+            files: ['a.txt'],
+            output: [],
+          },
+        },
+      },
+      'a.txt': 'v0',
+    });
+
+    const exec = rig.exec('npm run a --watch');
+
+    // Initial execution. A should run.
+    const inv = await cmdA.nextInvocation();
+    inv.exit(0);
+
+    // Input to A is changed, but has the same content as before. This is not an
+    // 'interesting' iteration, so metrics shouldn't be logged.
+    await rig.writeAtomic('a.txt', 'v0');
+
+    // Wait a moment to give the watcher time to react.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    exec.kill();
+    const {stdout} = await exec.exit;
+
+    // There should only be one metrics entry in stdout.
+    assert.equal([...stdout.matchAll(/\[metrics\]/gi)].length, 1);
+    assertNthMetric(0, stdout, {total: 1, ran: 1, percentRan: 100});
+  })
+);
+
+/**
+ * Asserts that the nth metric in stdout exists and matches the given arguments.
+ */
+function assertNthMetric(
+  n: number,
+  stdout: string,
+  args: {
+    total?: number;
+    ran?: number;
+    percentRan?: number;
+    fresh?: number;
+    percentFresh?: number;
+    cached?: number;
+    percentCached?: number;
+  }
+): void {
+  const metric = findNthMetric(n, stdout);
+
+  if (!metric) {
+    throw new Error(`Could not find metric ${n}`);
+  }
+
+  const actual = replaceTimeWithWildcard(metric);
+  const expected = buildExpectedMetric(args);
+
+  checkScriptOutput(actual, expected);
+}
+
+function findNthMetric(n: number, stdout: string): string | undefined {
+  const lines = stdout.split('\n');
+  const metricLength = 4;
+
+  let count = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('🏁 [metrics]')) {
+      count++;
+
+      if (count === n) {
+        return lines.slice(i, i + metricLength).join('\n');
+      }
+    }
+  }
+}
+
+function buildExpectedMetric(args: {
+  total?: number;
+  ran?: number;
+  percentRan?: number;
+  fresh?: number;
+  percentFresh?: number;
+  cached?: number;
+  percentCached?: number;
+}): string {
+  return `🏁 [metrics] Executed ${args.total ?? 0} script(s) in * seconds
+\tRan             : ${args.ran ?? 0} (${args.percentRan ?? 0}%)
+\tSkipped (fresh) : ${args.fresh ?? 0} (${args.percentFresh ?? 0}%)
+\tSkipped (cached): ${args.cached ?? 0} (${args.percentCached ?? 0}%)
+`;
+}
+
+/**
+ * Replaces the 'seconds' value in the metric with '*'. We are not interested
+ * in asserting on the exact time.
+ */
+function replaceTimeWithWildcard(metric: string): string {
+  const words = metric.split(' ');
+
+  for (let i = 0; i < words.length; i++) {
+    if (words[i].startsWith('seconds')) {
+      words[i - 1] = '*';
+      break;
+    }
+  }
+
+  return words.join(' ');
+}
+
+test.run();

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {suite} from 'uvu';
 import {timeout} from './util/uvu-timeout.js';
 import {WireitTestRig} from './util/test-rig.js';

--- a/src/test/metrics.test.ts
+++ b/src/test/metrics.test.ts
@@ -297,9 +297,9 @@ function buildExpectedMetric(args: {
   percentCached?: number;
 }): string {
   return `🏁 [metrics] Executed ${args.total ?? 0} script(s) in * seconds
-\tRan             : ${args.ran ?? 0} (${args.percentRan ?? 0}%)
-\tSkipped (fresh) : ${args.fresh ?? 0} (${args.percentFresh ?? 0}%)
-\tSkipped (cached): ${args.cached ?? 0} (${args.percentCached ?? 0}%)
+\tRan                 : ${args.ran ?? 0} (${args.percentRan ?? 0}%)
+\tSkipped (fresh)     : ${args.fresh ?? 0} (${args.percentFresh ?? 0}%)
+\tRestored from cache : ${args.cached ?? 0} (${args.percentCached ?? 0}%)
 `;
 }
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -11,7 +11,6 @@ import {Executor, FailureMode, ServiceMap} from './executor.js';
 import {Logger} from './logging/logger.js';
 import {Deferred} from './util/deferred.js';
 import {WorkerPool} from './util/worker-pool.js';
-import {MetricsLogger} from './logging/metrics-logger.js';
 import {WatchLogger} from './logging/watch-logger.js';
 import {
   ScriptConfig,
@@ -136,7 +135,7 @@ export class Watcher {
   constructor(
     rootScript: ScriptReference,
     extraArgs: string[] | undefined,
-    logger: MetricsLogger,
+    logger: Logger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
     failureMode: FailureMode,

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -11,6 +11,7 @@ import {Executor, FailureMode, ServiceMap} from './executor.js';
 import {Logger} from './logging/logger.js';
 import {Deferred} from './util/deferred.js';
 import {WorkerPool} from './util/worker-pool.js';
+import {MetricsLogger} from './logging/metrics-logger.js';
 import {WatchLogger} from './logging/watch-logger.js';
 import {
   ScriptConfig,
@@ -135,7 +136,7 @@ export class Watcher {
   constructor(
     rootScript: ScriptReference,
     extraArgs: string[] | undefined,
-    logger: Logger,
+    logger: MetricsLogger,
     workerPool: WorkerPool,
     cache: Cache | undefined,
     failureMode: FailureMode,


### PR DESCRIPTION
Adds a MetricsLogger class that keeps track of several metrics related to the execution of scripts:

- total successes (ignoring `no-command`'s, which don't run anything)
- scripts that ran
- scripts that were fresh 
- scripts that were restored from cache
- elapsed time

In 'normal' mode, metics are logged on each iteration with at least one 'success'. In 'watch mode', metrics are logged on each _interesting_ iteration with at least one 'success'.

<img width="1132" alt="metrics" src="https://user-images.githubusercontent.com/30248392/220718913-382c5647-ea83-45eb-b309-4fac7c610084.png">


 Addresses issue #525 