### PR TITLE
Add missing git tag links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,7 +538,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 [0.3.1]: https://github.com/google/wireit/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/google/wireit/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/google/wireit/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/google/wireit/compare/v0.2.0...v0.2.0
+[0.2.0]: https://github.com/google/wireit/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/google/wireit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/google/wireit/compare/v0.0.0...v0.1.0
 [0.0.0]: https://github.com/google/wireit/compare/tag/v0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,3 +515,30 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Initial release.
+
+[unreleased]: https://github.com/google/wireit/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/google/wireit/compare/v0.9.4...v0.9.5
+[0.9.4]: https://github.com/google/wireit/compare/v0.9.3...v0.9.4
+[0.9.3]: https://github.com/google/wireit/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/google/wireit/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/google/wireit/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/google/wireit/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/google/wireit/compare/v0.7.3...v0.8.0
+[0.7.3]: https://github.com/google/wireit/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/google/wireit/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/google/wireit/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/google/wireit/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/google/wireit/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/google/wireit/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/google/wireit/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/google/wireit/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/google/wireit/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/google/wireit/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/google/wireit/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/google/wireit/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/google/wireit/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/google/wireit/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/google/wireit/compare/v0.2.0...v0.2.0
+[0.1.1]: https://github.com/google/wireit/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/google/wireit/compare/v0.0.0...v0.1.0
+[0.0.0]: https://github.com/google/wireit/compare/tag/v0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -541,4 +541,4 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 [0.2.0]: https://github.com/google/wireit/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/google/wireit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/google/wireit/compare/v0.0.0...v0.1.0
-[0.0.0]: https://github.com/google/wireit/compare/tag/v0.0.0
+[0.0.0]: https://github.com/google/wireit/releases/tag/v0.0.0


### PR DESCRIPTION
Related to google/playground-elements#372

This PR adds the missing links to git tags for each release.