### PR TITLE
fix: provide a prefix to GitHub Action cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Added `"wireit-"` prefix to GitHub Actions cache keys so that they can be identified more easily.
 
 ## [0.14.10] - 2025-01-28
 

--- a/src/caching/github-actions-cache.ts
+++ b/src/caching/github-actions-cache.ts
@@ -485,9 +485,9 @@ export class GitHubActionsCache implements Cache {
   }
 
   #computeCacheKey(script: ScriptReference): string {
-    return createHash('sha256')
+    return `wireit-${createHash('sha256')
       .update(scriptReferenceToString(script))
-      .digest('hex');
+      .digest('hex')}`;
   }
 
   #computeVersion(fingerprint: Fingerprint): string {


### PR DESCRIPTION
Hey I was having some issue with GitHub actions, one thing I wanted to eliminate for the cause is the WireIt cache.
Problem is there is no way to filter out caches besides the Cache id. This means that I needed to nuke all the caches if you want to remove it, which is sub-optimal as if you are fixing an issue you want to do it 1 step at a time.

_Send through github.dev so couldn't run tests_