### PR TITLE
Don't upgrade a script to locally-valid if it has errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+## [Unreleased]
+
+### Fixed
+
+- More reliably handle and report diagnostics for scripts with invalid configurations. Specifically fixed https://github.com/google/wireit/issues/803.
+
 ## [0.13.0] - 2023-09-01
 
 ### Changed

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -585,6 +585,12 @@ export class Analyzer {
 
     const env = this.#processEnv(placeholder, packageJson, syntaxInfo, command);
 
+    if (placeholder.failures.length > 0) {
+      // A script with locally-determined errors doesn't get upgraded to
+      // locally-valid.
+      return;
+    }
+
     // It's important to in-place update the placeholder object, instead of
     // creating a new object, because other configs may be referencing this
     // exact object in their dependencies.

--- a/src/test/ide.test.ts
+++ b/src/test/ide.test.ts
@@ -154,6 +154,37 @@ test('we can get cyclic dependency errors', async ({rig}) => {
   });
 });
 
+test('warns for a service without a command', async ({rig}) => {
+  const ide = new IdeAnalyzer();
+  ide.setOpenFileContents(
+    rig.resolve('package.json'),
+    JSON.stringify(
+      {
+        scripts: {
+          a: 'wireit',
+          b: 'wireit',
+        },
+        wireit: {
+          a: {
+            service: true,
+            dependencies: ['b'],
+          },
+          b: {
+            command: 'echo',
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await assertDiagnostics(ide, {
+    [rig.resolve('package.json')]: [
+      `A "service" script must have a "command".`,
+    ],
+  });
+});
+
 async function assertDefinition(
   ide: IdeAnalyzer,
   options: {


### PR DESCRIPTION
This way later scripts can assume locally-valid means no failures in the script that are locally determinable.

I think this was the original intent, and some code seems to assume this. See e.g. https://github.com/google/wireit/issues/803