### PR TITLE
chore: bump node to lts major version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,5 +2,5 @@ name: 'wireit-setup-github-actions-caching'
 author: 'Google LLC'
 description: "Enables Wireit's GitHub Actions caching mode and exposes required environment variables"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Users of this GitHub Action are currently receiving warnings that 'node16' is no longer supported.