### PR TITLE
Replace braces with brace-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   install warnings (consistent with `0.13.0` which already raised the minimum
   supported version to Node 18).
 
-- Replaced `braces` dependency with smaller `brace-extension` dependency.
+- Replaced `braces` dependency with smaller `brace-expansion` dependency.
 
 ## [0.14.4] - 2024-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   install warnings (consistent with `0.13.0` which already raised the minimum
   supported version to Node 18).
 
+- Replaced `braces` dependency with smaller `brace-extension` dependency.
+
 ## [0.14.4] - 2024-01-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "website"
       ],
       "dependencies": {
-        "braces": "^3.0.2",
+        "brace-expansion": "^4.0.0",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",
         "jsonc-parser": "^3.0.0",
@@ -23,7 +23,7 @@
         "wireit": "bin/wireit.js"
       },
       "devDependencies": {
-        "@types/braces": "^3.0.1",
+        "@types/brace-expansion": "^1.1.2",
         "@types/node": "^18.17.14",
         "@types/node-forge": "^1.3.0",
         "@types/proper-lockfile": "^4.1.2",
@@ -1146,10 +1146,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/braces": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
-      "integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+    "node_modules/@types/brace-expansion": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/brace-expansion/-/brace-expansion-1.1.2.tgz",
+      "integrity": "sha512-+YDjlWHMm/zoiQSKhEhL/0HdfYxCVuGlP5tQLm5hoHtxGPAMqyHjGpLqm58YDw7vG+RafAahp7HKXeNIwBP3kQ==",
       "dev": true
     },
     "node_modules/@types/command-line-args": {
@@ -2263,11 +2263,22 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.0.tgz",
+      "integrity": "sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
+      "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/braces": {
@@ -3503,6 +3514,14 @@
       "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -5005,6 +5024,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minimist": {
@@ -6852,6 +6880,15 @@
       },
       "engines": {
         "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     }
   },
   "devDependencies": {
-    "@types/braces": "^3.0.1",
+    "@types/brace-expansion": "^1.1.2",
     "@types/node": "^18.17.14",
     "@types/node-forge": "^1.3.0",
     "@types/proper-lockfile": "^4.1.2",
@@ -437,7 +437,7 @@
     "bracketSpacing": false
   },
   "dependencies": {
-    "braces": "^3.0.2",
+    "brace-expansion": "^4.0.0",
     "chokidar": "^3.5.3",
     "fast-glob": "^3.2.11",
     "jsonc-parser": "^3.0.0",

--- a/src/util/glob.ts
+++ b/src/util/glob.ts
@@ -5,7 +5,7 @@
  */
 
 import fastGlob from 'fast-glob';
-import braces from 'braces';
+import braces from 'brace-expansion';
 import * as pathlib from 'path';
 
 import type {Entry} from 'fast-glob';
@@ -91,7 +91,8 @@ export async function glob(
     // can reliably interpret the syntax of the pattern. For example, for
     // re-rooting we need to check for a leading `/`, but we can't do that
     // directly on `{/foo,/bar}`.
-    for (const expanded of braces(pattern, {expand: true})) {
+    const allExpanded = pattern === '' ? [''] : braces(pattern);
+    for (const expanded of allExpanded) {
       expandedPatterns.push(expanded);
       if (opts.expandDirectories) {
         // Also include a recursive-children version of every pattern, in case


### PR DESCRIPTION
I'm helping out with some ecosystem cleanup and this dependency came up as a possible contender. Reference: https://github.com/43081j/ecosystem-cleanup/issues/17. I don't have a strong opinion here, but happy to discuss. 

https://npmgraph.js.org/?q=braces
https://npmgraph.js.org/?q=brace-expansion

