### PR TITLE
Fix output for TS Build Info File in TypeScript recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ This section contains advice about integrating specific build tools with Wireit.
       "command": "tsc --build --pretty",
       "clean": "if-file-deleted",
       "files": ["src/**/*.ts", "tsconfig.json"],
-      "output": ["lib/**", ".tsbuildinfo"]
+      "output": ["lib/**", "*.tsbuildinfo"]
     }
   }
 }


### PR DESCRIPTION
TS Build Info File is usually named `<config name>.tsbuildInfo` (e.g., `tsconfig.tsbuildinfo`). I had a weird issue where some files would go missing from the `outDir`, this occurred when I had a compilation error, and then I would fix the compilation error. The video below demonstrates the issue, you'll notice at the end that only `foo.ts` gets output to `foo.js`, `index.js` and `math.js` are missing completely. Changing `.tsbuildinfo` to `*.tsbuildinfo` (or `tsconfig.tsbuildinfo`) fixed the issue for me.

https://github.com/google/wireit/assets/876666/b2b97aea-3623-4fce-b799-9731dd9c27b3
