### PR TITLE
Fix hang when cancelling a service start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix our `npx wireit` detection so we continue to give a good error message
   with the latest version of `npm` when wireit is run this way.
 
+- Fix a bug where wireit would hang with an empty spinner after being killed
+  with CTRL-C when running a service whose dependencies were still starting.
+
 ## [0.14.0] - 2023-09-12
 
 ### Changed

--- a/src/execution/service.ts
+++ b/src/execution/service.ts
@@ -1009,10 +1009,22 @@ export class ServiceScriptExecution extends BaseExecutionWithCommand<ServiceScri
         };
         break;
       }
-      case 'initial':
       case 'executingDeps':
       case 'fingerprinting':
       case 'stoppingAdoptee':
+        this.#state.deferredFingerprint.resolve({
+          ok: false,
+          error: [
+            {
+              type: 'failure',
+              script: this._config,
+              reason: 'aborted',
+            },
+          ],
+        });
+        this.#enterStoppedState();
+        break;
+      case 'initial':
       case 'unstarted':
       case 'depsStarting': {
         this.#enterStoppedState();

--- a/src/test/util/rig-test.ts
+++ b/src/test/util/rig-test.ts
@@ -65,6 +65,7 @@ export const rigTest = <T extends {rig?: WireitTestRig}>(
         return context.rig;
       }
       const rig = new WireitTestRig();
+      
       await rig.setup();
       return rig;
     })();

--- a/src/test/util/rig-test.ts
+++ b/src/test/util/rig-test.ts
@@ -65,7 +65,7 @@ export const rigTest = <T extends {rig?: WireitTestRig}>(
         return context.rig;
       }
       const rig = new WireitTestRig();
-      
+
       await rig.setup();
       return rig;
     })();

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -422,6 +422,22 @@ class ExecResult {
     return this.#exited.promise;
   }
 
+  sendSigint(): void {
+    if (!this.running) {
+      throw new Error("Can't kill child process because it is not running");
+    }
+    if (this.#child.pid === undefined) {
+      throw new Error("Can't kill child process because it has no pid");
+    }
+    if (!IS_WINDOWS) {
+      process.kill(-this.#child.pid, 'SIGINT');
+    } else {
+      // On Windows, we don't have signals, so we just send a Ctrl+C character
+      // to the child process's stdin.
+      this.#child.stdin.write('\x03');
+    }
+  }
+
   /**
    * Kill the child process.
    */

--- a/src/test/util/test-rig.ts
+++ b/src/test/util/test-rig.ts
@@ -432,9 +432,8 @@ class ExecResult {
     if (!IS_WINDOWS) {
       process.kill(-this.#child.pid, 'SIGINT');
     } else {
-      // On Windows, we don't have signals, so we just send a Ctrl+C character
-      // to the child process's stdin.
-      this.#child.stdin.write('\x03');
+      // On Windows, we don't have signals, so we just kill the process.
+      this.kill();
     }
   }
 


### PR DESCRIPTION
The promise returned by ServiceExecution.execute() would never settle if it was aborted while its dependencies were started, meaning that other dependent promises would likewise never settle.

This was made clearer by the new quiet logger, because the spinner keeps going until the top level CLI run() function returns.