### PR TITLE
chore: bump brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "website"
       ],
       "dependencies": {
-        "brace-expansion": "^4.0.0",
+        "brace-expansion": "^4.0.1",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.2.11",
         "jsonc-parser": "^3.0.0",
@@ -2826,9 +2826,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.0.tgz",
-      "integrity": "sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
+      "integrity": "sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
     "bracketSpacing": false
   },
   "dependencies": {
-    "brace-expansion": "^4.0.0",
+    "brace-expansion": "^4.0.1",
     "chokidar": "^3.5.3",
     "fast-glob": "^3.2.11",
     "jsonc-parser": "^3.0.0",


### PR DESCRIPTION
Getting vulnerability from this package when running pnpm audit. Bumping brace-expansion to the patched version. 