### PR TITLE
Support node --run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,26 +6,33 @@ jobs:
   tests:
     strategy:
       # We support Node Current, LTS, and Maintenance. See
-      # https://nodejs.org/en/about/releases/ for release schedule.
+      # https://github.com/nodejs/release#release-schedule for release schedule
       #
       # We test all supported Node versions on Linux, and the oldest and newest
-      # on macOS/Windows.
+      # on macOS/Windows. See
+      # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+      # for the latest available images.
       matrix:
         include:
+          # Maintenance
           - node: 18
             os: ubuntu-22.04
           - node: 18
             os: macos-13
           - node: 18
             os: windows-2022
+
+          # LTS
           - node: 20
             os: ubuntu-22.04
-          - node: 20
+
+          # Current
+          - node: 22
+            os: ubuntu-22.04
+          - node: 22
             os: macos-13
-          - node: 20
+          - node: 22
             os: windows-2022
-          - node: 21
-            os: ubuntu-22.04
 
       # Allow all matrix configurations to complete, instead of cancelling as
       # soon as one fails. Useful because we often have different kinds of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added support for `node --run`, available in Node 22 and above (see
+  https://nodejs.org/en/blog/announcements/v22-release-announce#running-packagejson-scripts).
+
 ## [0.14.7] - 2024-08-05
 
 - When GitHub caching fails to initialize, more information is now shown about

--- a/README.md
+++ b/README.md
@@ -104,9 +104,7 @@ and replace the original script with the `wireit` command.
 </table>
 
 Now when you run `npm run build`, Wireit upgrades the script to be smarter and
