### PR TITLE
Handle `ENOENT` When Fingerprinting Deleted Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The default logger for non-interactive environments has been switched to the 'quiet-ci' logger.
 
+### Fixed
+
+- Handle missing file errors thrown while trying to fingerprint an input file.
+
 ## [0.14.1] - 2023-10-20
 
 ### Fixed

--- a/src/event.ts
+++ b/src/event.ts
@@ -100,7 +100,8 @@ export type Failure =
   | DependencyInvalid
   | ServiceExitedUnexpectedly
   | DependencyServiceExitedUnexpectedly
-  | Aborted;
+  | Aborted
+  | FilesDeletedDuringFingerprinting;
 
 interface ErrorBase<T extends PackageReference = ScriptReference>
   extends EventBase<T> {
@@ -279,6 +280,15 @@ export interface DependencyServiceExitedUnexpectedly extends ErrorBase {
  */
 export interface Aborted extends ErrorBase {
   reason: 'aborted';
+}
+
+/**
+ * A file was deleting after globbing but before fingerprinting and
+ * was unable to be read.
+ */
+export interface FilesDeletedDuringFingerprinting extends ErrorBase {
+  reason: 'files-deleted-during-fingerprinting';
+  filePaths: string[];
 }
 
 /**

--- a/src/execution/no-command.ts
+++ b/src/execution/no-command.ts
@@ -23,11 +23,17 @@ export class NoCommandScriptExecution extends BaseExecution<NoCommandScriptConfi
       this._config,
       dependencyFingerprints.value,
     );
+    if (!fingerprint.ok) {
+      return {
+        ok: false,
+        error: [fingerprint.error],
+      };
+    }
     this._logger.log({
       script: this._config,
       type: 'success',
       reason: 'no-command',
     });
-    return {ok: true, value: fingerprint};
+    return {ok: true, value: fingerprint.value};
   }
 }

--- a/src/execution/standard.ts
+++ b/src/execution/standard.ts
@@ -79,10 +79,17 @@ export class StandardScriptExecution extends BaseExecutionWithCommand<StandardSc
         // Note we must wait for dependencies to finish before generating the
         // cache key, because a dependency could create or modify an input file to
         // this script, which would affect the key.
-        const fingerprint = await Fingerprint.compute(
+        const fingerprintResponse = await Fingerprint.compute(
           this._config,
           dependencyFingerprints.value,
         );
+        if (!fingerprintResponse.ok) {
+          return {
+            ok: false,
+            error: [fingerprintResponse.error],
+          };
+        }
+        const fingerprint = fingerprintResponse.value;
         if (
           this._executor.failedInPreviousWatchIteration(
             this._config,

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -14,6 +14,8 @@ import type {
   ScriptReferenceString,
   Dependency,
 } from './config.js';
+import {Result} from './error.js';
+import {Failure} from './event.js';
 
 /**
  * All meaningful inputs of a script. Used for determining if a script is fresh,
@@ -131,7 +133,7 @@ export class Fingerprint {
   static async compute(
     script: ScriptConfig,
     dependencyFingerprints: Array<[Dependency, Fingerprint]>,
-  ): Promise<Fingerprint> {
+  ): Promise<Result<Fingerprint, Failure>> {
     let allDependenciesAreFullyTracked = true;
     const filteredDependencyFingerprints: Array<
       [ScriptReferenceString, FingerprintSha256HexDigest]
@@ -172,9 +174,9 @@ export class Fingerprint {
       // read) as a heuristic to detect files that have likely changed, and
       // otherwise re-use cached hashes that we store in e.g.
       // ".wireit/<script>/hashes".
-      let wasFileDeleted = false;
-      const globbedHashes = await Promise.all(
-        files.map(async (file): Promise<[string, FileSha256HexDigest]|undefined> => {
+      const erroredFilePaths: string[] = [];
+      fileHashes = await Promise.all(
+        files.map(async (file): Promise<[string, FileSha256HexDigest]> => {
           const absolutePath = file.path;
           const hash = createHash('sha256');
           try {
@@ -186,22 +188,25 @@ export class Fingerprint {
             // It's possible for a file to be deleted between the
             // time it is globbed and the time it is fingerprinted.
             const {code} = error as {code: string};
-            if (code === /* does not exist */ 'ENOENT') {
-              wasFileDeleted = true;
-              return undefined;
+            if (code !== /* does not exist */ 'ENOENT') {
+              throw error;
             }
-            throw error;
+            erroredFilePaths.push(absolutePath);
           }
           return [file.path, hash.digest('hex') as FileSha256HexDigest];
         }),
       );
 
-      if ( wasFileDeleted ) {
-        fileHashes = globbedHashes.filter(
-          (fileHash): fileHash is [string, FileSha256HexDigest] => fileHash !== undefined
-        );
-      } else {
-        fileHashes = globbedHashes as [string, FileSha256HexDigest][];
+      if (erroredFilePaths.length > 0) {
+        return {
+          ok: false,
+          error: {
+            type: 'failure',
+            reason: 'files-deleted-during-fingerprinting',
+            script: script,
+            filePaths: erroredFilePaths,
+          },
+        };
       }
     } else {
       fileHashes = [];
@@ -253,7 +258,7 @@ export class Fingerprint {
       env: script.env,
     };
     fingerprint.#data = data as FingerprintData;
-    return fingerprint;
+    return {ok: true, value: fingerprint};
   }
 
   #str?: FingerprintString;

--- a/src/logging/default-logger.ts
+++ b/src/logging/default-logger.ts
@@ -201,6 +201,14 @@ export class DefaultLogger implements Logger {
             this.console.error(`❌${prefix} Service exited unexpectedly`);
             break;
           }
+          case 'files-deleted-during-fingerprinting': {
+            for (const filePath of event.filePaths) {
+              this.console.error(
+                `❌${prefix} "${filePath}" was deleted during fingerprinting.`,
+              );
+            }
+            break;
+          }
           case 'aborted':
           case 'dependency-service-exited-unexpectedly': {
             // These event isn't very useful to log, because they are downstream

--- a/src/logging/quiet/run-tracker.ts
+++ b/src/logging/quiet/run-tracker.ts
@@ -558,6 +558,7 @@ export class QuietRunLogger implements Disposable {
         // Also logged elswhere.
         break;
       }
+      case 'files-deleted-during-fingerprinting':
       case 'service-exited-unexpectedly':
       case 'cycle':
       case 'dependency-invalid':


### PR DESCRIPTION
While computing the fingerprint there is a gap between input file globbing and fingerprinting wherein a file might have been deleted. This causes the hash building process to throw an exception and crashes the `--watch` operation. We ran into this problem while pairing a `wireit` script's `--watch` option with `webpack --watch`. When Webpack started replacing files it would sometimes cause the `wireit` script to stop the watch process.

This pull request adds some error handling to this process so that `wireit` will continue working in this case.