### PR TITLE
Support V2 GitHub Caching service (Part 1/2: Custodian)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2025-04-10
+
+### Added
+
+- Added `ACTIONS_RESULTS_URL` environment variable which is required for V2
+  of the GitHub cache service.
+
 ## [2.0.2] - 2024-08-22
 
 ### Fixed
@@ -46,7 +53,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial support for Wireit caching on GitHub Actions.
 
-[unreleased]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.2...setup-github-actions-caching
+[unreleased]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.3...setup-github-actions-caching
+[2.0.3]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.2...setup-github-actions-caching/v2.0.3
 [2.0.2]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.1...setup-github-actions-caching/v2.0.2
 [2.0.1]: https://github.com/google/wireit/compare/setup-github-actions-caching/v2.0.0...setup-github-actions-caching/v2.0.1
 [2.0.0]: https://github.com/google/wireit/compare/setup-github-actions-caching/v1.0.1...setup-github-actions-caching/v2.0.0

--- a/custodian.js
+++ b/custodian.js
@@ -15,7 +15,9 @@ const response = JSON.stringify({
     // workflows like this one, but not to regular "run" steps, so we need to
     // serve them for subsequent Wireit processes.
     github: {
-      // URL for the GitHub Actions cache service.
+      // V2 URL for the GitHub Actions cache service.
+      ACTIONS_RESULTS_URL: process.env.ACTIONS_RESULTS_URL,
+      // V1 URL for the GitHub Actions cache service.
       ACTIONS_CACHE_URL: process.env.ACTIONS_CACHE_URL,
       // A secret token for authenticating to the GitHub Actions cache service.
       ACTIONS_RUNTIME_TOKEN: process.env.ACTIONS_RUNTIME_TOKEN,


### PR DESCRIPTION
Add `ACTIONS_RESULTS_URL` to the set of environment variables we provide to wireit processes via the custodian server.

See https://github.com/google/wireit/issues/1297 and https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts for background on this change.

See https://github.com/google/wireit/pull/1146 for background on the custodian.

Pairs with https://github.com/google/wireit/pull/1302 for the actual wireit implementation.
