### PR TITLE
New dependency parser and introduce `#` delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- It is now supported _and preferred_ to use `#` as the delimiter between
+  packages and scripts in dependency specifiers, instead of `:`. For example,
+  instead of `"../other:build"`, it is now preferred to write
+  `"../other#build"`.
+
+  The `:` character will continue to work the same indefinitely, but the Wireit
+  documentation will exclusively show `#`, and upcoming new features for
+  dependency specifiers will only work with the newer `#` form.
+
+- **[BREAKING]** Certain special characters must now be escaped with a `\`
+  (which in JSON is written as `\\`) if they are to be intepreted literally in a
+  package specifier:
+
+  - `#`
+  - `\`
+  - `<`
+  - `>`
+  - `.` (only required at the start of the specifier)
+  - `!` (only required at the start of the specifier)
+  - `:` (only required when using the legacy delimiter, meaning a `#` does not
+    appear later in the specifier)
+
+  For example, in the (highly unusual) situation that you depend on a script
+  like `"../ha#shy:sl\\ashy"`, you should now write `"../ha\\#shy#sl\\\\ashy"`
+  (note that `\` escapes are _also_ required for JSON, hence the double
+  escapes).
 
 ## [0.14.11] - 2025-02-07
 

--- a/README.md
+++ b/README.md
@@ -171,9 +171,14 @@ other wireit scripts, and can never be run directly.
 ### Cross-package dependencies
 
 Dependencies can refer to scripts in other npm packages by using a relative path
-with the syntax `<relative-path>:<script-name>`. All cross-package dependencies
+with the syntax `<relative-path>#<script-name>`. All cross-package dependencies
 should start with a `"."`. Cross-package dependencies work well for npm
 workspaces, as well as in other kinds of monorepos.
+
+> [!NOTE]
+> The `:` character can also be used as a delimiter instead of `#` (e.g.
+> `"../other-package:build`), but `#` is preferred since February 2025 because
+> it is less ambiguous given the prevalence of `:` in npm script names.
 
 ```json
 {
@@ -183,7 +188,7 @@ workspaces, as well as in other kinds of monorepos.
   "wireit": {
     "build": {
       "command": "tsc",
-      "dependencies": ["../other-package:build"]
+      "dependencies": ["../other-package#build"]
     }
   }
 }
@@ -534,7 +539,7 @@ expected to exit by itself, set `"service": true`.
       "dependencies": [
         "build:server",
         {
-          "script": "../assets:build",
+          "script": "../assets#build",
           "cascade": false
         }
       ]
@@ -691,7 +696,7 @@ There are two main reasons you might want to set `cascade` to `false`:
          "dependencies": [
            "build:server",
            {
-             "script": "../assets:build",
+             "script": "../assets#build",
              "cascade": false
            }
          ],
@@ -853,7 +858,7 @@ The following properties can be set inside `wireit.<script>` objects in
 | ------------------------- | ---------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `command`                 | `string`                           | `undefined`             | The shell command to run.                                                                                                       |
 | `dependencies`            | `string[] \| object[]`             | `[]`                    | [Scripts that must run before this one](#dependencies).                                                                         |
-| `dependencies[i].script`  | `string`                           | `undefined`             | [The name of the script, when the dependency is an object.](#dependencies).                                                     |
+| `dependencies[i].script`  | `string`                           | `undefined`             | [The name of the script, when the dependency is an object](#dependencies).                                                      |
 | `dependencies[i].cascade` | `boolean`                          | `true`                  | [Whether this dependency always causes this script to re-execute](#execution-cascade).                                          |
 | `files`                   | `string[]`                         | `undefined`             | Input file [glob patterns](#glob-patterns), used to determine the [fingerprint](#fingerprint).                                  |
 | `output`                  | `string[]`                         | `undefined`             | Output file [glob patterns](#glob-patterns), used for [caching](#caching) and [cleaning](#cleaning-output).                     |

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:codeactions": "wireit",
     "test:copy": "wireit",
     "test:delete": "wireit",
+    "test:dependency-parser": "wireit",
     "test:diagnostic": "wireit",
     "test:errors-analysis": "wireit",
     "test:errors-usage": "wireit",
@@ -93,6 +94,7 @@
         "test:codeactions",
         "test:copy",
         "test:delete",
+        "test:dependency-parser",
         "test:diagnostic",
         "test:errors-analysis",
         "test:errors-usage",
@@ -214,6 +216,17 @@
     },
     "test:delete": {
       "command": "uvu lib/test \"^delete\\.test\\.js$\"",
+      "env": {
+        "NODE_OPTIONS": "--enable-source-maps"
+      },
+      "dependencies": [
+        "build"
+      ],
+      "files": [],
+      "output": []
+    },
+    "test:dependency-parser": {
+      "command": "uvu lib/test \"^dependency-parser\\.test\\.js$\"",
       "env": {
         "NODE_OPTIONS": "--enable-source-maps"
       },

--- a/src/analysis/dependency-parser.ts
+++ b/src/analysis/dependency-parser.ts
@@ -9,8 +9,9 @@ import type {DiagnosticWithoutFile, Range, Result} from '../error.js';
 /**
  * Parse a Wireit dependency specifier.
  *
- * A Wireit dependency string is what appears in a `"wireit.<script>.dependencies"` array in a
- * `package.json` file, which controls which script must run before the current one.
+ * A Wireit dependency specifier is what appears in a
+ * `"wireit.<script>.dependencies"` array in a `package.json` file, which
+ * controls which script must run before the current one.
  *
  *
  * ### QUICK EXAMPLES
@@ -54,8 +55,9 @@ import type {DiagnosticWithoutFile, Range, Result} from '../error.js';
  *
  * ### INVERSION
  *
- * A dependency specifier can be inverted by prefixing it with a `!`. This means that any matching
- * scripts will be excluded from the preceding (but not following) matching scripts.
+ * A dependency specifier can be inverted by prefixing it with a `!`. This means
+ * that any matching scripts will be excluded from the preceding (but not
+ * following) matching scripts.
  *
  * |                           |                                                                   |
  * |---------------------------|-------------------------------------------------------------------|
@@ -65,7 +67,8 @@ import type {DiagnosticWithoutFile, Range, Result} from '../error.js';
  *
  * ### ESCAPING
  *
- * The following characters have special meaning, and must be escaped with `\` if meant literally:
+ * The following characters have special meaning, and must be escaped with `\`
+ * if meant literally:
  *
  * |                           |                                                                   |
  * |---------------------------|-------------------------------------------------------------------|
@@ -153,7 +156,7 @@ type Segment = StringSegment | SpecialSegment;
 type StringSegment = {
   kind: 'string';
   string: string;
-  // Note this can be range can be longe than the length of `string`, since it
+  // Note this can be range can be longer than the length of `string`, since it
   // includes escapes.
   range: Range;
 };
@@ -486,10 +489,10 @@ class DependencyParser {
   #lookAheadForUnescapedHash(): boolean {
     for (let i = this.#pos + 1; i < this.#str.length; i++) {
       const char = this.#str[i];
-      if (char === BACKSLASH) {
-        i += 2;
-      } else if (char === HASH) {
+      if (char === HASH) {
         return true;
+      } else if (char === BACKSLASH) {
+        i++; // Skip an additional character (since it's escaped).
       }
     }
     return false;

--- a/src/analysis/dependency-parser.ts
+++ b/src/analysis/dependency-parser.ts
@@ -1,0 +1,497 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {DiagnosticWithoutFile, Range, Result} from '../error.js';
+
+/**
+ * Parse a Wireit dependency specifier.
+ *
+ * A Wireit dependency string is what appears in a `"wireit.<script>.dependencies"` array in a
+ * `package.json` file, which controls which script must run before the current one.
+ *
+ *
+ * ### QUICK EXAMPLES
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `build`                   | The script named `build` in the current package.                  |
+ * | `../foo#build`            | The script named `build` in the package located at `../foo`.      |
+ * | `my-npm-package#build`    | The script named `build` in the package named `my-npm-package`.   |
+ * | `<workspaces>#build`      | The script named `build` in all workspaces of the current package.|
+ * | `<dependencies>#<this>`   | The script named the same as the current script in all npm dependencies sharing a common workspace root. |
+ *
+ *
+ * ### GENERAL FORMS
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `script`                  | Script only. Package is implicitly the current one.               |
+ * | `package#script`          | Package and script with preferred `#` delimiter.                  |
+ * | `./path:script`           | Package and script with limited legacy `:` delimiter.             |
+ *
+ *
+ * ### PACKAGE SPECIFIERS
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `./path/to/pkg`           | A package path (identified by the leading `.`)                    |
+ * | `some-npm-package`        | An npm package.                                                   |
+ * | `<this>`                  | The current package.                                              |
+ * | `<workspaces>`            | All workspaces of the current package.                            |
+ * | `<dependencies>`          | All dependencies of the current package sharing a common workspace root. |
+ *
+ *
+ * ### SCRIPT SPECIFIERS
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `build`                   | A script name.                                                    |
+ * | `<this>`                  | The current script.                                               |
+ *
+ *
+ * ### INVERSION
+ *
+ * A dependency specifier can be inverted by prefixing it with a `!`. This means that any matching
+ * scripts will be excluded from the preceding (but not following) matching scripts.
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `<dependencies>:build`    | All dependency "build" scripts ...                                |
+ * | `../broken:build`         | ... except for the specific one in the "broken" folder.           |
+ *
+ *
+ * ### ESCAPING
+ *
+ * The following characters have special meaning, and must be escaped with `\` if meant literally:
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `\`                       | Escape character.                                                 |
+ * | `#`                       | Delimiter between package and script.                             |
+ * | `<`                       | Start of a _special_ like `<workspaces>`.                         |
+ * | `>`                       | End of a special.                                                 |
+ *
+ * The following characters have special meaning only at the beginning of the
+ * dependency string, and must be escaped with `\` if meant literally:
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `!`                       | Inverts the dependency.                                           |
+ * | `.`                       | A package path.                                                   |
+ *
+ * The following character has special meaning only in the legacy form
+ * `./path/to/pkg:script`, and must be escaped with `\` if meant literally:
+ *
+ * |                           |                                                                   |
+ * |---------------------------|-------------------------------------------------------------------|
+ * | `:`                       | Old delimiter between package and script.                         |
+ */
+
+export function parseDependency(
+  dependency: string,
+): Result<ParsedDependency, DiagnosticWithoutFile> {
+  const result = new DependencyParser(dependency).parse();
+  return result;
+}
+
+/**
+ * A parsed wireit dependency string. See {@link parseDependency}.
+ */
+export interface ParsedDependency {
+  package: ParsedPackageWithRange;
+  script: ParsedScriptWithRange;
+  inverted: boolean;
+}
+
+export type ParsedPackageWithRange = ParsedPackage & {range: Range};
+export type ParsedPackage =
+  | PackagePath
+  | PackageNpm
+  | PackageThis
+  | PackageWorkspaces
+  | PackageDependencies;
+
+export type ParsedScriptWithRange = ParsedScript & {range: Range};
+export type ParsedScript = ScriptName | ScriptThis;
+
+export interface PackagePath {
+  kind: 'path';
+  path: string;
+}
+
+export interface PackageNpm {
+  kind: 'npm';
+  package: string;
+}
+
+export interface PackageThis {
+  kind: 'this';
+}
+
+export interface PackageWorkspaces {
+  kind: 'workspaces';
+}
+
+export interface PackageDependencies {
+  kind: 'dependencies';
+}
+
+export interface ScriptName {
+  kind: 'name';
+  name: string;
+}
+
+export interface ScriptThis {
+  kind: 'this';
+}
+
+type Segment = StringSegment | SpecialSegment;
+
+type StringSegment = {
+  kind: 'string';
+  string: string;
+  // Note this can be range can be longe than the length of `string`, since it
+  // includes escapes.
+  range: Range;
+};
+
+type SpecialSegment = {
+  kind: 'special';
+  special: string;
+  range: Range;
+};
+
+const PERIOD = '.';
+const HASH = '#';
+const BACKSLASH = '\\';
+const EXCLAMATION = '!';
+const COLON = ':';
+const LT = '<';
+const GT = '>';
+
+class DependencyParser {
+  readonly #str: string;
+  readonly #len: number;
+  #pos = 0;
+
+  constructor(str: string) {
+    this.#str = str;
+    this.#len = str.length;
+  }
+
+  #peek(offset = 0): string | undefined {
+    return this.#str[this.#pos + offset];
+  }
+
+  #skip(num = 1): void {
+    this.#pos += num;
+  }
+
+  #done(): boolean {
+    return this.#pos === this.#len;
+  }
+
+  #error(
+    message: string,
+    range: Range,
+  ): {ok: false; error: DiagnosticWithoutFile} {
+    return {
+      ok: false,
+      error: {
+        severity: 'error',
+        message,
+        location: {range: range},
+      },
+    };
+  }
+
+  parse(): Result<ParsedDependency, DiagnosticWithoutFile> {
+    if (this.#done()) {
+      return this.#error('Dependency cannot be empty', {offset: 0, length: 0});
+    }
+
+    // "!" and "." have special meaning only at the beginning of the dependency.
+    let inverted = false;
+    let startsWithPeriod = false;
+    const firstChar = this.#peek();
+    if (firstChar === EXCLAMATION) {
+      inverted = true;
+      this.#skip();
+    } else if (firstChar === PERIOD) {
+      startsWithPeriod = true;
+    } else if (firstChar === BACKSLASH) {
+      const secondChar = this.#peek(1);
+      if (secondChar === EXCLAMATION || secondChar === PERIOD) {
+        this.#skip();
+      }
+      // Otherwise, let the next section handle the escape.
+    }
+
+    // It is convenient in this code to refer to both scripts and packages as
+    // "segments", because they are parsed very similarly, and because the first
+    // one we encounter could turn out to be either a script or a package
+    // depending on whether a delimiter shows up later.
+
+    const firstSegment = this.#parseSegment(startsWithPeriod);
+    if (!firstSegment.ok) {
+      return firstSegment;
+    }
+
+    if (this.#done()) {
+      // There was only one segment.
+      if (startsWithPeriod) {
+        // E.g. "../foo".
+        return this.#error(
+          `Cross-package dependency must use syntax "<relative-path>#<script-name>", ` +
+            `but there's no "#" character in ${JSON.stringify(this.#str)}.`,
+          {
+            offset: 0,
+            length: this.#len,
+          },
+        );
+      }
+      const script = this.#interpretSegmentAsScript(firstSegment.value);
+      if (!script.ok) {
+        return script;
+      }
+      // E.g. "build:tsc"
+      return {
+        ok: true,
+        value: {
+          package: {
+            kind: 'this',
+            range: {offset: 0, length: 0},
+          },
+          script: script.value,
+          inverted,
+        },
+      };
+    }
+
+    const pkg = this.#interpretSegmentAsPackage(firstSegment.value);
+    if (!pkg.ok) {
+      return pkg;
+    }
+
+    this.#skip(); // Skip the delimiter.
+
+    const secondSegment = this.#parseSegment(false);
+    if (!secondSegment.ok) {
+      return secondSegment;
+    }
+    if (!this.#done()) {
+      // E.g. "pkg#script#huh"
+      return this.#error(`Unexpected additional delimiter "${this.#peek()}"`, {
+        offset: this.#pos,
+        length: 1,
+      });
+    }
+
+    const script = this.#interpretSegmentAsScript(secondSegment.value);
+    if (!script.ok) {
+      return script;
+    }
+    return {
+      ok: true,
+      value: {
+        package: pkg.value,
+        script: script.value,
+        inverted,
+      },
+    };
+  }
+
+  /**
+   * Parse a "segment", which can be either a package or a script depending on
+   * its position.
+   */
+  #parseSegment(
+    inPathPosition: boolean,
+  ): Result<Segment, DiagnosticWithoutFile> {
+    if (this.#peek() === LT) {
+      // For now we only support specials when they comprise the entire segment.
+      return this.#parseSpecial();
+    }
+    const start = this.#pos;
+    let string = '';
+    let rawLength = 0;
+    while (!this.#done()) {
+      const cur = this.#peek()!;
+      if (cur === HASH) {
+        break;
+      }
+      if (
+        inPathPosition &&
+        cur === COLON &&
+        !this.#lookAheadForUnescapedHash()
+      ) {
+        // Support the old ":" delimiter (e.g. "./pkg:scr"), but only if we're
+        // not using the new "#" delimiter (e.g. "./pkg:foo#scr"), in which case
+        // treat ":" literally.
+        break;
+      }
+      if (cur === LT) {
+        // Reserve "<" in all positions, even though we only handle specials
+        // when they are the whole segment, because it is conceivable in the
+        // future that we may want to support specials appearing next to static
+        // strings or other specials, plus it seems simpler to understand if we
+        // are consistent with when you need to escape the special characters.
+        return this.#error(
+          String.raw`Unexpected "<". Escape as "\<" if you meant it literally.`,
+          {offset: this.#pos, length: 1},
+        );
+      }
+      if (cur === BACKSLASH) {
+        const next = this.#peek(1);
+        if (next === undefined) {
+          return this.#error('Trailing backslash', {offset: start, length: 1});
+        }
+        string += next;
+        this.#skip(2);
+        rawLength += 2;
+        continue;
+      }
+      string += cur;
+      rawLength += 1;
+      this.#skip();
+    }
+    return {
+      ok: true,
+      value: {
+        kind: 'string',
+        string,
+        range: {
+          offset: start,
+          length: rawLength,
+        },
+      },
+    };
+  }
+
+  #parseSpecial(): Result<SpecialSegment, DiagnosticWithoutFile> {
+    const start = this.#pos;
+    this.#skip(); // Assume LT
+    let special = '';
+    while (!this.#done()) {
+      const cur = this.#peek()!;
+      if (cur === GT) {
+        if (special.length === 0) {
+          return this.#error(
+            String.raw`Unexpected ">". Escape as "\>" if you meant it literally.`,
+            {offset: start, length: 2},
+          );
+        }
+        this.#skip();
+        return {
+          ok: true,
+          value: {
+            kind: 'special',
+            special,
+            range: {
+              offset: start,
+              length: special.length + 2,
+            },
+          },
+        };
+      } else {
+        special += cur;
+        this.#skip();
+      }
+    }
+    return this.#error(`Unexpected end of string in <special>`, {
+      offset: this.#pos,
+      length: 1,
+    });
+  }
+
+  #interpretSegmentAsPackage(
+    segment: Segment,
+  ): Result<ParsedPackageWithRange, DiagnosticWithoutFile> {
+    if (segment.kind === 'string') {
+      if (segment.string[0] === PERIOD) {
+        return {
+          ok: true,
+          value: {
+            kind: 'path',
+            path: segment.string,
+            range: segment.range,
+          },
+        };
+      } else if (segment.string.length !== 0) {
+        return {
+          ok: true,
+          value: {
+            kind: 'npm',
+            package: segment.string,
+            range: segment.range,
+          },
+        };
+      } else {
+        return this.#error('Package specifier cannot be empty', segment.range);
+      }
+    }
+    const special = segment.special;
+    if (
+      special === 'this' ||
+      special === 'workspaces' ||
+      special === 'dependencies'
+    ) {
+      return {
+        ok: true,
+        value: {
+          kind: special,
+          range: segment.range,
+        },
+      };
+    }
+    return this.#error(`Unknown special package "${special}"`, segment.range);
+  }
+
+  #interpretSegmentAsScript(
+    segment: Segment,
+  ): Result<ParsedScriptWithRange, DiagnosticWithoutFile> {
+    if (segment.kind === 'string') {
+      if (segment.string.length === 0) {
+        return this.#error(
+          `Cross-package dependency must use syntax "<relative-path>#<script-name>", ` +
+            `but there's no script name in ${JSON.stringify(this.#str)}.`,
+          {offset: 0, length: this.#len},
+        );
+      }
+      return {
+        ok: true,
+        value: {
+          kind: 'name',
+          name: segment.string,
+          range: segment.range,
+        },
+      };
+    }
+    const special = segment.special;
+    if (special === 'this') {
+      return {
+        ok: true,
+        value: {
+          kind: 'this',
+          range: segment.range,
+        },
+      };
+    }
+    return this.#error(`Unknown special script "${special}"`, segment.range);
+  }
+
+  #lookAheadForUnescapedHash(): boolean {
+    for (let i = this.#pos + 1; i < this.#str.length; i++) {
+      const char = this.#str[i];
+      if (char === BACKSLASH) {
+        i += 2;
+      } else if (char === HASH) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -6,9 +6,9 @@
 
 import * as pathlib from 'path';
 
+import type {ScriptReference} from './config.js';
 import type {Failure, UnknownErrorThrown} from './event.js';
 import type {JsonFile, NamedAstNode} from './util/ast.js';
-import type {ScriptReference} from './config.js';
 
 export type Result<T, E = Failure> =
   | {ok: true; value: T}
@@ -35,6 +35,10 @@ export interface Diagnostic {
   readonly location: Location;
   readonly supplementalLocations?: MessageLocation[];
 }
+
+export type DiagnosticWithoutFile = Omit<Diagnostic, 'location'> & {
+  location: {range: Range};
+};
 
 export class DiagnosticPrinter {
   #cwd: string;

--- a/src/test/dependency-parser.test.ts
+++ b/src/test/dependency-parser.test.ts
@@ -1,0 +1,350 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+import {
+  parseDependency,
+  type ParsedPackage,
+  type ParsedScript,
+} from '../analysis/dependency-parser.js';
+import type {DiagnosticWithoutFile} from '../error.js';
+
+const test = suite<object>();
+
+const cases: Array<
+  [
+    /**
+     * Dependency specifier, e.g. "./pkg#scr".
+     */
+    string,
+
+    /**
+     * A string the same length as the dependency specifier, where each
+     * character represents how we should interpret the corresponding character
+     * from the dependency, with P = package, S = script, E = error, and
+     * anything else is ignored (e.g. "PPPPP_SSS"). This way we can clearly
+     * annotate the expected character ranges for each parsed component.
+     */
+    string,
+    (
+      | {
+          package: ParsedPackage;
+          script: ParsedScript;
+          inverted?: true;
+        }
+      | Omit<DiagnosticWithoutFile, 'location'>
+    ),
+  ]
+> = [
+  [
+    '',
+    '',
+    {
+      severity: 'error',
+      message: 'Dependency cannot be empty',
+    },
+  ],
+  [
+    './pkg#scr',
+    'PPPPP_SSS',
+    {
+      package: {kind: 'path', path: './pkg'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    'scr',
+    'SSS',
+    {
+      package: {kind: 'this'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    '#scr',
+    '_SSS',
+    {
+      severity: 'error',
+      message: 'Package specifier cannot be empty',
+    },
+  ],
+  [
+    './pkg#scr#',
+    'PPPPP_SSSE',
+    {
+      severity: 'error',
+      message: 'Unexpected additional delimiter "#"',
+    },
+  ],
+  [
+    './pkg##',
+    'PPPPP_E',
+    {
+      severity: 'error',
+      message: 'Unexpected additional delimiter "#"',
+    },
+  ],
+  [
+    './pkg',
+    'EEEEE',
+    {
+      severity: 'error',
+      message:
+        `Cross-package dependency must use syntax ` +
+        `"<relative-path>#<script-name>", but there's no ` +
+        `"#" character in "./pkg".`,
+    },
+  ],
+  [
+    String.raw`./\#pkg\##scr`,
+    String.raw`PPPPPPPPP_SSS`,
+    {
+      package: {kind: 'path', path: './#pkg#'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    String.raw`./pkg#\#scr\#`,
+    String.raw`PPPPP_SSSSSSS`,
+    {
+      package: {kind: 'path', path: './pkg'},
+      script: {kind: 'name', name: '#scr#'},
+    },
+  ],
+  [
+    String.raw`\./scr`,
+    String.raw`_SSSSS`,
+    {
+      package: {kind: 'this'},
+      script: {kind: 'name', name: './scr'},
+    },
+  ],
+  [
+    '!./pkg#scr',
+    '_PPPPP_SSS',
+    {
+      inverted: true,
+      package: {kind: 'path', path: './pkg'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    '!scr',
+    '_SSS',
+    {
+      inverted: true,
+      package: {kind: 'this'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    '!!scr',
+    '_SSSS',
+    {
+      inverted: true,
+      package: {kind: 'this'},
+      script: {kind: 'name', name: '!scr'},
+    },
+  ],
+  [
+    String.raw`\!scr`,
+    String.raw`_SSSS`,
+    {
+      package: {kind: 'this'},
+      script: {kind: 'name', name: '!scr'},
+    },
+  ],
+  [
+    './pkg:scr',
+    'PPPPP_SSS',
+    {
+      package: {kind: 'path', path: './pkg'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    './pkg:foo#scr',
+    'PPPPPPPPP_SSS',
+    {
+      package: {
+        kind: 'path',
+        path: './pkg:foo',
+      },
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    String.raw`./pkg:foo\#scr`,
+    String.raw`PPPPP_SSSSSSSS`,
+    {
+      package: {kind: 'path', path: './pkg'},
+      script: {kind: 'name', name: 'foo#scr'},
+    },
+  ],
+  [
+    '#foo',
+    '_SSS',
+    {
+      severity: 'error',
+      message: 'Package specifier cannot be empty',
+    },
+  ],
+  [
+    './pkg:<workspaces>',
+    'PPPPP_EEEEEEEEEEEE',
+    {
+      severity: 'error',
+      message: 'Unknown special script "workspaces"',
+    },
+  ],
+  [
+    './pkg#<>',
+    'PPPPP_EE',
+    {
+      severity: 'error',
+      message: 'Unexpected ">". Escape as "\\>" if you meant it literally.',
+    },
+  ],
+  [
+    '<>',
+    'EE',
+    {
+      severity: 'error',
+      message: 'Unexpected ">". Escape as "\\>" if you meant it literally.',
+    },
+  ],
+  [
+    '<workspaces>#scr',
+    'PPPPPPPPPPPP_SSS',
+    {
+      package: {kind: 'workspaces'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    '<dependencies>#scr',
+    'PPPPPPPPPPPPPP_SSS',
+    {
+      package: {kind: 'dependencies'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    '<dependencies>#<this>',
+    'PPPPPPPPPPPPPP_SSSSSS',
+    {
+      package: {kind: 'dependencies'},
+      script: {kind: 'this'},
+    },
+  ],
+  [
+    String.raw`./pkg\*#scr\*`,
+    String.raw`PPPPPPP_SSSSS`,
+    {
+      package: {kind: 'path', path: './pkg*'},
+      script: {kind: 'name', name: 'scr*'},
+    },
+  ],
+  [
+    String.raw`./pkg\{foo,bar}#scr\{foo,bar}`,
+    String.raw`PPPPPPPPPPPPPPP_SSSSSSSSSSSSS`,
+    {
+      package: {
+        kind: 'path',
+        path: './pkg{foo,bar}',
+      },
+      script: {
+        kind: 'name',
+        name: 'scr{foo,bar}',
+      },
+    },
+  ],
+  [
+    'npm-package#scr',
+    'PPPPPPPPPPP_SSS',
+    {
+      package: {
+        kind: 'npm',
+        package: 'npm-package',
+      },
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
+    'package#scr:dee:doo',
+    'PPPPPPP_SSSSSSSSSSS',
+    {
+      package: {
+        kind: 'npm',
+        package: 'package',
+      },
+      script: {
+        kind: 'name',
+        name: 'scr:dee:doo',
+      },
+    },
+  ],
+] as const;
+
+for (const [dependency, rangeString, valueOrError] of cases) {
+  test(dependency, () => {
+    const actual = parseDependency(dependency);
+    const ranges = extractRanges(rangeString);
+    let expected: ReturnType<typeof parseDependency>;
+    if ('severity' in valueOrError) {
+      expected = {
+        ok: false,
+        error: {
+          ...valueOrError,
+          location: {range: ranges.E},
+        },
+      };
+    } else {
+      expected = {
+        ok: true,
+        value: {
+          ...valueOrError,
+          inverted: valueOrError.inverted ?? false,
+          package: {...valueOrError.package, range: ranges.P},
+          script: {...valueOrError.script, range: ranges.S},
+        },
+      };
+    }
+    assert.equal(actual, expected);
+  });
+}
+
+function extractRanges(str: string) {
+  const result = {
+    S: {offset: 0, length: 0},
+    P: {offset: 0, length: 0},
+    E: {offset: 0, length: 0},
+  };
+  for (const match of str.matchAll(/([SPE])\1*/g)) {
+    result[match[1] as 'S' | 'P' | 'E'] = {
+      offset: match.index,
+      length: match[0].length,
+    };
+  }
+  return result;
+}
+
+test('extractRanges', () => {
+  assert.equal(extractRanges('PPP_SS_E'), {
+    P: {offset: 0, length: 3},
+    S: {offset: 4, length: 2},
+    E: {offset: 7, length: 1},
+  });
+
+  assert.equal(extractRanges(''), {
+    P: {offset: 0, length: 0},
+    S: {offset: 0, length: 0},
+    E: {offset: 0, length: 0},
+  });
+});
+
+test.run();

--- a/src/test/dependency-parser.test.ts
+++ b/src/test/dependency-parser.test.ts
@@ -186,6 +186,14 @@ const cases: Array<
     },
   ],
   [
+    String.raw`./pkg:foo\##scr`,
+    String.raw`PPPPPPPPPPP_SSS`,
+    {
+      package: {kind: 'path', path: './pkg:foo#'},
+      script: {kind: 'name', name: 'scr'},
+    },
+  ],
+  [
     '#foo',
     '_SSS',
     {

--- a/src/test/errors-analysis.test.ts
+++ b/src/test/errors-analysis.test.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as pathlib from 'path';
 import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
-import * as pathlib from 'path';
-import {rigTest} from './util/rig-test.js';
 import {IS_WINDOWS} from '../util/windows.js';
 import {checkScriptOutput} from './util/check-script-output.js';
+import {rigTest} from './util/rig-test.js';
 
 const test = suite<object>();
 
@@ -774,6 +774,7 @@ test(
     );
   }),
 );
+
 test(
   'missing cross package dependency with complicated escaped names',
   rigTest(async ({rig}) => {
@@ -788,7 +789,7 @@ test(
         },
         wireit: {
           a: {
-            dependencies: ['./ch\t\\ ild:mis\t\\ sing'],
+            dependencies: ['./ch\t\\\\ ild:mis\t\\\\ sing'],
           },
         },
       },
@@ -802,11 +803,11 @@ test(
     checkScriptOutput(
       done.stderr,
       String.raw`
-❌ package.json:8:23 Cannot find script named "mis\t\\ sing" in package "${rig.resolve(
+❌ package.json:8:25 Cannot find script named "mis\t\\ sing" in package "${rig.resolve(
         'ch\t\\ ild',
       )}"
-            "./ch\t\\ ild:mis\t\\ sing"
-                          ~~~~~~~~~~~~`,
+            "./ch\t\\\\ ild:mis\t\\\\ sing"
+                            ~~~~~~~~~~~~~~`,
     );
   }),
 );
@@ -821,7 +822,7 @@ test(
         },
         wireit: {
           a: {
-            dependencies: ['../b\t\\ ar:b'],
+            dependencies: ['../b\t\\\\ ar:b'],
           },
         },
       },
@@ -835,8 +836,8 @@ test(
 ❌ package.json:8:10 package.json file missing: "${rig.resolve(
         'b\t\\ ar/package.json',
       )}"
-            "../b\t\\ ar:b"
-             ~~~~~~~~~~~`,
+            "../b\t\\\\ ar:b"
+             ~~~~~~~~~~~~~`,
     );
   }),
 );
@@ -1012,9 +1013,9 @@ test(
     checkScriptOutput(
       done.stderr,
       `
-❌ package.json:8:9 Cross-package dependency must use syntax "<relative-path>:<script-name>", but there's no ":" character in "../foo".
+❌ package.json:8:10 Cross-package dependency must use syntax "<relative-path>#<script-name>", but there's no "#" character in "../foo".
             "../foo"
-            ~~~~~~~~
+             ~~~~~~
 `,
     );
   }),
@@ -1041,9 +1042,9 @@ test(
     checkScriptOutput(
       done.stderr,
       `
-❌ package.json:8:9 Cross-package dependency must use syntax "<relative-path>:<script-name>", but there's no script name in "../foo:".
+❌ package.json:8:10 Cross-package dependency must use syntax "<relative-path>#<script-name>", but there's no script name in "../foo:".
             "../foo:"
-            ~~~~~~~~~
+             ~~~~~~~
 `,
     );
   }),
@@ -1070,9 +1071,9 @@ test(
     checkScriptOutput(
       done.stderr,
       `
-❌ package.json:8:9 Cross-package dependency ".:b" resolved to the same package.
+❌ package.json:8:10 Cross-package dependency ".:b" resolved to the same package.
             ".:b"
-            ~~~~~
+             ~
 `,
     );
   }),
@@ -1099,9 +1100,9 @@ test(
     checkScriptOutput(
       done.stderr,
       `
-❌ package.json:8:9 Cross-package dependency "../foo:b" resolved to the same package.
+❌ package.json:8:10 Cross-package dependency "../foo:b" resolved to the same package.
             "../foo:b"
-            ~~~~~~~~~~
+             ~~~~~~
 `,
     );
   }),


### PR DESCRIPTION
This PR introduces `#` as the new and preferred way to delimit the package and script portions of a dependency specifier, by way of a new dependency specifier parser. The `:` delimiter will remain supported indefinitely.

The goal of the new parser, and the new `#` delimiter, is to prepare for adding a number of new features to dependency specifiers, such as https://github.com/google/wireit/issues/23 (but see `dependency-parser.ts` for the actual list, the syntax has changed, I will update the issue). None of the new features are implemented in this PR, they will come in followups.

`#` was chosen as the new preferred delimiter because `:` is extremely common in npm script names, whereas `#` is uncommon in both paths and npm script names. This will allow us to differentiate between `npmpackage:script` (which becomes `npmpackage#script`) and `localscript:withcolon`. `#` is also the delimiter used by Turborepo, which seems like a slightly nice alignment.