### PR TITLE
Fix GitHub Caching action for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.1] - 2024-08-12
+
+### Fixed
+
+- Fixes Windows support by allowing the "custodian" HTTP server to persist after
+  the setup action has completed.
+
+## [2.0.0] - 2024-08-02
+
+### Changed
+
+- Security improvement. The `GITHUB_ACTIONS_TOKEN` environment variable is no
+  longer exported. A "custodian" HTTP server is used instead.
+
+- Updated Node version from `16` to `20`.
+
+## [1.0.1] - 2022-04-26
+
+### Fixed
+
+- Fixed invalid escaping in action YAML file.
+
+## [1.0.0] - 2022-04-18
+
+### Added
+
+- Initial support for Wireit caching on GitHub Actions.
+
+[unreleased]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.1...setup-github-actions-caching
+[2.0.1]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.0...setup-github-actions-caching/v2.0.1
+[2.0.0]: https://github.com/google/wireit/compare/setup-github-actions-caching/v1.0.1...setup-github-actions-caching/v2.0.0
+[1.0.1]: https://github.com/google/wireit/compare/setup-github-actions-caching/v1.0.0...setup-github-actions-caching/v1.0.1
+[1.0.0]: https://github.com/google/wireit/releases/tag/setup-github-actions-caching/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixes Windows support by allowing the "custodian" HTTP server to persist after
   the setup action has completed.
 
+### Changed
+
+- Custodian server now listens only on localhost instead of all hosts (should
+  have no effect).
+
 ## [2.0.0] - 2024-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## google/wireit@setup-github-actions-caching/v2
 
-This branch contains a GitHub action that users can use to automatically enable
-Wireit's GitHub Actions caching mode and expose the required environment
-variables.
+This branch contains a GitHub action that enables and configures Wireit's GitHub
+Actions caching mode.
 
 ```yaml
 - uses: google/wireit@setup-github-actions-caching/v2

--- a/custodian.js
+++ b/custodian.js
@@ -39,7 +39,7 @@ for (let i = 0; port === undefined && i < MAX_TRIES; i++) {
     const candidate = randIntInclusive(49152, 65535);
     console.log(`[custodian] Trying port ${candidate}`);
     server.once("error", resolve);
-    server.listen(candidate, () => {
+    server.listen(candidate, 'localhost', () => {
       port = candidate;
       resolve();
     });

--- a/custodian.js
+++ b/custodian.js
@@ -47,7 +47,6 @@ for (let i = 0; port === undefined && i < MAX_TRIES; i++) {
 }
 
 if (port) {
-  console.log(`[custodian] Listening on port ${port}`);
   // Writing to this file sets environment variables for all subsequent steps in
   // the user's workflow. Reference:
   // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
@@ -58,9 +57,7 @@ WIREIT_CACHE=github
 WIREIT_CACHE_GITHUB_CUSTODIAN_PORT=${port}
 `
   );
-  process.send(0);
+  console.log(`[custodian] Listening on port ${port}`);
 } else {
   console.error("[custodian] Could not find a free port");
-  process.send(1, () => process.exit(1));
 }
-

