### PR TITLE
Quick fix for failing windows runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,7 +617,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial release.
 
-[unreleased]: https://github.com/google/wireit/compare/v0.14.6...HEAD
+[unreleased]: https://github.com/google/wireit/compare/v0.14.7...HEAD
+[0.14.7]: https://github.com/google/wireit/compare/v0.14.6...v0.14.7
 [0.14.6]: https://github.com/google/wireit/compare/v0.14.5...v0.14.6
 [0.14.5]: https://github.com/google/wireit/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/google/wireit/compare/v0.14.3...v0.14.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## [0.14.7] - 2024-08-05
+
+- When GitHub caching fails to initialize, more information is now shown about
+  the error, and it is no longer fatal.
 
 ## [0.14.6] - 2024-08-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wireit",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wireit",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "license": "Apache-2.0",
       "workspaces": [
         "vscode-extension",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wireit",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Upgrade your npm scripts to make them smarter and more efficient",
   "author": "Google LLC",
   "license": "Apache-2.0",

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -15,6 +15,7 @@ import '../util/dispose.js';
 import {fileBudget} from '../util/fs.js';
 import {execFile} from 'child_process';
 import '../util/dispose.js';
+import {inspect} from 'util';
 
 import type * as http from 'http';
 import type {Cache, CacheHit} from './cache.js';
@@ -105,7 +106,7 @@ export class GitHubActionsCache implements Cache {
           reason: 'unknown-error-thrown',
           error: new Error(
             `Error communicating with cache token mediator service: ` +
-              String(error),
+              inspect(error),
           ),
         },
       };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,18 +31,18 @@ const run = async (options: Options): Promise<Result<void, Failure[]>> => {
         './caching/github-actions-cache.js'
       );
       const cacheResult = await GitHubActionsCache.create(logger);
-      if (!cacheResult.ok) {
-        return {
-          ok: false,
-          error: [
-            {
-              script: options.script,
-              ...cacheResult.error,
-            },
-          ],
-        };
+      if (cacheResult.ok) {
+        cache = cacheResult.value;
+      } else {
+        cache = undefined;
+        console.warn(
+          '⚠️ Error initializing GitHub cache. Caching is disabled for this run',
+        );
+        logger.log({
+          script: options.script,
+          ...cacheResult.error,
+        });
       }
-      cache = cacheResult.value;
       break;
     }
     case 'none': {

--- a/src/test/errors-usage.test.ts
+++ b/src/test/errors-usage.test.ts
@@ -180,13 +180,16 @@ test(
 test(
   'github caching without ACTIONS_CACHE_URL',
   rigTest(async ({rig}) => {
+    const cmd = await rig.newCommand();
     await rig.write({
       'package.json': {
         scripts: {
           main: 'wireit',
         },
         wireit: {
-          main: {command: (await rig.newCommand()).command},
+          main: {
+            command: cmd.command,
+          },
         },
       },
     });
@@ -197,8 +200,9 @@ test(
         ACTIONS_RUNTIME_TOKEN: 'token',
       },
     });
+    (await cmd.nextInvocation()).exit(0);
     const done = await result.exit;
-    assert.equal(done.code, 1);
+    assert.equal(done.code, 0);
     assert.match(
       done.stderr,
       `
@@ -210,13 +214,16 @@ test(
 test(
   'github caching but ACTIONS_CACHE_URL does not end in slash',
   rigTest(async ({rig}) => {
+    const cmd = await rig.newCommand();
     await rig.write({
       'package.json': {
         scripts: {
           main: 'wireit',
         },
         wireit: {
-          main: {command: (await rig.newCommand()).command},
+          main: {
+            command: cmd.command,
+          },
         },
       },
     });
@@ -227,8 +234,9 @@ test(
         ACTIONS_RUNTIME_TOKEN: 'token',
       },
     });
+    (await cmd.nextInvocation()).exit(0);
     const done = await result.exit;
-    assert.equal(done.code, 1);
+    assert.equal(done.code, 0);
     assert.match(
       done.stderr,
       `
@@ -240,13 +248,16 @@ test(
 test(
   'github caching without ACTIONS_RUNTIME_TOKEN',
   rigTest(async ({rig}) => {
+    const cmd = await rig.newCommand();
     await rig.write({
       'package.json': {
         scripts: {
           main: 'wireit',
         },
         wireit: {
-          main: {command: (await rig.newCommand()).command},
+          main: {
+            command: cmd.command,
+          },
         },
       },
     });
@@ -257,8 +268,9 @@ test(
         ACTIONS_RUNTIME_TOKEN: undefined,
       },
     });
+    (await cmd.nextInvocation()).exit(0);
     const done = await result.exit;
-    assert.equal(done.code, 1);
+    assert.equal(done.code, 0);
     assert.match(
       done.stderr,
       `


### PR DESCRIPTION
The new GitHub caching setup system (see https://github.com/google/wireit/pull/1146) is not working on Windows. The Wireit processes are unable to fetch from the local custodian server. 

I'm not sure why yet, but in the meantime this release will make it non-fatal when GitHub caching fails to set up.

Also shows more info when a fetch error occurs, and fixes an issue with environment variable inheritance in our integration tests.