### PR TITLE
Update our `npx wireit` detection

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -66,7 +66,7 @@ export const getOptions = (): Result<Options> => {
   // "npm_lifecycle_event" to "npx". The "npm_execpath" will be "npx-cli.js",
   // though, so we use that combination to detect this special case.
   const launchedWithNpx =
-    scriptName === 'npx' && process.env.npm_execpath?.endsWith('npx-cli.js');
+    scriptName === 'npx' && process.env.npm_command === 'exec';
   if (!packageDir || !scriptName || launchedWithNpx) {
     const detail = [];
     if (!packageDir) {

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "wireit" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+- Fix our `npx wireit` detection so we continue to give a good error message
+  with the latest version of `npm` when wireit is run this way.
+
 ## [0.7.0] - 2023-09-12
 
 - More reliably handle and report diagnostics for scripts with invalid


### PR DESCRIPTION
The latest version of npm doesn't set the `npm_execpath` env variable.