--- a/main.js
+++ b/main.js
@@ -4,16 +4,84 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fork } from "node:child_process";
+import { spawn } from "node:child_process";
+import { mkdtempSync, openSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 console.log("[main] Launching background custodian service");
-const server = fork(join(import.meta.dirname, "custodian.js"), {
-  detached: true,
-  stdio: "inherit",
-});
 
-server.on("message", (status) => {
-  console.log("[main] Received status from custodian service", status);
-  process.exit(status);
-});
+const scriptPath = join(import.meta.dirname, "custodian.js");
+const logDir = mkdtempSync(join(tmpdir(), "wireit_custodian_logs_"));
+console.log("[main] Writing logs to", logDir);
+const outPath = join(logDir, "stdout.log");
+const errPath = join(logDir, "stderr.log");
+
+let child;
+if (process.platform === "win32") {
+  child = spawn(
+    // Use `start` so that the server is not killed when our parent shell exits.
+    // https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start
+    //
+    // Under Windows, `{detached: true}` is not sufficient for keeping the
+    // server alive after the parent shell exits. The parent shell will exit
+    // soon as this main script is done, because this action is invoked through
+    // a GitHub Actions `uses:` clause (as opposed to `run:` where we would be
+    // sharing our parent shell with subsequent steps).
+    "start",
+    [
+      // Don't create a new Command Prompt window.
+      "/b",
+      // Spawn a shell so that we can do I/O redirection.
+      "cmd",
+      "/c",
+      // Note `^` is the escape sequence for cmd.exe.
+      `node "${scriptPath}" ^> "${outPath}" 2^> "${errPath}"`,
+    ],
+    {
+      // We need an outer shell too, because `start` is a cmd.exe builtin, not
+      // an executable.
+      shell: true,
+      detached: true,
+      stdio: "ignore",
+    }
+  );
+} else {
+  // Under Linux and macOS, `{detached: true}` is sufficient for keeping the
+  // server alive after the parent shell exits.
+  child = spawn("node", [scriptPath], {
+    detached: true,
+    stdio: ["ignore", openSync(outPath, "w"), openSync(errPath, "w")],
+  });
+}
+
+await new Promise((resolve) => child.once("spawn", resolve));
+child.unref();
+
+// Poll the server logs until it's ready. We could do something fancier with
+// some kind of IPC, but this is much simpler (especially with Windows in the
+// mix), plus it's nice to just dump all of the stdout/stderr in case something
+// unexpected happens.
+const timeoutSecs = 30;
+const pollMillis = 100;
+const start = Date.now();
+let stdout, stderr;
+while (true) {
+  await new Promise((resolve) => setTimeout(resolve, pollMillis));
+  stdout = readFileSync(outPath, "utf8");
+  stderr = readFileSync(errPath, "utf8");
+  if (stdout.match(/Listening on port/) !== null) {
+    console.error(stderr);
+    console.log(stdout);
+    console.log(`[main] Custodian server ready`);
+    process.exit(0);
+  }
+  if (Date.now() - start > timeoutSecs * 1000) {
+    console.error(stderr);
+    console.log(stdout);
+    console.log(
+      `[main] Timed out waiting for custodian server to be ready (${timeoutSecs} seconds)`
+    );
+    process.exit(1);
+  }
+}

--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ child.unref();
 // unexpected happens.
 const timeoutSecs = 30;
 const pollMillis = 100;
-const start = Date.now();
+const timedOutTime = Date.now() + timeoutSecs * 1000;
 let stdout, stderr;
 while (true) {
   await new Promise((resolve) => setTimeout(resolve, pollMillis));
@@ -76,7 +76,7 @@ while (true) {
     console.log(`[main] Custodian server ready`);
     process.exit(0);
   }
-  if (Date.now() - start > timeoutSecs * 1000) {
+  if (Date.now() > timedOutTime) {
     console.error(stderr);
     console.log(stdout);
     console.log(

--- a/main.js
+++ b/main.js
@@ -25,8 +25,8 @@ if (process.platform === "win32") {
     //
     // Under Windows, `{detached: true}` is not sufficient for keeping the
     // server alive after the parent shell exits. The parent shell will exit
-    // soon as this main script is done, because this action is invoked through
-    // a GitHub Actions `uses:` clause (as opposed to `run:` where we would be
+    // after this main script is done, because this action is invoked through a
+    // GitHub Actions `uses:` clause (as opposed to `run:` where we would be
     // sharing our parent shell with subsequent steps).
     "start",
     [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "type": "module"
 }


### PR DESCRIPTION
Fixes Windows support for GitHub Actions Caching, which has been broken since the security improvement in https://github.com/google/wireit/pull/1146. (This only affected users who had upgraded to `v2` of the action, and the failure was not fatal, it just disabled caching).

The problem was that under Windows, `{detached: true}` is not sufficient for keeping the server alive after the parent shell exits. The parent shell will exit as soon as the main launching script is done, because the action is invoked through a GitHub Actions `uses:` clause (as opposed to `run:` where we would be sharing our parent shell with subsequent steps).

We now use `start` so that the server is not killed when our parent shell exits: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start.

Also listens only on `localhost` instead of all hosts (shouldn't matter because we should have strong network isolation for free through the GitHub Actions container, but seems wise, and good in case this code runs in some other context for some reason).

Also adds a `CHANGELOG.md` file.