### PR TITLE
Fix bug relating to expanding symlinks to directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- When listing a symlink that points to a directory in `output` files, the
+  symlink will now be directly cached as a symlink, instead of its children
+  being cached. This also fixes an `file already exists, symlink` exception that
+  could occur in the same situation.
 
 ## [0.14.3] - 2024-01-10
 

--- a/src/test/glob.test.ts
+++ b/src/test/glob.test.ts
@@ -610,6 +610,23 @@ for (const mode of ['once', 'watch'] as const) {
       }),
   );
 
+  skipIfWatch(
+    `[${mode}] does not expand directly specified symlinked directories when followSymlinks=false`,
+    ({check}) =>
+      check({
+        mode,
+        files: [
+          'target/foo',
+          {target: 'target', path: 'symlink', windowsType: 'dir'},
+        ],
+        patterns: ['symlink'],
+        expected: ['symlink'],
+        followSymlinks: false,
+        includeDirectories: true,
+        expandDirectories: true,
+      }),
+  );
+
   test(`[${mode}] dirent tags files`, async ({rig}) => {
     await rig.touch('foo');
     const actual = await glob(['foo'], {


### PR DESCRIPTION
When listing a symlink that points to a directory in `output` files, the symlink will now be directly cached as a symlink, instead of its children being cached. This also fixes an `file already exists, symlink` exception that could occur in the same situation.