### PR TITLE
add parsing env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,22 @@ should not be re-used.
 }
 ```
 
+### Parsing the env file
+
+```json
+{
+  "wireit": {
+    "my-script": {
+      "command": "my-command",
+      "env-file": [
+        ".env",
+        ".dev.env"
+      ]
+    }
+  }
+}
+```
+
 ## Services
 
 By default, Wireit assumes that your scripts will eventually exit by themselves.

--- a/schema.json
+++ b/schema.json
@@ -117,6 +117,13 @@
                 }
               ]
             }
+          },
+          "env-file": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "type": "object"

--- a/src/read-env-file.ts
+++ b/src/read-env-file.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {readFile, stat} from 'node:fs/promises';
+
+// TODO string-template-parser
+
+export async function readEnvFile(filepath: string, entries: Array<[string, string]>): Promise<void> {
+  const fileStat = await stat(filepath);
+  if (!fileStat.isFile()) {
+    console.warn('Skipping non-file env file: ' + filepath);
+    return;
+  }
+  const content = await readFile(filepath, 'utf8');
+  const lines = content.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#')) {
+      continue;
+    }
+    const [key, ...rest] = trimmed.split('=');
+    if (rest.length === 0) {
+      continue;
+    }
+    const value = rest.join('=');
+    if (typeof key === 'string' && typeof value === 'string') {
+      entries.push([key, value]);
+    }
+  }
+}

--- a/src/read-env-file.ts
+++ b/src/read-env-file.ts
@@ -9,8 +9,8 @@ import {readFile, stat} from 'node:fs/promises';
 // TODO string-template-parser
 
 export async function readEnvFile(filepath: string, entries: Array<[string, string]>): Promise<void> {
-  const fileStat = await stat(filepath);
-  if (!fileStat.isFile()) {
+  const fileStat = await stat(filepath).catch(() => null);
+  if (!fileStat || !fileStat.isFile()) {
     console.warn('Skipping non-file env file: ' + filepath);
     return;
   }


### PR DESCRIPTION
`.env`
```
TEST_ENV=test-value
```

```json
{
  "wireit": {
    "my-script": {
      "command": "echo env=$TEST_ENV",
      "env-file": [
        ".env"
      ]
    }
  }
}
```

```sh
❯ npm run my-script

> monitoring@1.0.0 my-script
> wireit

env=test-value            
✅ Ran 1 script and skipped 0 in 0s.
```