-more efficient. Wireit works with [yarn](https://yarnpkg.com/)
-(both 1.X "[Classic](https://classic.yarnpkg.com/)" and its successor "Berry")
-and [pnpm](https://pnpm.io/), too.
+more efficient. Wireit also works with [`node --run`](https://nodejs.org/en/blog/announcements/v22-release-announce#running-packagejson-scripts), [yarn](https://yarnpkg.com/), and [pnpm](https://pnpm.io/).
 
 You should also add `.wireit` to your `.gitignore` file. Wireit uses the
 `.wireit` directory to store caches and other data for your scripts.
@@ -236,6 +234,13 @@ npm or Wireit:
 
 ```sh
 npm run build -- --verbose
+```
+
+An additional `--` is required when using `node --run` in order to distinguish
+between arguments intended for `node`, `wireit`, and the script itself:
+
+```sh
+node --run build -- -- --verbose
 ```
 
 ## Input and output files
@@ -420,7 +425,15 @@ flag:
 npm run <script> --watch
 ```
 
-The benefit of Wireit's watch mode over built-in watch modes are:
+An additional `--` is required when using `node --run`, otherwise Node's
+built-in [watch](https://nodejs.org/docs/v20.17.0/api/cli.html#--watch) feature
+will be triggered instead of Wireit's:
+
+```sh
+node --run <script> -- --watch
+```
+
+The benefit of Wireit's watch mode over the built-in watch modes of Node and other programs are:
 
 - Wireit watches the entire dependency graph, so a single watch command replaces
   many built-in ones.
@@ -719,7 +732,7 @@ WIREIT_FAILURES=kill
 By default, Wireit automatically treats package manager lock files as input
 files
 ([`package-lock.json`](https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json)
-for npm,
+for npm and `node --run`,
 [`yarn.lock`](https://yarnpkg.com/configuration/yarnrc#lockfileFilename) for
 yarn, and [`pnpm-lock.yaml`](https://pnpm.io/git#lockfiles) for pnpm). Wireit
 will look for these lock files in the script's package, and all parent
@@ -921,13 +934,11 @@ input also affects the fingerprint:
 
 Wireit is supported on Linux, macOS, and Windows.
 
-Wireit is supported on Node Current (21), Active LTS (20), and Maintenance LTS
+Wireit is supported on Node Current (22), Active LTS (20), and Maintenance LTS
 (18). See [Node releases](https://nodejs.org/en/about/releases/) for the
 schedule.
 
-Wireit is supported on the npm versions that ship with the latest versions of
-the above supported Node versions (6 and 8), Yarn Classic (1), Yarn Berry (3),
-and pnpm (7).
+Wireit scripts can be launched via `npm`, `node --run`, `pnpm`, and `yarn`.
 
 ## Related tools
 

--- a/README.md
+++ b/README.md
@@ -236,11 +236,17 @@ npm or Wireit:
 npm run build -- --verbose
 ```
 
+Or in general:
+
+```sh
+npm run {script} {npm args} {wireit args} -- {script args}
+```
+
 An additional `--` is required when using `node --run` in order to distinguish
 between arguments intended for `node`, `wireit`, and the script itself:
 
 ```sh
-node --run build -- -- --verbose
+node --run {script} {node args} -- {wireit args} -- {script args}
 ```
 
 ## Input and output files

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -5,31 +5,31 @@
  */
 
 import * as pathlib from 'path';
+import {Dependency, scriptReferenceToString, ServiceConfig} from './config.js';
+import {findNodeAtLocation, JsonFile} from './util/ast.js';
 import * as fs from './util/fs.js';
 import {
   CachingPackageJsonReader,
   FileSystem,
 } from './util/package-json-reader.js';
-import {Dependency, scriptReferenceToString, ServiceConfig} from './config.js';
-import {findNodeAtLocation, JsonFile} from './util/ast.js';
 import {IS_WINDOWS} from './util/windows.js';
 
+import type {Agent} from './cli-options.js';
+import type {
+  ScriptConfig,
+  ScriptReference,
+  ScriptReferenceString,
+} from './config.js';
+import type {Diagnostic, MessageLocation, Result} from './error.js';
+import type {Cycle, DependencyOnMissingPackageJson, Failure} from './event.js';
+import {Logger} from './logging/logger.js';
 import type {
   ArrayNode,
   JsonAstNode,
   NamedAstNode,
   ValueTypes,
 } from './util/ast.js';
-import type {Diagnostic, MessageLocation, Result} from './error.js';
-import type {Cycle, DependencyOnMissingPackageJson, Failure} from './event.js';
 import type {PackageJson, ScriptSyntaxInfo} from './util/package-json.js';
-import type {
-  ScriptConfig,
-  ScriptReference,
-  ScriptReferenceString,
-} from './config.js';
-import type {Agent} from './cli-options.js';
-import {Logger} from './logging/logger.js';
 
 export interface AnalyzeResult {
   config: Result<ScriptConfig, Failure[]>;
@@ -118,6 +118,7 @@ const DEFAULT_EXCLUDE_PATHS = [
 
 const DEFAULT_LOCKFILES: Record<Agent, string[]> = {
   npm: ['package-lock.json'],
+  nodeRun: ['package-lock.json'],
   yarnClassic: ['yarn.lock'],
   yarnBerry: ['yarn.lock'],
   pnpm: ['pnpm-lock.yaml'],

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -17,9 +17,10 @@ import * as fs from './util/fs.js';
 import {unreachable} from './util/unreachable.js';
 
 export const packageDir = await (async (): Promise<string | undefined> => {
-  // Recent versions of npm set this environment variable that tells us the
-  // package.
-  const packageJsonPath = process.env.npm_package_json;
+  // Recent versions of npm, and node --run, set environment variables to tell
+  // us the current package.json.
+  const packageJsonPath =
+    process.env.npm_package_json ?? process.env.NODE_RUN_PACKAGE_JSON_PATH;
   if (packageJsonPath) {
     return pathlib.dirname(packageJsonPath);
   }

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -5,16 +5,16 @@
  */
 
 import * as os from 'os';
-import * as fs from './util/fs.js';
 import * as pathlib from 'path';
-import {Result} from './error.js';
-import {MetricsLogger} from './logging/metrics-logger.js';
 import {ScriptReference} from './config.js';
+import {Result} from './error.js';
 import {FailureMode} from './executor.js';
-import {unreachable} from './util/unreachable.js';
-import {Console, Logger} from './logging/logger.js';
-import {QuietCiLogger, QuietLogger} from './logging/quiet-logger.js';
 import {DefaultLogger} from './logging/default-logger.js';
+import {Console, Logger} from './logging/logger.js';
+import {MetricsLogger} from './logging/metrics-logger.js';
+import {QuietCiLogger, QuietLogger} from './logging/quiet-logger.js';
+import * as fs from './util/fs.js';
+import {unreachable} from './util/unreachable.js';
 
 export const packageDir = await (async (): Promise<string | undefined> => {
   // Recent versions of npm set this environment variable that tells us the
@@ -45,7 +45,7 @@ export const packageDir = await (async (): Promise<string | undefined> => {
   }
 })();
 
-export type Agent = 'npm' | 'pnpm' | 'yarnClassic' | 'yarnBerry';
+export type Agent = 'npm' | 'nodeRun' | 'pnpm' | 'yarnClassic' | 'yarnBerry';
 
 export interface Options {
   script: ScriptReference;
@@ -61,7 +61,8 @@ export interface Options {
 export const getOptions = async (): Promise<Result<Options>> => {
   // This environment variable is set by npm, yarn, and pnpm, and tells us which
   // script is running.
-  const scriptName = process.env.npm_lifecycle_event;
+  const scriptName =
+    process.env.npm_lifecycle_event ?? process.env['NODE_RUN_SCRIPT_NAME'];
   // We need to handle "npx wireit" as a special case, because it sets
   // "npm_lifecycle_event" to "npx". The "npm_execpath" will be "npx-cli.js",
   // though, so we use that combination to detect this special case.
@@ -279,6 +280,9 @@ function getArgvOptions(
         extraArgs: process.argv.slice(2),
       };
     }
+    case 'nodeRun': {
+      return parseRemainingArgs(process.argv.slice(2));
+    }
     case 'yarnClassic': {
       // yarn 1.22.18
       //   - If there is no "--", all arguments go to argv.
@@ -313,6 +317,9 @@ function getArgvOptions(
  * Try to find the npm user agent being used. If we can't detect it, assume npm.
  */
 function getNpmUserAgent(): Agent {
+  if (process.env['NODE_RUN_SCRIPT_NAME'] !== undefined) {
+    return 'nodeRun';
+  }
   const userAgent = process.env['npm_config_user_agent'];
   if (userAgent !== undefined) {
     const match = userAgent.match(/^(npm|yarn|pnpm)\//);
@@ -320,7 +327,6 @@ function getNpmUserAgent(): Agent {
       if (match[1] === 'yarn') {
         return /^yarn\/[01]\./.test(userAgent) ? 'yarnClassic' : 'yarnBerry';
       }
-
       return match[1] as 'npm' | 'pnpm';
     }
   }


### PR DESCRIPTION
Adds support for the new `node --run` feature which is available starting in Node 22 (basically `npm run` but faster, see https://nodejs.org/en/blog/announcements/v22-release-announce#running-packagejson-scripts and https://www.yagiz.co/developing-fast-builtin-task-runner/).

Note that `node --run` is stricter than the other runners when it comes to distinguishing between arguments for the runner vs the script, so an additional `--` is needed to set wireit flags and script flags (explained in the README).

Thank you very much to @anonrig for adding the environment variables this required (https://github.com/nodejs/node/pull/53032, https://github.com/nodejs/node/pull/53058) and @justinfagnani for filing the issue (https://github.com/nodejs/node/issues/52673)!

There is a problem with recursive invocations on Windows that I believe is a Node bug but need to double-check, tracking at https://github.com/google/wireit/issues/1168.

Fixes https://github.com/google/wireit/issues/1094

Reviewer: the "Refactor tests a bit" commit is pretty noisy, but you can take my word it's a no-op :)