### PR TITLE
Make all GitHub Actions cache service HTTP errors non-fatal, and add scheduled live test

### DIFF
--- a/.github/workflows/test-real-github-actions-cache-service.yml
+++ b/.github/workflows/test-real-github-actions-cache-service.yml
@@ -1,0 +1,33 @@
+name: Test real GitHub Actions cache service
+
+on:
+  schedule:
+    - cron: '14 7 * * *' # 6:07AM PST / 7:07AM PDT
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        include:
+          - node: 20 # LTS
+            os: ubuntu-22.04
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      WIREIT_LOGGER: 'quiet-ci'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      # Note we intentionally don't enable Wireit caching for this workflow,
+      # because we're looking for problems coming from the real production
+      # GitHub Actions cache service, which is independent of any of our files.
+      # - uses: google/wireit@setup-github-actions-caching/v2
+
+      - run: npm ci
+      - run: npm run test:cache-github-real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- HTTP errors from the GitHub Actions cache service are no longer ever fatal,
+  and should always continue gracefully with GitHub Actions caching temporarily
+  disabled (previously only network errors and HTTP 429/503 errors failed
+  gracefully).
 
 ## [0.14.12] - 2025-04-10
 


### PR DESCRIPTION
HTTP errors from the GitHub Actions cache service are no longer ever fatal, and should always continue gracefully with GitHub Actions Caching temporarily disabled. Previously only network errors and HTTP 429/503 errors failed gracefully.

This should mean that if something like https://github.com/google/wireit/issues/1297 happens again (where we started getting 422 "Unprocessable" errors because of a breaking change to their API), users won't be broken.

Also adds a scheduled daily test of the live service (just one platform, morning PT), since the above change would otherwise reduce the timeliness of us finding out about a problem with the production service.