### PR TITLE
Re-Added Unhandled Exception Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - The default logger for non-interactive environments has been switched to the 'quiet-ci' logger.
+- Unhandled exceptions will now be handled more gracefully.
 
 ## [0.14.1] - 2023-10-20
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -25,8 +25,8 @@ import type {
 } from './config.js';
 import type {Failure} from './event.js';
 import type {Fingerprint} from './fingerprint.js';
-import { ExecutionResult } from './execution/base.js';
-import { convertExceptionToFailure } from './error.js';
+import {ExecutionResult} from './execution/base.js';
+import {convertExceptionToFailure} from './error.js';
 
 type Execution =
   | NoCommandScriptExecution
@@ -190,10 +190,8 @@ export class Executor {
     const errors: Failure[] = [];
     let rootExecutionResult: ExecutionResult;
     try {
-      rootExecutionResult = await this.getExecution(
-        this.#rootConfig,
-      ).execute();
-    } catch ( error ) {
+      rootExecutionResult = await this.getExecution(this.#rootConfig).execute();
+    } catch (error) {
       rootExecutionResult = convertExceptionToFailure(error, this.#rootConfig);
     }
     if (!rootExecutionResult.ok) {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -25,6 +25,8 @@ import type {
 } from './config.js';
 import type {Failure} from './event.js';
 import type {Fingerprint} from './fingerprint.js';
+import { ExecutionResult } from './execution/base.js';
+import { convertExceptionToFailure } from './error.js';
 
 type Execution =
   | NoCommandScriptExecution
@@ -186,9 +188,14 @@ export class Executor {
     }
 
     const errors: Failure[] = [];
-    const rootExecutionResult = await this.getExecution(
-      this.#rootConfig,
-    ).execute();
+    let rootExecutionResult: ExecutionResult;
+    try {
+      rootExecutionResult = await this.getExecution(
+        this.#rootConfig,
+      ).execute();
+    } catch ( error ) {
+      rootExecutionResult = convertExceptionToFailure(error, this.#rootConfig);
+    }
     if (!rootExecutionResult.ok) {
       errors.push(...rootExecutionResult.error);
     }


### PR DESCRIPTION
In https://github.com/google/wireit/pull/471 the handling of unhandled exceptions was removed. This adds that missing handling back so that any exceptions that aren't caught can be gracefully handled and raised to the user correctly.