### PR TITLE
Upgrade setup-github-actions-caching to use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,5 +2,5 @@ name: 'wireit-setup-github-actions-caching'
 author: 'Google LLC'
 description: "Enables Wireit's GitHub Actions caching mode and exposes required environment variables"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node 16 reached EOL last September and although there is probably okay to keep using Node 16 for this action for now, GitHub started warning about an outdated Node version being used. This PR removes that warning by upgrading to Node 20 (LTS; https://nodejs.org/en/about/previous-releases#release-schedule) and reduces the risk of breaking if Node 16 becomes not available on GitHub Actions.

Fixes https://github.com/google/wireit/issues/1039