### PR TITLE
ci: upgrade GitHub Action to Node v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,5 +2,5 @@ name: "wireit-setup-github-actions-caching"
 author: "Google LLC"
 description: "Enables Wireit's GitHub Actions caching mode and exposes required environment variables"
 runs:
-  using: "node20"
+  using: "node24"
   main: "main.js"


### PR DESCRIPTION
Fixes warning 
```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: google/wireit@f21db1f3a6a4db31f42787a958cf2a18308effed. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
``