### PR TITLE
Add some missing links for recent releases in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -542,7 +542,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Initial release.
 
 [unreleased]: https://github.com/google/wireit/compare/v0.13.0...HEAD
-[0.13.0]: https://github.com/google/wireit/compare/v0.12.0....v0.13.0
+[0.13.0]: https://github.com/google/wireit/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/google/wireit/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/google/wireit/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/google/wireit/compare/v0.9.5...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -541,7 +541,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
-[unreleased]: https://github.com/google/wireit/compare/v0.9.5...HEAD
+[unreleased]: https://github.com/google/wireit/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/google/wireit/compare/v0.12.0....v0.13.0
+[0.12.0]: https://github.com/google/wireit/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/google/wireit/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/google/wireit/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/google/wireit/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/google/wireit/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/google/wireit/compare/v0.9.2...v0.9.3


### PR DESCRIPTION
This format got added in https://github.com/google/wireit/pull/784 and it seems nice.

I also manually created the tags for the recent releases which will make these links work.